### PR TITLE
CI: Add missing security context to values

### DIFF
--- a/helm_deploy/templates/deployment-worker.yaml
+++ b/helm_deploy/templates/deployment-worker.yaml
@@ -25,8 +25,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}-worker
           securityContext:

--- a/helm_deploy/templates/deployment.yaml
+++ b/helm_deploy/templates/deployment.yaml
@@ -25,8 +25,6 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -67,6 +67,14 @@ secrets:
 service_account:
   name: laa-assess-non-standard-magistrate-fee-dev-irsa
 
+securityContext:
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  seccompProfile:
+    type: RuntimeDefault
+  capabilities:
+    drop: [ "ALL" ]
+
 # This is used to configure the temporary non-RDS postgres DB
 postgresql:
   enabled: true

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -67,6 +67,14 @@ secrets:
 service_account:
   name: laa-assess-non-standard-magistrate-fee-prod-irsa
 
+securityContext:
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  seccompProfile:
+    type: RuntimeDefault
+  capabilities:
+    drop: [ "ALL" ]
+
 # Instead of a temporary postgres pod we use RDS
 postgresql:
   enabled: false

--- a/helm_deploy/values-uat.yaml
+++ b/helm_deploy/values-uat.yaml
@@ -67,6 +67,14 @@ secrets:
 service_account:
   name: laa-assess-non-standard-magistrate-fee-uat-irsa
 
+securityContext:
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  seccompProfile:
+    type: RuntimeDefault
+  capabilities:
+    drop: [ "ALL" ]
+
 # Instead of a temporary postgres pod we use RDS
 postgresql:
   enabled: false


### PR DESCRIPTION
## Description of change
Add missing security context to values

To handle warning:

```
W0226 11:53:29.208237     328 warnings.go:70] would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "**************************************-worker" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "**************************************-worker" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "**************************************-worker" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "**************************************-worker" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
W0226 11:53:29.502009     328 warnings.go:70] would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "**************************************" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "**************************************" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "**************************************" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "**************************************" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
```
