### PR TITLE
Document and add env vars required for local e2e development

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -6,8 +6,7 @@
 #
 DATABASE_URL=postgresql://postgres@localhost/laa_assess_non_standard_magistrate_fee_dev
 
-
-
+# Local datastore url - default is http://localhost:8000
 APP_STORE_URL=http://localhost:8000
 
 # Set to true to bypass authentication (a mock will be used)
@@ -21,3 +20,10 @@ DEV_AUTH_ENABLED=true
 
 SIDEKIQ_WEB_UI_USERNAME=sidekiq
 SIDEKIQ_WEB_UI_PASSWORD=sidekiq
+
+# App store credentials (for authenticating to a local app store currently)
+# use dev azure-secret creds.
+# TODO: OAuth requirment may be removed from local/development app store in the future
+APP_STORE_CLIENT_ID=not-a-real-key
+APP_STORE_CLIENT_SECRET=not-a-real-key
+APP_STORE_TENANT_ID=not-a-real-key

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
-web: bin/rails server -p 3000
+web: bin/rails server -p 3002
 js: yarn build --watch
 css: yarn build:css --watch
 sidekiq: DISABLE_SIDEKIQ_ALIVE=true bundle exec sidekiq

--- a/README.md
+++ b/README.md
@@ -124,3 +124,8 @@ This will run everything except for the accessibility tests, which are slow, and
 To run those, run `INCLUDE_ACCESSIBILITY_SPECS=1 bundle exec rspec`.
 Our test suite will report as failing if line and branch coverage is not at 100%.
 We expect every feature's happy path to have a system test, and every screen to have an accessibility test.
+
+
+**8. Development end-to-end setup**
+
+see [Development e2e setup](https://github.com/ministryofjustice/laa-submit-crime-forms/blob/main/docs/development-e2e-setup.md)


### PR DESCRIPTION
## Description of change
- Hardcode default port in Procfile, inline with provider app's
- link to documentation in provider app for e2e setup
- Add env vars required for local e2e development