### PR TITLE
CRM457-992: Change format period inline with prototype designs

### DIFF
--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -5,15 +5,15 @@ en:
     time_period:
       hours:
         short:
-          one: '%{count} Hr '
-          other: '%{count} Hrs '
+          one: '%{count} hour '
+          other: '%{count} hours '
         long_html:
-          one: '%{count} Hour<br>'
-          other: '%{count} Hours<br>'
+          one: '%{count} hour<br>'
+          other: '%{count} hours<br>'
       minutes:
         short:
-          one: '%{count} Min'
-          other: '%{count} Mins'
+          one: '%{count} minute'
+          other: '%{count} minutes'
         long_html:
-          one: '%{count} Minute'
-          other: '%{count} Minutes'
+          one: '%{count} minute'
+          other: '%{count} minutes'

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -76,10 +76,19 @@ RSpec.describe ApplicationHelper, type: :helper do
       it { expect(helper.format_period(nil)).to be_nil }
     end
 
-    context 'when period is not nil' do
+    context 'when period is not nil and short style specified' do
       it 'formats the value in hours and minutes' do
-        expect(helper.format_period(62)).to eq('1 Hr 2 Mins')
-        expect(helper.format_period(1)).to eq('0 Hrs 1 Min')
+        expect(helper.format_period(62)).to eq('1 hour 2 minutes')
+        expect(helper.format_period(1)).to eq('0 hours 1 minute')
+        expect(helper.format_period(120)).to eq('2 hours 0 minutes')
+      end
+    end
+
+    context 'when period is not nil and long style specified' do
+      it 'formats the value in hours and minutes' do
+        expect(helper.format_period(62, style: :long)).to eq('1 hour<br>2 minutes')
+        expect(helper.format_period(1, style: :long)).to eq('0 hours<br>1 minute')
+        expect(helper.format_period(120, style: :long)).to eq('2 hours<br>0 minutes')
       end
     end
   end

--- a/spec/system/nsm/work_items_spec.rb
+++ b/spec/system/nsm/work_items_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Work items' do
       expect(page).to have_content(
         'Waiting' \
         '95%' \
-        '2 Hours41 Minutes' \
+        '2 hours41 minutes' \
         'Change'
       )
       click_on 'Change'
@@ -37,9 +37,9 @@ RSpec.describe 'Work items' do
       expect(page).to have_content(
         'Waiting' \
         '95%' \
-        '2 Hours41 Minutes' \
+        '2 hours41 minutes' \
         '0%' \
-        '10 Hours59 Minutes' \
+        '10 hours59 minutes' \
         'Change'
       )
     end
@@ -61,9 +61,9 @@ RSpec.describe 'Work items' do
       expect(page).to have_content(
         'Waiting' \
         '95%' \
-        '2 Hours41 Minutes' \
+        '2 hours41 minutes' \
         '0%' \
-        '2 Hours41 Minutes' \
+        '2 hours41 minutes' \
         'Change'
       )
     end
@@ -81,7 +81,7 @@ RSpec.describe 'Work items' do
       expect(page).to have_content(
         'Waiting' \
         'Date12 December 2022' \
-        'Time spent2 Hrs 41 Mins' \
+        'Time spent2 hours 41 minutes' \
         'Fee earner initialsaaa' \
         'Uplift claimed95%' \
         'Claim cost£125.58'

--- a/spec/system/prior_authority/adjustments_spec.rb
+++ b/spec/system/prior_authority/adjustments_spec.rb
@@ -35,6 +35,6 @@ RSpec.describe 'View applications' do
     fill_in 'Minutes', with: '17'
     fill_in 'Explanation', with: 'typoe'
     click_on 'Save changes'
-    expect(page).to have_content '3 Hrs 17 Mins'
+    expect(page).to have_content '3 hours 17 minutes'
   end
 end

--- a/spec/system/prior_authority/view_adjust_quote_spec.rb
+++ b/spec/system/prior_authority/view_adjust_quote_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe 'View Adjust quote tab' do
 
     within('.govuk-table#service_costs') do
       expect(page)
-        .to have_content('Amount3 Hrs 0 Mins')
+        .to have_content('Amount3 hours 0 minutes')
         .and have_content('Cost£3.50 per hour')
         .and have_content('Total£10.50')
     end
@@ -88,7 +88,7 @@ RSpec.describe 'View Adjust quote tab' do
 
     within('.govuk-table#travel_costs') do
       expect(page)
-        .to have_content('Time1 Hr 35 Mins')
+        .to have_content('Time1 hour 35 minutes')
         .and have_content('Cost£10.50 per hour')
         .and have_content('Total£16.63')
     end
@@ -114,7 +114,7 @@ RSpec.describe 'View Adjust quote tab' do
 
     within('.govuk-table#additional_cost_2') do
       expect(page)
-        .to have_content('Time4 Hrs 0 Mins')
+        .to have_content('Time4 hours 0 minutes')
         .and have_content('Cost£50.00 per hour')
         .and have_content('Total£200.00')
     end

--- a/spec/view_models/nsm/v1/claim_details_spec.rb
+++ b/spec/view_models/nsm/v1/claim_details_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Nsm::V1::ClaimDetails do
                                      { title: 'Number of witnesses', value: 2 },
                                      { title: 'Supplemental claim', value: 'No' },
                                      { title: 'Recorded evidence', value: 'Yes' },
-                                     { title: 'Recorded evidence', value: '1 Hr 50 Mins' },
+                                     { title: 'Recorded evidence', value: '1 hour 50 minutes' },
                                      { title: 'Work done before order was granted', value: 'Yes' },
                                      { title: 'Date of work before order was granted', value: '20 January 2023' },
                                      { title: 'Work was done after last hearing', value: 'Yes' },

--- a/spec/view_models/nsm/v1/travel_and_waiting_spec.rb
+++ b/spec/view_models/nsm/v1/travel_and_waiting_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Nsm::V1::TravelAndWaiting do
 
       it 'includes the summed table field row' do
         expect(subject.table_fields).to include(
-          ['Travel', '0 Hours<br>20 Minutes', '£120.00', '0 Hours<br>20 Minutes', '£120.00'],
+          ['Travel', '0 hours<br>20 minutes', '£120.00', '0 hours<br>20 minutes', '£120.00'],
         )
       end
 
@@ -65,8 +65,8 @@ RSpec.describe Nsm::V1::TravelAndWaiting do
 
       it 'returns a single table field row' do
         expect(subject.table_fields).to include(
-          ['Travel', '0 Hours<br>20 Minutes', '£120.00', '0 Hours<br>20 Minutes', '£120.00'],
-          ['Waiting', '0 Hours<br>30 Minutes', '£120.00', '0 Hours<br>30 Minutes', '£120.00']
+          ['Travel', '0 hours<br>20 minutes', '£120.00', '0 hours<br>20 minutes', '£120.00'],
+          ['Waiting', '0 hours<br>30 minutes', '£120.00', '0 hours<br>30 minutes', '£120.00']
         )
       end
 
@@ -95,7 +95,7 @@ RSpec.describe Nsm::V1::TravelAndWaiting do
 
       it 'includes a summed table field row' do
         expect(subject.table_fields).to include(
-          ['Travel', '0 Hours<br>50 Minutes', '£240.00', '0 Hours<br>50 Minutes', '£240.00']
+          ['Travel', '0 hours<br>50 minutes', '£240.00', '0 hours<br>50 minutes', '£240.00']
         )
       end
     end

--- a/spec/view_models/nsm/v1/work_item_spec.rb
+++ b/spec/view_models/nsm/v1/work_item_spec.rb
@@ -47,14 +47,14 @@ RSpec.describe Nsm::V1::WorkItem do
     end
 
     it 'returns the fields for the table display' do
-      expect(subject.table_fields).to eq(['Waiting', '0%', '2 Hours<br>41 Minutes', '', ''])
+      expect(subject.table_fields).to eq(['Waiting', '0%', '2 hours<br>41 minutes', '', ''])
     end
 
     context 'when adjustments exists' do
       let(:adjustments) { [build(:event, :edit_work_item_uplift)] }
 
       it 'also renders caseworker values' do
-        expect(subject.table_fields).to eq(['Waiting', '20%', '2 Hours<br>41 Minutes', '0%', '2 Hours<br>41 Minutes'])
+        expect(subject.table_fields).to eq(['Waiting', '20%', '2 hours<br>41 minutes', '0%', '2 hours<br>41 minutes'])
       end
     end
   end
@@ -291,7 +291,7 @@ RSpec.describe Nsm::V1::WorkItem do
       it 'calculates the correct provider requested amount' do
         expect(subject.provider_fields).to eq(
           '.date' => '14 December 2022',
-          '.time_spent' => '2 Hrs 51 Mins',
+          '.time_spent' => '2 hours 51 minutes',
           '.fee_earner' => 'JGB',
           '.uplift_claimed' => '20%',
           '.vat' => '20%',
@@ -306,7 +306,7 @@ RSpec.describe Nsm::V1::WorkItem do
       it 'calculates the correct provider requested amount' do
         expect(subject.provider_fields).to eq(
           '.date' => '14 December 2022',
-          '.time_spent' => '2 Hrs 51 Mins',
+          '.time_spent' => '2 hours 51 minutes',
           '.fee_earner' => 'JGB',
           '.uplift_claimed' => '20%',
           '.total_claimed' => '£82.08',

--- a/spec/view_models/prior_authority/v1/additional_cost_spec.rb
+++ b/spec/view_models/prior_authority/v1/additional_cost_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe PriorAuthority::V1::AdditionalCost do
   describe '#unit_description' do
     it 'translates a period into something sensible' do
       cost = described_class.new(unit_type: 'per_hour', period: 180)
-      expect(cost.unit_description).to eq('3 Hrs 0 Mins')
+      expect(cost.unit_description).to eq('3 hours 0 minutes')
     end
 
     it 'translates an item into something sensible' do


### PR DESCRIPTION
## Description of change
Change format period inline with prototype/designs

[link to ticket](https://dsdmoj.atlassian.net/browse/CRM457-1204)
[came out of ticket](https://dsdmoj.atlassian.net/browse/CRM457-992)
[and ticket](https://dsdmoj.atlassian.net/browse/CRM457-1115)

Came out of conversation with content and design who decided
that a consistent approach across NSM and PA on both caseworker
and provider app is preferred and should be

- full word for hours and minutes, lower case
- no leading zeros

### Before changes:
![Screenshot 2024-02-29 at 17 43 07](https://github.com/ministryofjustice/laa-assess-crime-forms/assets/7016425/7a53e25e-bc30-4491-9438-688a8ebb34a2)


### After changes:

![Screenshot 2024-02-29 at 17 41 54](https://github.com/ministryofjustice/laa-assess-crime-forms/assets/7016425/08c0e1fa-8e8d-4665-9342-416cd26ab69d)

