### PR TITLE
Make indentifier for ingress valid (UAT)

### DIFF
--- a/helm_deploy/values-uat.yaml
+++ b/helm_deploy/values-uat.yaml
@@ -30,7 +30,7 @@ ingress:
         SecRuleEngine On
         SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"
         SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6"
-      external-dns.alpha.kubernetes.io/set-identifier: laa-assess-crime-forms-app-laa-assess-crime-forms-green
+      external-dns.alpha.kubernetes.io/set-identifier: laa-assess-crime-forms-app-laa-assess-crime-forms-uat-green
       external-dns.alpha.kubernetes.io/aws-weight: "100"
   hosts:
     - host: nsmassessuat.apps.live.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
## Description of change
Correct identifier for UAT ingress so that it includes the namespace 

[To fix this ](https://app.circleci.com/pipelines/github/ministryofjustice/laa-assess-crime-forms/1871/workflows/4bc4894b-cead-4fda-b295-55ae7bfe3b0c/jobs/11895)