### PR TITLE
CRM457-1114: update overview to show original values

### DIFF
--- a/app/view_models/prior_authority/v1/additional_cost.rb
+++ b/app/view_models/prior_authority/v1/additional_cost.rb
@@ -33,7 +33,7 @@ module PriorAuthority
       end
 
       def formatted_total_cost
-        NumberTo.pounds(total_cost)
+        NumberTo.pounds(total_cost(original: true))
       end
 
       def form_attributes
@@ -44,16 +44,16 @@ module PriorAuthority
         I18n.t(unit_type, scope: 'prior_authority.application_details.items.unit_description')
       end
 
-      def unit_description
+      def original_unit_description
         if unit_type == 'per_item'
-          "#{items} #{I18n.t('prior_authority.application_details.items.item').pluralize(items)}"
+          "#{original_items} #{I18n.t('prior_authority.application_details.items.item').pluralize(original_items)}"
         else
-          format_period(period)
+          format_period(original_period)
         end
       end
 
-      def cost_per_unit
-        NumberTo.pounds(unit_type == 'per_item' ? cost_per_item : cost_per_hour)
+      def original_cost_per_unit
+        NumberTo.pounds(unit_type == 'per_item' ? original_cost_per_item : original_cost_per_hour)
       end
     end
   end

--- a/app/view_models/prior_authority/v1/application_details/alternative_quote_card.rb
+++ b/app/view_models/prior_authority/v1/application_details/alternative_quote_card.rb
@@ -9,6 +9,7 @@ module PriorAuthority
         ].freeze
 
         delegate :additional_cost_list, :formatted_total_cost, to: :quote
+        delegate :formatted_original_total_cost, to: :primary_quote
 
         def initialize(application_details, alternative_quote)
           @alternative_quote = alternative_quote
@@ -65,11 +66,9 @@ module PriorAuthority
         end
 
         def footer_row
-          [tag.strong(total_label), tag.strong(formatted_total_cost), tag.strong(formatted_primary_quote_total_cost)]
-        end
-
-        def formatted_primary_quote_total_cost
-          primary_quote.formatted_total_cost
+          [tag.strong(total_label),
+           tag.strong(formatted_total_cost),
+           tag.strong(formatted_original_total_cost)]
         end
       end
     end

--- a/app/view_models/prior_authority/v1/application_details/primary_quote_card.rb
+++ b/app/view_models/prior_authority/v1/application_details/primary_quote_card.rb
@@ -26,13 +26,15 @@ module PriorAuthority
 
         def additional_cost_row(additional_cost)
           [additional_cost.name,
-           additional_cost.unit_description,
-           additional_cost.cost_per_unit,
+           additional_cost.original_unit_description,
+           additional_cost.original_cost_per_unit,
            additional_cost.formatted_total_cost]
         end
 
         delegate :primary_quote, :service_name, :prior_authority_granted, to: :application_details
-        delegate :travel_cost_reason, :base_units, :base_cost_per_unit, :travel_units, :travel_cost_per_unit,
+
+        delegate :base_units, :base_cost_per_unit,
+                 :travel_units, :travel_cost_per_unit, :travel_cost_reason,
                  :formatted_base_cost, :formatted_travel_cost,
                  to: :quote
 

--- a/app/view_models/prior_authority/v1/application_summary.rb
+++ b/app/view_models/prior_authority/v1/application_summary.rb
@@ -51,13 +51,11 @@ module PriorAuthority
         @all_quotes ||= Quote.build(:quote, submission, 'quotes')
       end
 
-      def service_cost
-        @service_cost ||= all_quotes.find { |q| q.primary == true }
+      def built_primary_quote
+        @built_primary_quote ||= all_quotes.find { |q| q.primary == true }
       end
-
-      def travel_cost
-        @travel_cost ||= all_quotes.find { |q| q.primary == true }
-      end
+      alias travel_cost built_primary_quote
+      alias service_cost built_primary_quote
 
       def primary_quote
         @primary_quote ||=

--- a/app/view_models/prior_authority/v1/quote.rb
+++ b/app/view_models/prior_authority/v1/quote.rb
@@ -93,6 +93,10 @@ module PriorAuthority
         NumberTo.pounds(total_cost)
       end
 
+      def formatted_original_total_cost
+        NumberTo.pounds(original_total_cost)
+      end
+
       def travel_costs(original: false)
         time = original ? original_travel_time : travel_time
         hourly_cost = original ? original_travel_cost_per_hour : travel_cost_per_hour

--- a/app/view_models/prior_authority/v1/quote.rb
+++ b/app/view_models/prior_authority/v1/quote.rb
@@ -59,34 +59,34 @@ module PriorAuthority
 
       def base_units
         if cost_type == 'per_item'
-          "#{items} #{I18n.t("prior_authority.application_details.items.#{item_type}").pluralize(items)}"
+          "#{original_items} #{I18n.t("prior_authority.application_details.items.#{item_type}").pluralize(items)}"
         else
-          format_period(period)
+          format_period(original_period)
         end
       end
 
       def travel_units
-        format_period(travel_time)
+        format_period(original_travel_time)
       end
 
       def travel_cost_per_unit
-        NumberTo.pounds(travel_cost_per_hour)
+        NumberTo.pounds(original_travel_cost_per_hour)
       end
 
       def base_cost_per_unit
-        NumberTo.pounds(cost_type == 'per_item' ? cost_per_item : cost_per_hour)
+        NumberTo.pounds(cost_type == 'per_item' ? original_cost_per_item : original_cost_per_hour)
       end
 
       def formatted_base_cost
-        NumberTo.pounds(base_cost)
+        NumberTo.pounds(base_cost(original: true))
       end
 
       def formatted_travel_cost
-        NumberTo.pounds(travel_costs)
+        NumberTo.pounds(travel_costs(original: true))
       end
 
       def formatted_additional_costs
-        NumberTo.pounds(total_additional_costs)
+        NumberTo.pounds(total_additional_costs(original: true))
       end
 
       def formatted_total_cost

--- a/spec/view_models/prior_authority/v1/additional_cost_spec.rb
+++ b/spec/view_models/prior_authority/v1/additional_cost_spec.rb
@@ -1,15 +1,25 @@
 require 'rails_helper'
 
 RSpec.describe PriorAuthority::V1::AdditionalCost do
-  describe '#unit_description' do
+  describe '#original_unit_description' do
     it 'translates a period into something sensible' do
       cost = described_class.new(unit_type: 'per_hour', period: 180)
-      expect(cost.unit_description).to eq('3 hours 0 minutes')
+      expect(cost.original_unit_description).to eq('3 hours 0 minutes')
     end
 
     it 'translates an item into something sensible' do
       cost = described_class.new(unit_type: 'per_item', items: 1)
-      expect(cost.unit_description).to eq('1 item')
+      expect(cost.original_unit_description).to eq('1 item')
+    end
+
+    it 'uses the original period value' do
+      cost = described_class.new(unit_type: 'per_hour', period_original: 90, period: 180)
+      expect(cost.original_unit_description).to eq('1 hour 30 minutes')
+    end
+
+    it 'uses the original items value' do
+      cost = described_class.new(unit_type: 'per_item', items_original: 2, items: 1)
+      expect(cost.original_unit_description).to eq('2 items')
     end
   end
 
@@ -35,15 +45,25 @@ RSpec.describe PriorAuthority::V1::AdditionalCost do
     end
   end
 
-  describe '#cost_per_unit' do
+  describe '#original_cost_per_unit' do
     it 'translates a period into something sensible' do
       cost = described_class.new(unit_type: 'per_hour', cost_per_hour: 50.3)
-      expect(cost.cost_per_unit).to eq('£50.30')
+      expect(cost.original_cost_per_unit).to eq('£50.30')
     end
 
     it 'translates an item into something sensible' do
       cost = described_class.new(unit_type: 'per_item', cost_per_item: 1)
-      expect(cost.cost_per_unit).to eq('£1.00')
+      expect(cost.original_cost_per_unit).to eq('£1.00')
+    end
+
+    it 'uses the original cost_per_hour value' do
+      cost = described_class.new(unit_type: 'per_hour', cost_per_hour_original: '200.00', cost_per_hour: '180.00')
+      expect(cost.original_cost_per_unit).to eq('£200.00')
+    end
+
+    it 'uses the original cost_per_item value' do
+      cost = described_class.new(unit_type: 'per_item', cost_per_item_original: '50.00', cost_per_item: '30.00')
+      expect(cost.original_cost_per_unit).to eq('£50.00')
     end
   end
 


### PR DESCRIPTION
## Description of change
Update overview tab to display original/requested values

[link to ticket](https://dsdmoj.atlassian.net/browse/CRM457-1220)
[link to parent ticket](https://dsdmoj.atlassian.net/browse/CRM457-1114)

Following the adjusted quotes work the overview page needs to 
ensure it shows the original provider supplied quote values
for the primary quote
