### PR TITLE
CRM457-1002: Add sortable lists of applications

### DIFF
--- a/app/controllers/prior_authority/adjustments_controller.rb
+++ b/app/controllers/prior_authority/adjustments_controller.rb
@@ -5,9 +5,10 @@ module PriorAuthority
       application_summary = BaseViewModel.build(:application_summary, application)
       service_cost = BaseViewModel.build(:service_cost, application)
       core_cost_summary = BaseViewModel.build(:core_cost_summary, application)
+      editable = application_summary.can_edit?(current_user)
 
       @key_information = BaseViewModel.build(:key_information, application)
-      render locals: { application:, application_summary:, service_cost:, core_cost_summary: }
+      render locals: { application:, application_summary:, service_cost:, core_cost_summary:, editable: }
     end
   end
 end

--- a/app/controllers/prior_authority/applications_controller.rb
+++ b/app/controllers/prior_authority/applications_controller.rb
@@ -1,17 +1,41 @@
 module PriorAuthority
   class ApplicationsController < PriorAuthority::BaseController
-    def your
-      applications = PriorAuthorityApplication.pending_and_assigned_to(current_user).map do |application|
-        BaseViewModel.build(:application_summary, application)
-      end
+    before_action :set_default_table_sort_options, only: %i[your open assessed]
 
-      @pagy, @applications = pagy_array(applications)
+    def your
+      @pagy, applications = order_and_paginate(PriorAuthorityApplication.pending_and_assigned_to(current_user))
+      @applications = applications.map do |application|
+        BaseViewModel.build(:table_row, application)
+      end
+    end
+
+    def open
+      @pagy, applications = order_and_paginate(PriorAuthorityApplication.pending_decision)
+      @applications = applications.map do |application|
+        BaseViewModel.build(:table_row, application)
+      end
+    end
+
+    def assessed
+      @pagy, applications = order_and_paginate(PriorAuthorityApplication.decision_made)
+      @applications = applications.map do |application|
+        BaseViewModel.build(:table_row, application)
+      end
     end
 
     def show
       application = PriorAuthorityApplication.find(params[:id])
       @summary = BaseViewModel.build(:application_summary, application)
       @details = BaseViewModel.build(:application_details, application)
+    end
+
+    def order_and_paginate(query)
+      pagy(Sorter.call(query, @sort_by, @sort_direction))
+    end
+
+    def set_default_table_sort_options
+      @sort_by = params.fetch(:sort_by, 'laa_reference')
+      @sort_direction = params.fetch(:sort_direction, 'ascending')
     end
   end
 end

--- a/app/controllers/prior_authority/assignments_controller.rb
+++ b/app/controllers/prior_authority/assignments_controller.rb
@@ -7,7 +7,7 @@ module PriorAuthority
 
         if application
           application.assignments.create!(user: current_user)
-          application.update(state: 'in_progress')
+          application.update!(state: 'in_progress')
           Event::Assignment.build(submission: application, current_user: current_user)
 
           redirect_to prior_authority_application_path(application)

--- a/app/controllers/prior_authority/assignments_controller.rb
+++ b/app/controllers/prior_authority/assignments_controller.rb
@@ -7,6 +7,7 @@ module PriorAuthority
 
         if application
           application.assignments.create!(user: current_user)
+          application.update(state: 'in_progress')
           Event::Assignment.build(submission: application, current_user: current_user)
 
           redirect_to prior_authority_application_path(application)

--- a/app/helpers/sortable_table_helper.rb
+++ b/app/helpers/sortable_table_helper.rb
@@ -1,0 +1,19 @@
+module SortableTableHelper
+  def table_header(column, i18n_stem, index, path, sort_by, sort_direction)
+    aria_sort = sort_by == column.to_s ? sort_direction : 'none'
+    next_direction = sort_direction == 'ascending' ? 'descending' : 'ascending'
+    tag.th(scope: 'col', class: 'govuk-table__header', 'aria-sort': aria_sort) do
+      reorder_form(path, column, next_direction, i18n_stem, index)
+    end
+  end
+
+  def reorder_form(path, column, next_direction, i18n_stem, index)
+    tag.form(action: path, method: 'get') do
+      safe_join([tag.input(type: 'hidden', name: 'sort_by', value: column),
+                 tag.input(type: 'hidden', name: 'sort_direction', value: next_direction),
+                 tag.button(type: 'submit', 'data-index': index) do
+                   I18n.t(column, scope: i18n_stem)
+                 end])
+    end
+  end
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,6 +1,5 @@
 import "@hotwired/turbo-rails"
 import "./controllers"
-import "./component/sortable_table"
 import "./component/nsm/letters_calls_adjustment"
 import "./component/nsm/work_item_adjustment"
 import "./component/prior_authority/service_cost_adjustment"

--- a/app/javascript/component/sortable_table.js
+++ b/app/javascript/component/sortable_table.js
@@ -1,8 +1,0 @@
-import MOJFrontend from '@ministryofjustice/frontend'
-import $ from 'jquery'
-
-window.$ = $
-
-$(document).on('turbo:load', function () {
-  MOJFrontend.initAll()
-});

--- a/app/services/prior_authority/sorter.rb
+++ b/app/services/prior_authority/sorter.rb
@@ -1,0 +1,27 @@
+module PriorAuthority
+  class Sorter
+    ORDERS = {
+      'laa_reference' => "data->>'laa_reference' ?",
+      'firm_name' => "data->>'firm_name' ?",
+      'client_name' => "data->>'client_name' ?",
+      'date_received' => 'submissions.created_at ?',
+      'caseworker' => 'users.last_name ?, users.first_name ?',
+      # 'submitted' state has visual label "Not assigned", so correct for that when ordering alphabetically
+      'status' => "CASE WHEN state = 'submitted' THEN 'not_assigned' ELSE state END ?",
+      'date_assessed' => 'submissions.updated_at ?'
+    }.freeze
+
+    DIRECTIONS = {
+      'descending' => 'DESC',
+      'ascending' => 'ASC',
+    }.freeze
+
+    class << self
+      def call(base_query, sort_by, sort_direction)
+        order_template = ORDERS[sort_by]
+        direction = DIRECTIONS[sort_direction]
+        base_query.left_joins(assignments: :user).order(Arel.sql(order_template.gsub('?', direction)))
+      end
+    end
+  end
+end

--- a/app/view_models/prior_authority/v1/application_summary.rb
+++ b/app/view_models/prior_authority/v1/application_summary.rb
@@ -80,13 +80,17 @@ module PriorAuthority
       end
 
       def current_section(current_user)
-        if submission.state != 'submitted'
+        if !submission.state.in?(%w[submitted in_progress])
           :assessed
         elsif submission.assignments.find_by(user: current_user)
           :your
         else
           :open
         end
+      end
+
+      def can_edit?(caseworker)
+        submission.state == 'in_progress' && submission.assignments.find_by(user: caseworker)
       end
     end
   end

--- a/app/view_models/prior_authority/v1/table_row.rb
+++ b/app/view_models/prior_authority/v1/table_row.rb
@@ -1,0 +1,46 @@
+module PriorAuthority
+  module V1
+    class TableRow < BaseViewModel
+      include ActionView::Helpers::TagHelper
+
+      attribute :laa_reference, :string
+      attribute :firm_name
+      attribute :client_name
+      attribute :submission
+
+      delegate :id, to: :submission
+
+      def date_created_str
+        submission.created_at.to_fs(:stamp)
+      end
+
+      def date_assessed_str
+        submission.updated_at.to_fs(:stamp)
+      end
+
+      def caseworker
+        submission.assignments.first&.display_name || I18n.t('prior_authority.applications.not_assigned')
+      end
+
+      def status
+        tag.span(class: "govuk-tag govuk-tag--#{tag_colour}") do
+          I18n.t("prior_authority.applications.statuses.#{submission.state}")
+        end
+      end
+
+      private
+
+      def tag_colour
+        {
+          'submitted' => 'grey',
+          'in_progress' => 'purple',
+          'provider_updated' => 'grey',
+          'sent_back' => 'yellow',
+          'part_grant' => 'blue',
+          'granted' => 'green',
+          'rejected' => 'red'
+        }.fetch(submission.state)
+      end
+    end
+  end
+end

--- a/app/views/prior_authority/adjustments/_additional_costs.html.erb
+++ b/app/views/prior_authority/adjustments/_additional_costs.html.erb
@@ -33,9 +33,11 @@
           end
         end
       end %>
-  <%= link_to t(".adjust_additional_cost"),
-              edit_prior_authority_application_additional_cost_path(application, additional_cost.id),
-              class: 'govuk-button govuk-button--secondary',
-              id: "additional_cost_#{index + 1}",
-              data: { turbo: false } %>
+  <% if editable %>
+    <%= link_to t(".adjust_additional_cost"),
+                edit_prior_authority_application_additional_cost_path(application, additional_cost.id),
+                class: 'govuk-button govuk-button--secondary',
+                id: "additional_cost_#{index + 1}",
+                data: { turbo: false } %>
+  <% end %>
 <% end %>

--- a/app/views/prior_authority/adjustments/_service_costs.html.erb
+++ b/app/views/prior_authority/adjustments/_service_costs.html.erb
@@ -31,8 +31,9 @@
         end
       end
     end %>
-<%= link_to t(".adjust_service_cost"),
-            edit_prior_authority_application_service_cost_path(application, service_cost.id),
-            data: { turbo: false },
-            class: 'govuk-button govuk-button--secondary' %>
-
+<% if application_summary.can_edit?(current_user) %>
+  <%= link_to t(".adjust_service_cost"),
+              edit_prior_authority_application_service_cost_path(application, service_cost.id),
+              data: { turbo: false },
+              class: 'govuk-button govuk-button--secondary' %>
+<% end %>

--- a/app/views/prior_authority/adjustments/_service_costs.html.erb
+++ b/app/views/prior_authority/adjustments/_service_costs.html.erb
@@ -31,7 +31,7 @@
         end
       end
     end %>
-<% if application_summary.can_edit?(current_user) %>
+<% if editable %>
   <%= link_to t(".adjust_service_cost"),
               edit_prior_authority_application_service_cost_path(application, service_cost.id),
               data: { turbo: false },

--- a/app/views/prior_authority/adjustments/_travel_costs.erb
+++ b/app/views/prior_authority/adjustments/_travel_costs.erb
@@ -35,8 +35,9 @@
         end
       end
     end %>
-<%= link_to t(".adjust_travel_cost"),
-            edit_prior_authority_application_travel_cost_path(application, quote.id),
-            data: { turbo: false },
-            class: 'govuk-button govuk-button--secondary' %>
-
+<% if application_summary.can_edit?(current_user) %>
+  <%= link_to t(".adjust_travel_cost"),
+              edit_prior_authority_application_travel_cost_path(application, quote.id),
+              data: { turbo: false },
+              class: 'govuk-button govuk-button--secondary' %>
+<% end %>

--- a/app/views/prior_authority/adjustments/_travel_costs.erb
+++ b/app/views/prior_authority/adjustments/_travel_costs.erb
@@ -35,7 +35,7 @@
         end
       end
     end %>
-<% if application_summary.can_edit?(current_user) %>
+<% if editable %>
   <%= link_to t(".adjust_travel_cost"),
               edit_prior_authority_application_travel_cost_path(application, quote.id),
               data: { turbo: false },

--- a/app/views/prior_authority/adjustments/index.html.erb
+++ b/app/views/prior_authority/adjustments/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:primary_navigation) do %>
-  <% render partial: 'layouts/prior_authority/primary_navigation', current: :your %>
+  <% render 'layouts/prior_authority/primary_navigation', current: application_summary.current_section(current_user) %>
 <% end %>
 <% title t('.page_title') %>
 
@@ -17,12 +17,13 @@
       <%= render 'travel_costs', application_summary:, application: %>
     <% end %>
 
-    <%= render 'additional_costs', additional_costs: core_cost_summary.additional_costs, application: %>
-
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-9">
-    <div class="govuk-button-group">
-      <%= govuk_button_link_to(t('.make_a_decision'), '#') %>
-      <%= govuk_button_link_to(t('.save_and_exit'), your_prior_authority_applications_path, secondary: true) %>
-    </div>
+    <%= render 'additional_costs', additional_costs: core_cost_summary.additional_costs, application:, editable: application_summary.can_edit?(current_user) %>
+    <% if application_summary.can_edit?(current_user) %>
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-9">
+      <div class="govuk-button-group">
+        <%= govuk_button_link_to(t('.make_a_decision'), '#') %>
+        <%= govuk_button_link_to(t('.save_and_exit'), your_prior_authority_applications_path, secondary: true) %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/app/views/prior_authority/adjustments/index.html.erb
+++ b/app/views/prior_authority/adjustments/index.html.erb
@@ -11,14 +11,14 @@
     <h2 class="govuk-heading-m"><%= t('.adjust_quote') %></h2>
 
     <%= render 'key_information_card', model: @key_information.key_information_card %>
-    <%= render 'service_costs', application_summary:, application: %>
+    <%= render 'service_costs', application_summary:, application:, editable: %>
 
     <% if application_summary.primary_quote.travel_costs.positive? %>
-      <%= render 'travel_costs', application_summary:, application: %>
+      <%= render 'travel_costs', application_summary:, application:, editable: %>
     <% end %>
 
-    <%= render 'additional_costs', additional_costs: core_cost_summary.additional_costs, application:, editable: application_summary.can_edit?(current_user) %>
-    <% if application_summary.can_edit?(current_user) %>
+    <%= render 'additional_costs', additional_costs: core_cost_summary.additional_costs, application:, editable: %>
+    <% if editable %>
       <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-9">
       <div class="govuk-button-group">
         <%= govuk_button_link_to(t('.make_a_decision'), '#') %>

--- a/app/views/prior_authority/applications/_table.html.erb
+++ b/app/views/prior_authority/applications/_table.html.erb
@@ -1,0 +1,31 @@
+<table class="govuk-table" data-module="moj-sortable-table" aria-describedby="page-title">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <% columns.keys.each_with_index do |column_key, index| %>
+        <%= table_header(column_key,
+                        "prior_authority.applications.table.header",
+                        index,
+                        path,
+                        @sort_by,
+                        @sort_direction) %>
+      <% end %>
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body app-task-list__items">
+    <% @applications.each do |application| %>
+      <tr class="govuk-table__row app-task-list__item">
+        <% columns.values.each_with_index do |value_attribute, index| %>
+          <td class="govuk-table__cell">
+            <% if index.zero? %>
+              <%= link_to application.send(value_attribute), prior_authority_application_path(application.id), data: { turbo: false } %>
+            <% else %>
+              <%= application.send(value_attribute) %>
+            <% end %>
+          </td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+<%= render 'shared/pagination', pagy: @pagy, item: t("prior_authority.applications.table.table_info_item") %>

--- a/app/views/prior_authority/applications/assessed.html.erb
+++ b/app/views/prior_authority/applications/assessed.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:primary_navigation) do %>
-  <% render 'layouts/prior_authority/primary_navigation', current: :your %>
+  <% render 'layouts/prior_authority/primary_navigation', current: :assessed %>
 <% end %>
 <% title t('.page_title') %>
 
@@ -8,18 +8,16 @@
     <h1 id="page-title" class="govuk-heading-xl"><%= t('.page_title') %></h1>
     <% if @applications.none? %>
       <h2 class="govuk-body-l"><%= t('.no_applications') %></h2>
-    <% end %>
-    <div class="govuk-button-group">
-      <%= govuk_button_to(t('.next_application'), prior_authority_assignments_path) %>
-    </div>
-    <% if @applications.any? %>
+    <% else %>
       <%= render 'table',
-                 path: your_prior_authority_applications_path,
+                 path: assessed_prior_authority_applications_path,
                  columns: {
                     laa_reference: :laa_reference,
                     firm_name: :firm_name,
                     client_name: :client_name,
-                    date_received: :date_created_str
+                    caseworker: :caseworker,
+                    date_assessed: :date_assessed_str,
+                    status: :status
                  } %>
     <% end %>
   </div>

--- a/app/views/prior_authority/applications/open.html.erb
+++ b/app/views/prior_authority/applications/open.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:primary_navigation) do %>
-  <% render 'layouts/prior_authority/primary_navigation', current: :your %>
+  <% render 'layouts/prior_authority/primary_navigation', current: :open %>
 <% end %>
 <% title t('.page_title') %>
 
@@ -8,18 +8,16 @@
     <h1 id="page-title" class="govuk-heading-xl"><%= t('.page_title') %></h1>
     <% if @applications.none? %>
       <h2 class="govuk-body-l"><%= t('.no_applications') %></h2>
-    <% end %>
-    <div class="govuk-button-group">
-      <%= govuk_button_to(t('.next_application'), prior_authority_assignments_path) %>
-    </div>
-    <% if @applications.any? %>
+    <% else %>
       <%= render 'table',
-                 path: your_prior_authority_applications_path,
+                 path: open_prior_authority_applications_path,
                  columns: {
                     laa_reference: :laa_reference,
                     firm_name: :firm_name,
                     client_name: :client_name,
-                    date_received: :date_created_str
+                    caseworker: :caseworker,
+                    date_received: :date_created_str,
+                    status: :status
                  } %>
     <% end %>
   </div>

--- a/app/views/prior_authority/applications/show.html.erb
+++ b/app/views/prior_authority/applications/show.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:primary_navigation) do %>
-  <% render partial: 'layouts/prior_authority/primary_navigation', current: @summary.current_section(current_user) %>
+  <% render 'layouts/prior_authority/primary_navigation', current: @summary.current_section(current_user) %>
 <% end %>
 <% title t('.page_title') %>
 
@@ -30,10 +30,12 @@
     <h2 class="govuk-heading-m"><%= t('.contact_details') %></h2>
     <%= render 'case_contact_card', model: @details.case_contact_card %>
 
-    <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-9">
-    <div class="govuk-button-group">
-      <%= govuk_button_link_to(t('.make_a_decision'), '#') %>
-      <%= govuk_button_link_to(t('.come_back_later'), your_prior_authority_applications_path, secondary: true) %>
-    </div>
+    <% if @summary.can_edit?(current_user) %>
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-9">
+      <div class="govuk-button-group">
+        <%= govuk_button_link_to(t('.make_a_decision'), '#') %>
+        <%= govuk_button_link_to(t('.come_back_later'), your_prior_authority_applications_path, secondary: true) %>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/config/locales/en/prior_authority/applications.yml
+++ b/config/locales/en/prior_authority/applications.yml
@@ -12,14 +12,14 @@ en:
         provider_updated: Provider updated
       your:
         page_title: 'Your applications'
-        no_applications: 'You have no applications assigned to you for assessment'
+        no_applications: 'You have no applications assigned to you for assessment.'
         next_application: 'Assess next application'
       open:
         page_title: Open applications
-        no_applications: There are no open applications.
+        no_applications: There are not any applications to assess. Good job!
       assessed:
         page_title: Assessed applications
-        no_applications: There are no assessed applications.
+        no_applications: There are not any applications that have been assessed.
       table:
         table_info_item: 'application'
         header:

--- a/config/locales/en/prior_authority/applications.yml
+++ b/config/locales/en/prior_authority/applications.yml
@@ -1,16 +1,35 @@
 en:
   prior_authority:
     applications:
+      not_assigned: Not assigned
+      statuses:
+        submitted: Not assigned
+        in_progress: In progress
+        granted: Granted
+        part_grant: Part granted
+        rejected: Rejected
+        sent_back: Sent back
+        provider_updated: Provider updated
       your:
-        table_info_item: 'application'
         page_title: 'Your applications'
-        table_heading: 'Your applications'
-        laa_reference: LAA reference
-        firm_name: Firm name
-        client_name: Client name
-        date_received: Date received
         no_applications: 'You have no applications assigned to you for assessment'
         next_application: 'Assess next application'
+      open:
+        page_title: Open applications
+        no_applications: There are no open applications.
+      assessed:
+        page_title: Assessed applications
+        no_applications: There are no assessed applications.
+      table:
+        table_info_item: 'application'
+        header:
+          laa_reference: LAA reference
+          firm_name: Firm name
+          client_name: Client
+          caseworker: Caseworker
+          date_received: Received
+          date_assessed: Assessed
+          status: Status
       show:
         page_title: Application details
         overview: Overview

--- a/db/migrate/20240308150518_add_indexes_to_submissions.rb
+++ b/db/migrate/20240308150518_add_indexes_to_submissions.rb
@@ -1,0 +1,7 @@
+class AddIndexesToSubmissions < ActiveRecord::Migration[7.1]
+  def change
+    add_index(:submissions, "(data->>'laa_reference')", name: "index_submissions_on_laa_reference")
+    add_index(:submissions, "(data->>'firm_name')", name: "index_submissions_on_firm_name")
+    add_index(:submissions, "(data->>'client_name')", name: "index_submissions_on_client_name")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_07_154917) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_08_150518) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -52,6 +52,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_07_154917) do
     t.jsonb "data"
     t.datetime "app_store_updated_at"
     t.string "application_type"
+    t.index "((data ->> 'client_name'::text))", name: "index_submissions_on_client_name"
+    t.index "((data ->> 'firm_name'::text))", name: "index_submissions_on_firm_name"
+    t.index "((data ->> 'laa_reference'::text))", name: "index_submissions_on_laa_reference"
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/spec/system/prior_authority/adjust_additional_costs_spec.rb
+++ b/spec/system/prior_authority/adjust_additional_costs_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe 'Adjust additional costs' do
     let(:application) do
       create(
         :prior_authority_application,
+        state: 'in_progress',
         data: build(
           :prior_authority_data,
           laa_reference: 'LAA-1234',

--- a/spec/system/prior_authority/adjust_service_costs_spec.rb
+++ b/spec/system/prior_authority/adjust_service_costs_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe 'Adjust service costs' do
     let(:application) do
       create(
         :prior_authority_application,
+        state: 'in_progress',
         data: build(
           :prior_authority_data,
           laa_reference: 'LAA-1234',
@@ -109,6 +110,7 @@ RSpec.describe 'Adjust service costs' do
     let(:application) do
       create(
         :prior_authority_application,
+        state: 'in_progress',
         data: build(
           :prior_authority_data,
           laa_reference: 'LAA-1234',

--- a/spec/system/prior_authority/adjust_travel_costs_spec.rb
+++ b/spec/system/prior_authority/adjust_travel_costs_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe 'Adjust travel costs' do
   let(:application) do
     create(
       :prior_authority_application,
+      state: 'in_progress',
       data: build(
         :prior_authority_data,
         laa_reference: 'LAA-1234',

--- a/spec/system/prior_authority/adjustments_spec.rb
+++ b/spec/system/prior_authority/adjustments_spec.rb
@@ -4,10 +4,12 @@ RSpec.describe 'View applications' do
   let(:caseworker) { create(:caseworker) }
   let(:application) do
     create(:prior_authority_application,
+           state: 'submitted',
            data: build(:prior_authority_data,
                        laa_reference: 'LAA-1234',
                        additional_costs: [build(:additional_cost, description: 'Postage stamps')]))
   end
+  let(:cost_adjustment_button_label) { 'Adjust additional cost' }
 
   before do
     sign_in caseworker
@@ -15,55 +17,80 @@ RSpec.describe 'View applications' do
     click_on 'Accept analytics cookies'
   end
 
-  it 'shows the application adjustments overview' do
-    visit prior_authority_application_adjustments_path(application)
-    expect(page).to have_content 'Postage stamps'
+  context 'when application is not assigned to me' do
+    it 'does not give me the option to adjust it' do
+      visit prior_authority_application_adjustments_path(application)
+      expect(page).to have_no_content cost_adjustment_button_label
+    end
   end
 
-  it 'shows an error if I make an adjustment without an explanation' do
-    visit prior_authority_application_adjustments_path(application)
-    click_on 'Adjust additional cost'
-    fill_in 'Hours', with: '3'
-    click_on 'Save changes'
+  context 'when application is assigned to me' do
+    before do
+      create(:assignment,
+             user: caseworker,
+             submission: application)
+      application.update(state: 'in_progress')
+    end
 
-    expect(page).to have_content 'Explain your decision for adjusting the costs'
-  end
+    it 'shows the application adjustments overview' do
+      visit prior_authority_application_adjustments_path(application)
+      expect(page).to have_content 'Postage stamps'
+    end
 
-  it 'lets me adjust an additional cost' do
-    visit prior_authority_application_adjustments_path(application)
-    click_on 'Adjust additional cost'
-    fill_in 'Hours', with: '3'
-    fill_in 'Minutes', with: '17'
-    fill_in 'Explain your decision', with: 'typoe'
-    click_on 'Save changes'
-    expect(page).to have_content '3 hours 17 minutes'
-  end
+    it 'shows an error if I make an adjustment without an explanation' do
+      visit prior_authority_application_adjustments_path(application)
+      click_on cost_adjustment_button_label
+      fill_in 'Hours', with: '3'
+      click_on 'Save changes'
 
-  it 'updates the total at the top of the page' do
-    visit prior_authority_application_path(application)
-    expect(page).to have_content 'Requested: £356.50'
-    click_on 'Adjust quote'
-    expect(page).to have_content 'Time1 hour 0 minutesCost£32.00 per hour'
-    click_on 'Adjust additional cost'
-    fill_in 'Minutes', with: '30'
-    fill_in 'Explain your decision', with: 'Feeling generous'
-    click_on 'Save changes'
-    expect(page).to have_content 'Requested: £356.50'
-    expect(page).to have_content 'Allowed: £372.50'
-  end
+      expect(page).to have_content 'Explain your decision for adjusting the costs'
+    end
 
-  it 'does not change the requested value even if I make multiple adjustments' do
-    visit prior_authority_application_adjustments_path(application)
-    click_on 'Adjust additional cost'
-    fill_in 'Minutes', with: '30'
-    fill_in 'Explain your decision', with: 'Feeling generous'
-    click_on 'Save changes'
+    it 'lets me adjust an additional cost' do
+      visit prior_authority_application_adjustments_path(application)
+      click_on cost_adjustment_button_label
+      fill_in 'Hours', with: '3'
+      fill_in 'Minutes', with: '17'
+      fill_in 'Explain your decision', with: 'typoe'
+      click_on 'Save changes'
+      expect(page).to have_content '3 hours 17 minutes'
+    end
 
-    click_on 'Adjust additional cost'
-    fill_in 'Minutes', with: '15'
-    fill_in 'Explain your decision', with: 'Feeling less generous'
-    click_on 'Save changes'
+    it 'updates the total at the top of the page' do
+      visit prior_authority_application_path(application)
+      expect(page).to have_content 'Requested: £356.50'
+      click_on 'Adjust quote'
+      expect(page).to have_content 'Time1 hour 0 minutesCost£32.00 per hour'
+      click_on cost_adjustment_button_label
+      fill_in 'Minutes', with: '30'
+      fill_in 'Explain your decision', with: 'Feeling generous'
+      click_on 'Save changes'
+      expect(page).to have_content 'Requested: £356.50'
+      expect(page).to have_content 'Allowed: £372.50'
+    end
 
-    expect(page).to have_content 'Requested: £356.50'
+    it 'does not change the requested value even if I make multiple adjustments' do
+      visit prior_authority_application_adjustments_path(application)
+      click_on cost_adjustment_button_label
+      fill_in 'Minutes', with: '30'
+      fill_in 'Explain your decision', with: 'Feeling generous'
+      click_on 'Save changes'
+
+      click_on cost_adjustment_button_label
+      fill_in 'Minutes', with: '15'
+      fill_in 'Explain your decision', with: 'Feeling less generous'
+      click_on 'Save changes'
+
+      expect(page).to have_content 'Requested: £356.50'
+    end
+
+    context 'when application is already assessed' do
+      before { application.update(state: 'granted') }
+
+      it 'does not give me the option to adjust it' do
+        visit prior_authority_application_adjustments_path(application)
+        expect(page).to have_no_content cost_adjustment_button_label
+      end
+    end
   end
 end

--- a/spec/system/prior_authority/application_lists_spec.rb
+++ b/spec/system/prior_authority/application_lists_spec.rb
@@ -1,0 +1,74 @@
+require 'rails_helper'
+
+RSpec.describe 'Prior authority list views' do
+  let(:me) { create(:caseworker) }
+  let(:someone_else) { create(:caseworker) }
+  let(:assigned_to_me) do
+    create(:prior_authority_application,
+           state: 'in_progress',
+           data: build(:prior_authority_data, laa_reference: 'LAA-111'))
+  end
+  let(:assigned_to_someone_else) do
+    create(:prior_authority_application,
+           state: 'in_progress',
+           data: build(:prior_authority_data, laa_reference: 'LAA-222'))
+  end
+  let(:unassigned) do
+    create(:prior_authority_application,
+           state: 'submitted',
+           data: build(:prior_authority_data, laa_reference: 'LAA-333'))
+  end
+  let(:assessed) do
+    create(:prior_authority_application,
+           state: 'granted',
+           data: build(:prior_authority_data, laa_reference: 'LAA-444'))
+  end
+
+  before do
+    create(:assignment, user: me, submission: assigned_to_me)
+    create(:assignment, user: me, submission: assessed)
+    create(:assignment, user: someone_else, submission: assigned_to_someone_else)
+    unassigned
+    assessed
+    sign_in me
+  end
+
+  context 'when I visit your applications' do
+    before { visit your_prior_authority_applications_path }
+
+    it 'only shows me unassessed applications assigned to me' do
+      expect(page).to have_content 'LAA-1'
+      expect(page).to have_no_content 'LAA-2'
+      expect(page).to have_no_content 'LAA-3'
+      expect(page).to have_no_content 'LAA-4'
+    end
+  end
+
+  context 'when I visit open applications' do
+    before { visit open_prior_authority_applications_path }
+
+    it 'only shows me non-assessed applications' do
+      expect(page).to have_content 'LAA-1'
+      expect(page).to have_content 'LAA-2'
+      expect(page).to have_content 'LAA-3'
+      expect(page).to have_no_content 'LAA-4'
+    end
+
+    it 'lets me sort applications' do
+      expect(page.body).to match(/111.*222.*333/m)
+      click_on 'LAA reference'
+      expect(page.body).to match(/333.*222.*111/m)
+    end
+  end
+
+  context 'when I visit assessed applications' do
+    before { visit assessed_prior_authority_applications_path }
+
+    it 'only shows me assessed applications' do
+      expect(page).to have_no_content 'LAA-1'
+      expect(page).to have_no_content 'LAA-2'
+      expect(page).to have_no_content 'LAA-3'
+      expect(page).to have_content 'LAA-4'
+    end
+  end
+end

--- a/spec/system/prior_authority/assign_applications_spec.rb
+++ b/spec/system/prior_authority/assign_applications_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe 'Assign applications' do
       # As the UI has not yet been built, the most we can do is demonstrate that an assignment has been made
       expect(application.reload.assignments.first.user).to eq caseworker
       expect(application.events.first).to be_an Event::Assignment
+      expect(application.state).to eq 'in_progress'
     end
   end
 

--- a/spec/system/prior_authority/view_adjust_quote_spec.rb
+++ b/spec/system/prior_authority/view_adjust_quote_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe 'View Adjust quote tab' do
     let(:application) do
       create(
         :prior_authority_application,
+        state: 'in_progress',
         data: build(
           :prior_authority_data,
           laa_reference: 'LAA-1234',
@@ -128,6 +129,7 @@ RSpec.describe 'View Adjust quote tab' do
       let(:application) do
         create(
           :prior_authority_application,
+          state: 'in_progress',
           data: build(
             :prior_authority_data,
             laa_reference: 'LAA-1234',


### PR DESCRIPTION
## Description of change
* The tickets refer to an 'in progress' state, so I've added that when an application is assigned to a caseworker
* Reuse the basic mechanism for sorting and pagination from provider app
* Stop using the  js-based MOJ sorting because we know it's not an appropriate solution (as doesn't consider pagination) and the JS was messing with this more thorough approach
* Implement readonly mode unless a user is assigned to the application and it is current 'in_progress'

## Link to relevant ticket

[CRM457-1002](https://dsdmoj.atlassian.net/browse/)

## Notes for reviewer

## Screenshots of changes (if applicable)
<img width="1165" alt="Screenshot 2024-03-08 at 15 50 09" src="https://github.com/ministryofjustice/laa-assess-crime-forms/assets/113888736/8df18213-564d-4502-9c12-d6f349a2e71e">


[CRM457-1002]: https://dsdmoj.atlassian.net/browse/CRM457-1002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ