### PR TITLE
Extract coverage to separate job and collate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,21 +106,6 @@ commands:
     steps:
       - install-gems
       - install-compile-assets
-      - install-codeclimate-tt
-
-  install-codeclimate-tt:
-      steps:
-        - run:
-            name: Install codeclimate test reporter
-            command: |
-              mkdir -p tmp/
-              mkdir -p tmp/coverage/
-              curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > tmp/cc-test-reporter
-              chmod +x tmp/cc-test-reporter
-        - persist_to_workspace:
-            root: tmp
-            paths:
-              - cc-test-reporter
 
   rubocop:
     steps:
@@ -142,14 +127,9 @@ commands:
   rspec:
     steps:
       - db-setup
-      - save_cache:
-          key: nsmf-assess-repo-{{ .Environment.CIRCLE_SHA1 }}
-          paths:
-            - ~/repo
       - run:
           name: Run rspec tests
           command: |
-            tmp/cc-test-reporter before-build
             TESTFILES=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings --timings-type=filename)
             RUBYOPT=-W:no-deprecated \
             INCLUDE_ACCESSIBILITY_SPECS=1 \
@@ -158,28 +138,20 @@ commands:
               --format RspecJunitFormatter \
               --out /tmp/test-results/rspec/rspec.xml \
               -- ${TESTFILES}
-
-            tmp/cc-test-reporter format-coverage -t simplecov -o "tmp/coverage/codeclimate.$CIRCLE_NODE_INDEX.json"
       - store_test_results:
           path: /tmp/test-results/rspec
-      - restore_cache:
-          key: nsmf-assess-repo-{{ .Environment.CIRCLE_SHA1 }}
+      - run:
+          name: Stash coverage results
+          command: |
+            mkdir coverage_results
+            cp -R coverage/.resultset.json coverage_results/.resultset-${CIRCLE_NODE_INDEX}.json
+      - persist_to_workspace:
+          root: .
+          paths:
+            - coverage_results
       - store_artifacts:
           path: ~/repo/coverage
           destination: coverage
-      - persist_to_workspace:
-          root: tmp
-          paths:
-            - coverage/codeclimate.*.json
-      - store_artifacts:
-          path: tmp/coverage
-
-  upload-coverage:
-      steps:
-        - run:
-            name: Upload coverage results to Code Climate
-            command: |
-              tmp/cc-test-reporter sum-coverage --output - tmp/coverage/codeclimate.*.json | tmp/cc-test-reporter upload-coverage --input -
 
   build-docker-image-for-scan:
       steps:
@@ -245,6 +217,7 @@ jobs:
       - rubocop
 
   rspec-tests:
+    parallelism: 2
     executor: test-executor
     steps:
       - checkout
@@ -256,13 +229,28 @@ jobs:
           install-firefox: false
           install-geckodriver: false
           install-chromedriver: false
+      - save_cache:
+          name: Saving assets and dependencies cache for use in later steps
+          key: assess-crime-forms-repo-{{ .Environment.CIRCLE_SHA1 }}
+          paths:
+            - ~/repo
       - rspec
 
-  upload-test-coverage:
+  coverage:
     executor: test-executor
     steps:
-      - *attach-tmp-workspace
-      - upload-coverage
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          name: Restoring assets and dependencies cache from tests
+          key: assess-crime-forms-repo-{{ .Environment.CIRCLE_SHA1 }}
+      - run:
+          name: Process coverage
+          command: |
+            bundle exec rake simplecov:process_coverage
+      - store_artifacts:
+          path: ~/repo/coverage
+          destination: coverage
 
   scan-docker-image:
     executor: test-executor
@@ -349,12 +337,12 @@ workflows:
       - rspec-tests:
           requires:
             - build-test-container
-      - upload-test-coverage:
+      - coverage:
           requires:
             - rspec-tests
       - scan-docker-image:
           requires:
-            - upload-test-coverage
+            - rspec-tests
 
   build-opened-pr:
     jobs:
@@ -382,7 +370,7 @@ workflows:
       - rspec-tests:
           requires:
             - build-test-container
-      - upload-test-coverage:
+      - coverage:
           requires:
             - rspec-tests
       - build-to-ecr:

--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ group :development, :test do
   gem 'overcommit'
   gem 'pry'
   gem 'rspec-expectations'
-  gem 'rspec_junit_formatter'
+  gem 'rspec_junit_formatter', require: false
   gem 'rspec-rails'
 end
 

--- a/lib/tasks/simplecov/process_coverage.rake
+++ b/lib/tasks/simplecov/process_coverage.rake
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+if ENV["CI"]
+  namespace :simplecov do
+    desc "Process coverage results"
+    task process_coverage: :environment do
+      require "simplecov"
+
+      SimpleCov.collate Dir["./coverage_results/.resultset*.json"], "rails" do
+        enable_coverage :branch
+        primary_coverage :branch
+        minimum_coverage branch: 100, line: 100
+        refuse_coverage_drop :line, :branch
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -74,4 +74,8 @@ RSpec.configure do |config|
   config.before(:each, :javascript, type: :system) do
     driven_by Capybara.javascript_driver
   end
+
+  config.after(:each, type: :system) do
+    ActiveJob::Base.queue_adapter.enqueued_jobs.clear
+  end
 end

--- a/spec/services/app_store_token_provider_spec.rb
+++ b/spec/services/app_store_token_provider_spec.rb
@@ -2,6 +2,23 @@
 
 require 'rails_helper'
 
+RSpec.shared_context 'with nil access token' do
+  let(:previous_access_token) { client.instance_variable_get(:@access_token) }
+
+  before do
+    # remove @access_token to ensure a new oauth token request is made, otherwise previous
+    # calls in tests could mean the token exists already and has not expired, causing
+    # the oauth/token endpoint to not be hit, resulting in test failure or flickers if oauth/token
+    # end point hitting is expected by the test :(
+    previous_access_token
+    client.instance_variable_set(:@access_token, nil)
+  end
+
+  after do
+    client.instance_variable_set(:@access_token, previous_access_token)
+  end
+end
+
 RSpec.describe AppStoreTokenProvider do
   subject(:client) { described_class.instance }
 
@@ -14,24 +31,20 @@ RSpec.describe AppStoreTokenProvider do
     it { is_expected.to respond_to :client_credentials }
   end
 
-  describe '#access_token', :stub_expired_oauth_token do
+  describe '#access_token', :stub_oauth_token do
     subject(:access_token) { client.access_token }
 
     it { is_expected.to be_an OAuth2::AccessToken }
     it { is_expected.to respond_to :token }
     it { expect(access_token.token).to eql 'test-bearer-token' }
 
-    context 'when token nil? or expired?' do
-      let(:test_client) { client }
-
-      before do
-        allow(test_client).to receive(:new_access_token)
-        access_token
-      end
+    context 'when token nil?' do
+      include_context 'with nil access token'
 
       it 'retrieves new access_token' do
+        allow(client).to receive(:new_access_token)
         access_token
-        expect(test_client).to have_received(:new_access_token)
+        expect(client).to have_received(:new_access_token)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,47 +1,32 @@
 require 'simplecov'
 require 'simplecov_json_formatter'
-require 'simplecov-lcov'
 require 'webmock/rspec'
 
-# This allows both LCOV and HTML formatting -
-# lcov for undercover gem and cc-test-reporter, HTML for humans
-module SimpleCov
-  module Formatter
-    class MergedFormatter
-      def format(result)
-        SimpleCov::Formatter::HTMLFormatter.new.format(result)
-        SimpleCov::Formatter::LcovFormatter.new.format(result)
-        SimpleCov::Formatter::JSONFormatter.new.format(result)
-      end
-    end
-  end
-end
+SimpleCov.start 'rails' do
+  add_filter 'spec/'
+  add_filter 'gems/'
+  add_filter 'config/'
 
-SimpleCov::Formatter::LcovFormatter.config.report_with_single_file = true
-# for cc-test-reporter after-build action
-SimpleCov::Formatter::LcovFormatter.config.output_directory = 'coverage'
-SimpleCov::Formatter::LcovFormatter.config.lcov_file_name = 'lcov.info'
-SimpleCov.formatter = SimpleCov::Formatter::MergedFormatter
+  add_filter 'app/presenters/claim_details/table.rb'
+  add_filter 'app/jobs/application_job.rb'
+  add_filter 'app/mailers/application_mailer.rb'
+  add_filter 'app/controllers/concerns/error_handling.rb'
+  add_filter 'lib/govuk_design_system_formbuilder/elements/period.rb'
 
-unless ENV['NOCOVERAGE']
-  SimpleCov.start 'rails' do
-    add_filter 'spec/'
-    add_filter 'gems/'
-    add_filter 'config/'
+  add_group 'Forms', '/app/forms'
+  add_group 'Services', '/app/services'
+  add_group 'View models', '/app/view_models'
 
-    add_filter 'app/presenters/claim_details/table.rb'
-    add_filter 'app/jobs/application_job.rb'
-    add_filter 'app/mailers/application_mailer.rb'
-    add_filter 'app/controllers/concerns/error_handling.rb'
-    add_filter 'lib/govuk_design_system_formbuilder/elements/period.rb'
+  enable_coverage :branch
 
-    add_group 'Forms', '/app/forms'
-    add_group 'Services', '/app/services'
-    add_group 'View models', '/app/view_models'
-
-    enable_coverage :branch
+  # Do not fail coverage on circleci as it breaks parrallel spec runs, instead rely on coverage step in CI
+  unless ENV['CI']
     primary_coverage :branch
     minimum_coverage branch: 100, line: 100
+
+    SimpleCov.at_exit do
+      SimpleCov.result.format!
+    end
   end
 end
 


### PR DESCRIPTION
## Description of change
Extract coverage to separate job and collate results

Allow parallel test suite runs and separate test failures 
from coverage failures.

Also remove codeclimate because:
a. we have sonarcloud wired up which does a lot of the duplication and quality analysis already, 
b.  rubocop is already linting as part of the test suite,
c.  it clutters the circleci config with setup for it.
d. its never been in, or currently isn't in, provider app.
