### PR TITLE
CRM457-1114: Do not display calculated adjustments on page load

### DIFF
--- a/app/javascript/component/prior_authority/additional_cost_adjustment.js
+++ b/app/javascript/component/prior_authority/additional_cost_adjustment.js
@@ -14,7 +14,6 @@ function init() {
   const costAdjustment = new CostAdjustment(...fields)
 
   if (costAdjustment.calculationType() != 'unknown_type') {
-    costAdjustment.updateDomElements();
     costAdjustment.calculateChangeButton.addEventListener('click', handleTestButtonClick);
   }
 

--- a/app/javascript/component/prior_authority/service_cost_adjustment.js
+++ b/app/javascript/component/prior_authority/service_cost_adjustment.js
@@ -14,7 +14,6 @@ function init() {
   const costAdjustment = new CostAdjustment(...fields)
 
   if (costAdjustment.calculationType() != 'unknown_type') {
-    costAdjustment.updateDomElements();
     costAdjustment.calculateChangeButton.addEventListener('click', handleTestButtonClick);
   }
 

--- a/app/javascript/component/prior_authority/travel_cost_adjustment.js
+++ b/app/javascript/component/prior_authority/travel_cost_adjustment.js
@@ -6,7 +6,6 @@ function init() {
   const adjustedCost = document.getElementById('adjusted-cost');
 
   if (hoursField && minutesField && costPerHourField) {
-    updateDomElements();
     calculateChangeButton.addEventListener('click', handleTestButtonClick);
   }
 

--- a/app/views/prior_authority/additional_costs/edit.html.erb
+++ b/app/views/prior_authority/additional_costs/edit.html.erb
@@ -19,7 +19,7 @@
                                id:'calculate_change_button') %>
 
       <h2 class="govuk-heading-l">
-        <span class="govuk-caption-m">Adjusted cost</span>
+        <span class="govuk-caption-m"><%= t('.adjusted_cost') %></span>
         £
         <span id="adjusted-cost">0.00</span>
       </h2>

--- a/app/views/prior_authority/service_costs/edit.html.erb
+++ b/app/views/prior_authority/service_costs/edit.html.erb
@@ -22,7 +22,7 @@
                                id:'calculate_change_button') %>
 
       <h2 class="govuk-heading-l">
-        <span class="govuk-caption-m">Adjusted cost</span>
+        <span class="govuk-caption-m"><%= t('.adjusted_cost') %></span>
         £
         <span id="adjusted-cost">0.00</span>
       </h2>

--- a/app/views/prior_authority/travel_costs/edit.html.erb
+++ b/app/views/prior_authority/travel_costs/edit.html.erb
@@ -24,7 +24,7 @@
                                id:'calculate_change_button') %>
 
       <h2 class="govuk-heading-l">
-        <span class="govuk-caption-m">Adjusted cost</span>
+        <span class="govuk-caption-m"><%= t('.adjusted_cost') %></span>
         £
         <span id="adjusted-cost">0.00</span>
       </h2>

--- a/config/locales/en/prior_authority/additional_costs.yml
+++ b/config/locales/en/prior_authority/additional_costs.yml
@@ -2,6 +2,7 @@ en:
   prior_authority:
     additional_costs:
       edit:
+        adjusted_cost: Adjusted cost
         adjustment_blurb: Adjust the providers' costs by changing the values.
         calculate_button_text: Calculate my changes
         explanation:

--- a/config/locales/en/prior_authority/service_costs.yml
+++ b/config/locales/en/prior_authority/service_costs.yml
@@ -13,6 +13,7 @@ en:
 
       edit:
         adjustment_blurb: Adjust the providers' costs by changing the values.
+        adjusted_cost: Adjusted cost
         calculate_button_text: Calculate my changes
         explanation:
           hint: For example, why you made adjustments to the cost or time. We'll share this explanation with the provider.

--- a/config/locales/en/prior_authority/travel_costs.yml
+++ b/config/locales/en/prior_authority/travel_costs.yml
@@ -2,6 +2,7 @@ en:
   prior_authority:
     travel_costs:
       edit:
+        adjusted_cost: Adjusted cost
         adjustment_blurb: Adjust the providers' costs by changing the values.
         calculate_button_text: Calculate my changes
         explanation:

--- a/spec/system/prior_authority/adjust_additional_costs_spec.rb
+++ b/spec/system/prior_authority/adjust_additional_costs_spec.rb
@@ -118,6 +118,7 @@ RSpec.describe 'Adjust additional costs' do
       fill_in 'Number of items', with: 100
       fill_in 'What is the cost per item?', with: '3.00'
 
+      expect(page).to have_css('#adjusted-cost', text: '0.00')
       click_on 'Calculate my changes'
       expect(page).to have_css('#adjusted-cost', text: '300.00')
     end
@@ -131,6 +132,7 @@ RSpec.describe 'Adjust additional costs' do
       fill_in 'Minutes', with: 30
       fill_in 'What is the hourly cost?', with: '40.00'
 
+      expect(page).to have_css('#adjusted-cost', text: '0.00')
       click_on 'Calculate my changes'
       expect(page).to have_css('#adjusted-cost', text: '60.00')
     end

--- a/spec/system/prior_authority/adjust_service_costs_spec.rb
+++ b/spec/system/prior_authority/adjust_service_costs_spec.rb
@@ -87,6 +87,7 @@ RSpec.describe 'Adjust service costs' do
       fill_in 'Minutes', with: 0
       fill_in 'Hourly cost', with: '1.50'
 
+      expect(page).to have_css('#adjusted-cost', text: '0.00')
       click_on 'Calculate my changes'
       expect(page).to have_css('#adjusted-cost', text: '30.00')
     end
@@ -164,6 +165,7 @@ RSpec.describe 'Adjust service costs' do
       fill_in 'Number of minutes', with: 60
       fill_in 'What is the cost per minute?', with: 2.50
 
+      expect(page).to have_css('#adjusted-cost', text: '0.00')
       click_on 'Calculate my changes'
       expect(page).to have_css('#adjusted-cost', text: '150.00')
     end

--- a/spec/system/prior_authority/adjust_travel_costs_spec.rb
+++ b/spec/system/prior_authority/adjust_travel_costs_spec.rb
@@ -97,6 +97,7 @@ RSpec.describe 'Adjust travel costs' do
     fill_in 'Minutes', with: 0
     fill_in 'Hourly cost', with: '100.00'
 
+    expect(page).to have_css('#adjusted-cost', text: '0.00')
     click_on 'Calculate my changes'
     expect(page).to have_css('#adjusted-cost', text: '200.00')
   end


### PR DESCRIPTION

## Description of change
Do not display calculated adjustments on page load

[link to ticket](https://dsdmoj.atlassian.net/browse/CRM457-1114)

Inline with prototype the adjustment forms should not
populate the "Adjusted cost" on page load but only on
clicking the "Calculate my changes" button.

### Before changes:
<img width="684" alt="Screenshot 2024-03-11 at 10 03 10" src="https://github.com/ministryofjustice/laa-assess-crime-forms/assets/7016425/6efa4acc-d3c9-4451-b1d1-25a1af67fa8f">

### After changes:
<img width="652" alt="Screenshot 2024-03-11 at 10 07 13" src="https://github.com/ministryofjustice/laa-assess-crime-forms/assets/7016425/0aed36bb-4e2a-4fe7-89f2-2271c43ed339">

