### PR TITLE
CRM457-993: Add related applications

### DIFF
--- a/app/controllers/prior_authority/related_applications_controller.rb
+++ b/app/controllers/prior_authority/related_applications_controller.rb
@@ -1,0 +1,38 @@
+module PriorAuthority
+  class RelatedApplicationsController < PriorAuthority::BaseController
+    before_action :set_default_table_sort_options, only: %i[index]
+
+    def index
+      application = PriorAuthorityApplication.find(params[:application_id])
+      application_summary = BaseViewModel.build(:application_summary, application)
+      editable = application_summary.can_edit?(current_user)
+
+      @pagy, records = order_and_paginate(related_applications_query_for(application))
+      @applications = records.map do |record|
+        BaseViewModel.build(:table_row, record)
+      end
+
+      render locals: { application:, application_summary:, editable: }
+    end
+
+    private
+
+    def related_applications_query_for(application)
+      PriorAuthorityApplication
+        .related_applications(
+          application.data['ufn'],
+          application.data['firm_office']['account_number']
+        )
+        .where.not(id: application.id)
+    end
+
+    def order_and_paginate(query)
+      pagy(Sorter.call(query, @sort_by, @sort_direction))
+    end
+
+    def set_default_table_sort_options
+      @sort_by = params.fetch(:sort_by, 'date_created')
+      @sort_direction = params.fetch(:sort_direction, 'descending')
+    end
+  end
+end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -14,6 +14,10 @@ class Submission < ApplicationRecord
   scope :pending_decision, -> { where.not(state: Nsm::MakeDecisionForm::STATES) }
   scope :decision_made, -> { where(state: Nsm::MakeDecisionForm::STATES) }
 
+  scope :related_applications, lambda { |ufn, account_number|
+    PriorAuthority::RelatedApplications.call(ufn, account_number)
+  }
+
   scope :pending_and_assigned_to, lambda { |user|
     pending_decision
       .joins(:assignments)

--- a/app/services/prior_authority/related_applications.rb
+++ b/app/services/prior_authority/related_applications.rb
@@ -1,0 +1,11 @@
+module PriorAuthority
+  class RelatedApplications
+    class << self
+      def call(ufn, account_number)
+        PriorAuthorityApplication
+          .where("data->>'ufn' = :ufn", ufn:)
+          .where("data->'firm_office'->>'account_number' = :account_number", account_number:)
+      end
+    end
+  end
+end

--- a/app/services/prior_authority/sorter.rb
+++ b/app/services/prior_authority/sorter.rb
@@ -19,7 +19,7 @@ module PriorAuthority
       'date_updated' => 'submissions.updated_at ?',
       'date_assessed' => 'submissions.updated_at ?',
       'date_created' => 'submissions.created_at ?',
-      'service_name' => 'submissions.service_type ?',
+      'service_name' => "data->>'service_type' ?",
     }.freeze
 
     DIRECTIONS = {

--- a/app/services/prior_authority/sorter.rb
+++ b/app/services/prior_authority/sorter.rb
@@ -16,6 +16,7 @@ module PriorAuthority
       'date_received' => 'submissions.created_at ?',
       'caseworker' => "COALESCE(users.first_name, 'Not') || ' ' || COALESCE(users.last_name, 'assigned') ?",
       'status' => STATUS_ORDER_CLAUSE,
+      'date_updated' => 'submissions.updated_at ?',
       'date_assessed' => 'submissions.updated_at ?',
       'date_created' => 'submissions.created_at ?',
       'service_name' => 'submissions.service_type ?',

--- a/app/services/prior_authority/sorter.rb
+++ b/app/services/prior_authority/sorter.rb
@@ -1,5 +1,7 @@
 module PriorAuthority
   class Sorter
+    # NOTE: applications in a 'submitted' state can be assigned and therefore "In progresss", or unassigned.
+    # Unassigned applications require the visual label "Not assigned" for caseworker
     STATUS_ORDER_CLAUSE = <<-SQL.squish.freeze
     CASE WHEN state = 'submitted' THEN
            CASE WHEN users.id IS NULL THEN  'not_assigned'
@@ -9,14 +11,14 @@ module PriorAuthority
 
     ORDERS = {
       'laa_reference' => "data->>'laa_reference' ?",
-      'firm_name' => "data->>'firm_name' ?",
-      'client_name' => "data->>'client_name' ?",
+      'firm_name' => "data->'firm_office'->>'name' ?",
+      'client_name' => "(data->'defendant'->>'first_name') || ' ' || (data->'defendant'->>'last_name') ?",
       'date_received' => 'submissions.created_at ?',
-      'caseworker' => 'users.last_name ?, users.first_name ?',
-      # 'submitted' state has visual label "Not assigned" or "In progress",
-      # so correct for that when ordering alphabetically
+      'caseworker' => "COALESCE(users.first_name, 'Not') || ' ' || COALESCE(users.last_name, 'assigned') ?",
       'status' => STATUS_ORDER_CLAUSE,
-      'date_assessed' => 'submissions.updated_at ?'
+      'date_assessed' => 'submissions.updated_at ?',
+      'date_created' => 'submissions.created_at ?',
+      'service_name' => 'submissions.service_type ?',
     }.freeze
 
     DIRECTIONS = {

--- a/app/view_models/prior_authority/v1/table_row.rb
+++ b/app/view_models/prior_authority/v1/table_row.rb
@@ -25,6 +25,7 @@ module PriorAuthority
       def date_assessed_str
         submission.updated_at.to_fs(:stamp)
       end
+      alias date_updated_str date_assessed_str
 
       def service_name
         I18n.t(submission.data['service_type'], scope: 'prior_authority.service_types')

--- a/app/view_models/prior_authority/v1/table_row.rb
+++ b/app/view_models/prior_authority/v1/table_row.rb
@@ -4,11 +4,19 @@ module PriorAuthority
       include ActionView::Helpers::TagHelper
 
       attribute :laa_reference, :string
-      attribute :firm_name
-      attribute :client_name
+      attribute :firm_office
+      attribute :defendant
       attribute :submission
 
       delegate :id, to: :submission
+
+      def firm_name
+        firm_office['name']
+      end
+
+      def client_name
+        "#{defendant['first_name']} #{defendant['last_name']}"
+      end
 
       def date_created_str
         submission.created_at.to_fs(:stamp)
@@ -16,6 +24,10 @@ module PriorAuthority
 
       def date_assessed_str
         submission.updated_at.to_fs(:stamp)
+      end
+
+      def service_name
+        I18n.t(submission.data['service_type'], scope: 'prior_authority.service_types')
       end
 
       def caseworker

--- a/app/views/prior_authority/related_applications/_table.html.erb
+++ b/app/views/prior_authority/related_applications/_table.html.erb
@@ -1,0 +1,32 @@
+<%# # TODO: add and use shared/_sortable_table.html.erb with applications/_table.html.erb %>
+<table class="govuk-table" data-module="moj-sortable-table" aria-describedby="page-title">
+  <thead class="govuk-table__head">
+    <tr class="govuk-table__row">
+      <% columns.keys.each_with_index do |column_key, index| %>
+        <%= table_header(column_key,
+                        "prior_authority.applications.table.header",
+                        index,
+                        path,
+                        @sort_by,
+                        @sort_direction) %>
+      <% end %>
+    </tr>
+  </thead>
+
+  <tbody class="govuk-table__body app-task-list__items">
+    <% @applications.each do |application| %>
+      <tr class="govuk-table__row app-task-list__item">
+        <% columns.values.each_with_index do |value_attribute, index| %>
+          <td class="govuk-table__cell">
+            <% if index.zero? %>
+              <%= link_to application.send(value_attribute), prior_authority_application_path(application.id), data: { turbo: false } %>
+            <% else %>
+              <%= application.send(value_attribute) %>
+            <% end %>
+          </td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+<%= render 'shared/pagination', pagy: @pagy, item: t("prior_authority.applications.table.table_info_item") %>

--- a/app/views/prior_authority/related_applications/_table.html.erb
+++ b/app/views/prior_authority/related_applications/_table.html.erb
@@ -1,4 +1,3 @@
-<%# # TODO: add and use shared/_sortable_table.html.erb with applications/_table.html.erb %>
 <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="page-title">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">

--- a/app/views/prior_authority/related_applications/index.html.erb
+++ b/app/views/prior_authority/related_applications/index.html.erb
@@ -22,7 +22,7 @@
                         client_name: :client_name,
                         caseworker: :caseworker,
                         service_name: :service_name,
-                        date_received: :date_created_str,
+                        date_updated: :date_updated_str,
                         status: :status
                     } %>
         <% end %>

--- a/app/views/prior_authority/related_applications/index.html.erb
+++ b/app/views/prior_authority/related_applications/index.html.erb
@@ -1,0 +1,41 @@
+<% content_for(:primary_navigation) do %>
+  <% render 'layouts/prior_authority/primary_navigation', current: application_summary.current_section(current_user) %>
+<% end %>
+<% title t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+      <%= render 'prior_authority/shared/application_nav', application_summary:, current_page: 'related_applications' %>
+  </div>
+  <div class="govuk-grid-column-full">
+    <h2 class="govuk-heading-m"><%= t('.page_title') %></h2>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <% if @applications.none? %>
+          <h2 class="govuk-body-l"><%= t('.no_applications') %></h2>
+        <% else %>
+          <%= render 'table',
+                    path: prior_authority_application_related_applications_path,
+                    columns: {
+                        laa_reference: :laa_reference,
+                        client_name: :client_name,
+                        caseworker: :caseworker,
+                        service_name: :service_name,
+                        date_received: :date_created_str,
+                        status: :status
+                    } %>
+        <% end %>
+      </div>
+    </div>
+
+    <% if editable %>
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-9">
+      <div class="govuk-button-group">
+        <%= govuk_button_link_to(t('.make_a_decision'), '#') %>
+        <%= govuk_button_link_to(t('.save_and_exit'), your_prior_authority_applications_path, secondary: true) %>
+      </div>
+    <% end %>
+  </div>
+</div>
+

--- a/app/views/prior_authority/shared/_application_nav.html.erb
+++ b/app/views/prior_authority/shared/_application_nav.html.erb
@@ -41,7 +41,7 @@
       <%= link_to t('.adjust_quote'), prior_authority_application_adjustments_path(application_summary.id), class: 'moj-sub-navigation__link', 'aria-current': (current_page == 'adjust_quote' ? "page" : nil) %>
     </li>
     <li class="moj-sub-navigation__item">
-      <%= link_to t('.related_applications'), '#', class: 'moj-sub-navigation__link', 'aria-current': (current_page == 'related_applications' ? "page" : nil) %>
+      <%= link_to t('.related_applications'), prior_authority_application_related_applications_path(application_summary.id), class: 'moj-sub-navigation__link', 'aria-current': (current_page == 'related_applications' ? "page" : nil) %>
     </li>
     <li class="moj-sub-navigation__item">
       <%= link_to t('.application_history'), '#', class: 'moj-sub-navigation__link', 'aria-current': (current_page == 'application_history' ? "page" : nil) %>

--- a/config/locales/en/prior_authority/applications.yml
+++ b/config/locales/en/prior_authority/applications.yml
@@ -29,6 +29,7 @@ en:
           service_name: Service
           caseworker: Caseworker
           date_received: Received
+          date_updated: Last updated
           date_assessed: Assessed
           status: Status
       show:

--- a/config/locales/en/prior_authority/applications.yml
+++ b/config/locales/en/prior_authority/applications.yml
@@ -26,6 +26,7 @@ en:
           laa_reference: LAA reference
           firm_name: Firm name
           client_name: Client
+          service_name: Service
           caseworker: Caseworker
           date_received: Received
           date_assessed: Assessed

--- a/config/locales/en/prior_authority/related_applications.yml
+++ b/config/locales/en/prior_authority/related_applications.yml
@@ -1,0 +1,8 @@
+en:
+  prior_authority:
+    related_applications:
+      index:
+        make_a_decision: Make a decision
+        no_applications: No related applications have been found
+        page_title: Related applications
+        save_and_exit: Save and exit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,6 +94,7 @@ Rails.application.routes.draw do
       end
 
       resources :adjustments, only: :index
+      resources :related_applications, only: :index
       resources :service_costs, only: [:edit, :update]
       resources :travel_costs, only: [:edit, :update]
       resources :additional_costs, only: [:edit, :update]

--- a/db/migrate/20240313095200_add_correct_indexes_to_submissions.rb
+++ b/db/migrate/20240313095200_add_correct_indexes_to_submissions.rb
@@ -1,0 +1,20 @@
+class AddCorrectIndexesToSubmissions < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    remove_index :submissions, name: "index_submissions_on_firm_name", if_exists: true
+    remove_index :submissions, name: "index_submissions_on_client_name", if_exists: true
+
+    add_index(:submissions, "(data->'firm_office'->>'name')", name: "index_submissions_on_firm_name", algorithm: :concurrently)
+    add_index(:submissions, "(data->'defendant'->>'first_name'), (data->'defendant'->>'last_name')", name: "index_submissions_on_client_name", algorithm: :concurrently)
+  end
+
+  def down
+    remove_index :submissions, name: "index_submissions_on_firm_name", if_exists: true
+    remove_index :submissions, name: "index_submissions_on_client_name", if_exists: true
+
+    add_index(:submissions, "(data->>'firm_name')", name: "index_submissions_on_firm_name", algorithm: :concurrently)
+    add_index(:submissions, "(data->>'client_name')", name: "index_submissions_on_client_name", algorithm: :concurrently)
+  end
+end
+

--- a/db/migrate/20240313120114_add_ufn_service_type_indexes_to_submission.rb
+++ b/db/migrate/20240313120114_add_ufn_service_type_indexes_to_submission.rb
@@ -1,0 +1,10 @@
+class AddUfnServiceTypeIndexesToSubmission < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index(:submissions, "(data->>'ufn')", name: "index_submissions_on_ufn", algorithm: :concurrently)
+    add_index(:submissions, "(data->'firm_office'->>'account_number')", name: "index_submissions_on_firm_account_number", algorithm: :concurrently)
+    add_index(:submissions, "(data->>'ufn'), (data->'firm_office'->>'account_number')", name: "index_submissions_on_related_applications", algorithm: :concurrently)
+    add_index(:submissions, "(data->>'service_type')", name: "index_submissions_on_service_type", algorithm: :concurrently)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_13_095200) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_13_120114) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -53,8 +53,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_13_095200) do
     t.datetime "app_store_updated_at"
     t.string "application_type"
     t.index "(((data -> 'defendant'::text) ->> 'first_name'::text)), (((data -> 'defendant'::text) ->> 'last_name'::text))", name: "index_submissions_on_client_name"
+    t.index "(((data -> 'firm_office'::text) ->> 'account_number'::text))", name: "index_submissions_on_firm_account_number"
     t.index "(((data -> 'firm_office'::text) ->> 'name'::text))", name: "index_submissions_on_firm_name"
     t.index "((data ->> 'laa_reference'::text))", name: "index_submissions_on_laa_reference"
+    t.index "((data ->> 'service_type'::text))", name: "index_submissions_on_service_type"
+    t.index "((data ->> 'ufn'::text))", name: "index_submissions_on_ufn"
+    t.index "((data ->> 'ufn'::text)), (((data -> 'firm_office'::text) ->> 'account_number'::text))", name: "index_submissions_on_related_applications"
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_08_150518) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_13_095200) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -52,8 +52,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_08_150518) do
     t.jsonb "data"
     t.datetime "app_store_updated_at"
     t.string "application_type"
-    t.index "((data ->> 'client_name'::text))", name: "index_submissions_on_client_name"
-    t.index "((data ->> 'firm_name'::text))", name: "index_submissions_on_firm_name"
+    t.index "(((data -> 'defendant'::text) ->> 'first_name'::text)), (((data -> 'defendant'::text) ->> 'last_name'::text))", name: "index_submissions_on_client_name"
+    t.index "(((data -> 'firm_office'::text) ->> 'name'::text))", name: "index_submissions_on_firm_name"
     t.index "((data ->> 'laa_reference'::text))", name: "index_submissions_on_laa_reference"
   end
 

--- a/spec/factories/prior_authority_applications.rb
+++ b/spec/factories/prior_authority_applications.rb
@@ -39,6 +39,16 @@ FactoryBot.define do
     rep_order_date { '2023-01-02' }
     next_hearing_date { '2025-01-01' }
     quotes { [build(:primary_quote)] }
+
+    trait :related_application do
+      ufn { '111111/111' }
+      firm_office do
+        {
+          'name' => 'LegalCo',
+          'account_number' => '2B0N2B'
+        }
+      end
+    end
   end
 
   factory :additional_cost, class: Hash do

--- a/spec/system/prior_authority/view_related_applications_spec.rb
+++ b/spec/system/prior_authority/view_related_applications_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe 'View related applications' do
 
     it 'displays the required table headers' do
       within('.govuk-table') do
-        expect(page).to have_content("LAA reference\nClient\nCaseworker\nService\nReceived\nStatus\n")
+        expect(page).to have_content("LAA reference\nClient\nCaseworker\nService\nLast updated\nStatus\n")
       end
     end
 
@@ -179,13 +179,13 @@ RSpec.describe 'View related applications' do
       end
     end
 
-    it 'allows me to sort by received date' do
-      click_on 'Received'
+    it 'allows me to sort by "Last updated" date' do
+      click_on 'Last updated'
       within(top_row_selector) do
         expect(page).to have_content('LAA-555')
       end
 
-      click_on 'Received'
+      click_on 'Last updated'
       within(top_row_selector) do
         expect(page).to have_content('LAA-222')
       end

--- a/spec/system/prior_authority/view_related_applications_spec.rb
+++ b/spec/system/prior_authority/view_related_applications_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe 'View related applications' do
         :prior_authority_data,
         :related_application,
         laa_reference: 'LAA-222',
+        service_type: 'ae_consultant',
         defendant: { 'last_name' => 'Abrahams', 'first_name' => 'Abe' },
       )
     )
@@ -34,6 +35,7 @@ RSpec.describe 'View related applications' do
         :prior_authority_data,
         :related_application,
         laa_reference: 'LAA-333',
+        service_type: 'voice_recognition',
         defendant: { 'last_name' => 'Bacharach', 'first_name' => 'Burt' },
       )
     )
@@ -176,6 +178,18 @@ RSpec.describe 'View related applications' do
       click_on 'Caseworker'
       within(top_row_selector) do
         expect(page).to have_content('Able Worker')
+      end
+    end
+
+    it 'allows me to sort by Service name' do
+      click_on 'Service'
+      within(top_row_selector) do
+        expect(page).to have_content('Voice recognition')
+      end
+
+      click_on 'Service'
+      within(top_row_selector) do
+        expect(page).to have_content('A&E consultant')
       end
     end
 

--- a/spec/system/prior_authority/view_related_applications_spec.rb
+++ b/spec/system/prior_authority/view_related_applications_spec.rb
@@ -1,0 +1,241 @@
+require 'rails_helper'
+
+RSpec.describe 'View related applications' do
+  let(:me) { create(:caseworker) }
+  let(:wanda) { create(:caseworker, first_name: 'Wanda', last_name: 'Worker') }
+  let(:able) { create(:caseworker, first_name: 'Able', last_name: 'Worker') }
+
+  let(:assigned_to_me) do
+    create(:prior_authority_application,
+           state: 'in_progress',
+           data: build(:prior_authority_data, :related_application, laa_reference: 'LAA-111'))
+  end
+
+  let(:unassigned) do
+    create(
+      :prior_authority_application,
+      state: 'submitted',
+      created_at: 4.days.ago,
+      data: build(
+        :prior_authority_data,
+        :related_application,
+        laa_reference: 'LAA-222',
+        defendant: { 'last_name' => 'Abrahams', 'first_name' => 'Abe' },
+      )
+    )
+  end
+
+  let(:in_progress) do
+    create(
+      :prior_authority_application,
+      state: 'in_progress',
+      created_at: 3.days.ago,
+      data: build(
+        :prior_authority_data,
+        :related_application,
+        laa_reference: 'LAA-333',
+        defendant: { 'last_name' => 'Bacharach', 'first_name' => 'Burt' },
+      )
+    )
+  end
+
+  let(:rejected) do
+    create(
+      :prior_authority_application,
+      state: 'rejected',
+      created_at: 2.days.ago,
+      data: build(
+        :prior_authority_data,
+        :related_application,
+        laa_reference: 'LAA-444',
+        defendant: { 'last_name' => 'Xerxes', 'first_name' => 'Xana' },
+      )
+    )
+  end
+
+  let(:granted) do
+    create(
+      :prior_authority_application,
+      state: 'granted',
+      created_at: 1.day.ago,
+      data: build(
+        :prior_authority_data,
+        :related_application,
+        laa_reference: 'LAA-555',
+        defendant: { 'last_name' => 'Ziegler', 'first_name' => 'Zoe' },
+      )
+    )
+  end
+
+  let(:unrelated) do
+    create(:prior_authority_application,
+           state: 'granted',
+           data: build(:prior_authority_data, laa_reference: 'LAA-xxx', ufn: '010124/001'))
+  end
+
+  before do
+    sign_in me
+    visit '/'
+    click_on 'Accept analytics cookies'
+
+    create(:assignment,
+           user: me,
+           submission: assigned_to_me)
+
+    visit prior_authority_root_path
+    click_on 'Start now'
+  end
+
+  context 'when the application has NO related applications' do
+    before do
+      click_on 'LAA-111'
+      click_on 'Related applications'
+    end
+
+    it 'displays expected title' do
+      expect(page).to have_title('Related applications')
+    end
+
+    it 'displays info indicating the application has no related applications' do
+      expect(page).to have_content('No related applications have been found')
+    end
+  end
+
+  context 'when the application has related applications' do
+    before do
+      unassigned
+      in_progress
+      rejected
+      granted
+
+      create(:assignment, user: wanda, submission: in_progress)
+      create(:assignment, user: able, submission: rejected)
+      create(:assignment, user: able, submission: granted)
+
+      click_on 'LAA-111'
+      click_on 'Related applications'
+    end
+
+    it 'displays the required table headers' do
+      within('.govuk-table') do
+        expect(page).to have_content("LAA reference\nClient\nCaseworker\nService\nReceived\nStatus\n")
+      end
+    end
+
+    it 'does NOT show the current application or unrelated applications' do
+      within('.govuk-table') do
+        expect(page).to have_no_content('LAA-1')
+        expect(page).to have_no_content('LAA-x')
+      end
+    end
+
+    it 'shows related applications' do
+      within('.govuk-table') do
+        expect(page).to have_content('LAA-2')
+        expect(page).to have_content('LAA-3')
+        expect(page).to have_content('LAA-4')
+      end
+    end
+
+    it 'default sort order is newest first' do
+      within(top_row_selector) do
+        expect(page).to have_content('LAA-555')
+      end
+    end
+
+    it 'allows me to sort by LAA reference' do
+      click_on 'LAA reference'
+      within(top_row_selector) do
+        expect(page).to have_content('LAA-555')
+      end
+
+      click_on 'LAA reference'
+      within(top_row_selector) do
+        expect(page).to have_content('LAA-222')
+      end
+    end
+
+    it 'allows me to sort by client name' do
+      click_on 'Client'
+      within(top_row_selector) do
+        expect(page).to have_content('Zoe Ziegler')
+      end
+
+      click_on 'Client'
+      within(top_row_selector) do
+        expect(page).to have_content('Abe Abrahams')
+      end
+    end
+
+    it 'allows me to sort by case worker name' do
+      click_on 'Caseworker'
+      within(top_row_selector) do
+        expect(page).to have_content('Wanda Worker')
+      end
+
+      click_on 'Caseworker'
+      within(top_row_selector) do
+        expect(page).to have_content('Able Worker')
+      end
+    end
+
+    it 'allows me to sort by received date' do
+      click_on 'Received'
+      within(top_row_selector) do
+        expect(page).to have_content('LAA-555')
+      end
+
+      click_on 'Received'
+      within(top_row_selector) do
+        expect(page).to have_content('LAA-222')
+      end
+    end
+
+    it 'allows me to sort by status' do
+      click_on 'Status'
+      within(top_row_selector) do
+        expect(page).to have_content('Rejected')
+      end
+
+      click_on 'Status'
+      within(top_row_selector) do
+        expect(page).to have_content('Granted')
+      end
+    end
+
+    def top_row_selector
+      '.govuk-table tbody tr:nth-child(1)'
+    end
+  end
+
+  context 'when the application has many related applications' do
+    let(:other) do
+      create_list(
+        :prior_authority_application,
+        10,
+        state: 'submitted',
+        created_at: 36.hours.ago,
+        data: build(
+          :prior_authority_data,
+          :related_application,
+          defendant: { 'last_name' => 'Geiger', 'first_name' => 'Gert' },
+        )
+      )
+    end
+
+    before do
+      in_progress
+      other
+
+      click_on 'LAA-111'
+      click_on 'Related applications'
+    end
+
+    it 'allows me to paginate' do
+      expect(page).to have_content('Showing 1 to 10 of 11 applications')
+      click_on 'Next page'
+      expect(page).to have_content('Showing 11 to 11 of 11 applications')
+      click_on 'Previous page'
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Add related applications

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-993)

## Notes for reviewer
Ordering/sorting has been amended as it did not appear to be working for client name. This should be retrospectively functional for assessed applications too. I have also amended the firm name sorting but not tested in this PR as that column is not used for related applications, only for assessed/open applications by the looks of the prototype.

In addition I have amended the table_row view model to include the firm_name and client_name methods as system tests
showed them to not be functioning, despite, weirdly, the client name working on the page in development. Still not sure why :(. Regardless it seemed sensible to explicitly rely on a defined `client_name` and `firm_name` method in the `TableRow` view model in any event.

## Screenshots of changes (if applicable)

<img width="683" alt="Screenshot 2024-03-11 at 21 57 18" src="https://github.com/ministryofjustice/laa-assess-crime-forms/assets/7016425/d1a68db6-a554-453d-9805-56a80d95f4f0">
