### PR TITLE
CRM457-992: Changes from QA

### DIFF
--- a/app/forms/base_adjustment_form.rb
+++ b/app/forms/base_adjustment_form.rb
@@ -13,7 +13,7 @@ class BaseAdjustmentForm
 
   private
 
-  def process_field(value:, field:)
+  def process_field(value:, field:, comment_field: 'adjustment_comment')
     return if selected_record[field] == value
 
     # does this belong in the Event object as that is where it is
@@ -27,7 +27,7 @@ class BaseAdjustmentForm
     }.merge(changed_value(value, selected_record[field]))
 
     ensure_original_field_value_set(field)
-    assign_new_attributes(field, value)
+    assign_new_attributes(field, value, comment_field)
 
     Event::Edit.build(submission:, details:, linked:, current_user:)
   end
@@ -36,9 +36,9 @@ class BaseAdjustmentForm
     selected_record["#{field}_original"] ||= selected_record[field]
   end
 
-  def assign_new_attributes(field, value)
+  def assign_new_attributes(field, value, comment_field)
     selected_record[field] = value
-    selected_record['adjustment_comment'] = explanation
+    selected_record[comment_field] = explanation
   end
 
   def changed_value(val1, val2)

--- a/app/forms/prior_authority/travel_cost_form.rb
+++ b/app/forms/prior_authority/travel_cost_form.rb
@@ -23,8 +23,10 @@ module PriorAuthority
     private
 
     def process_fields
-      process_field(value: travel_time.to_i, field: 'travel_time')
-      process_field(value: travel_cost_per_hour.to_s, field: 'travel_cost_per_hour')
+      comment_field = 'travel_adjustment_comment'
+
+      process_field(value: travel_time.to_i, field: 'travel_time', comment_field: comment_field)
+      process_field(value: travel_cost_per_hour.to_s, field: 'travel_cost_per_hour', comment_field: comment_field)
     end
 
     def selected_record

--- a/app/javascript/component/nsm/work_item_adjustment.js
+++ b/app/javascript/component/nsm/work_item_adjustment.js
@@ -1,7 +1,7 @@
 function init() {
   const workItemAdjustmentContainer = document.getElementById('work-items-adjustment-container');
-  const hoursField = document.getElementById('nsm_work_item_form_time_spent_1i');
-  const minutesField = document.getElementById('nsm_work_item_form_time_spent_2i');
+  const hoursField = document.getElementById('nsm_work_item_form_time_spent_1');
+  const minutesField = document.getElementById('nsm_work_item_form_time_spent_2');
   const upliftRemovedYesField = document.getElementById('nsm-work-item-form-uplift-yes-field');
   const upliftRemovedNoField = document.getElementById('nsm-work-item-form-uplift-no-field');
   const calculateChangeButton = document.getElementById('calculate_change_button');

--- a/app/javascript/component/prior_authority/additional_cost_adjustment.js
+++ b/app/javascript/component/prior_authority/additional_cost_adjustment.js
@@ -2,8 +2,8 @@ import CostAdjustment from './cost_adjustment.js'
 
 function init() {
   const fields = [
-    document.getElementById('prior_authority_additional_cost_form_period_1i'),
-    document.getElementById('prior_authority_additional_cost_form_period_2i'),
+    document.getElementById('prior_authority_additional_cost_form_period_1'),
+    document.getElementById('prior_authority_additional_cost_form_period_2'),
     document.getElementById('prior-authority-additional-cost-form-cost-per-hour-field'),
     document.getElementById('prior-authority-additional-cost-form-items-field'),
     document.getElementById('prior-authority-additional-cost-form-cost-per-item-field'),

--- a/app/javascript/component/prior_authority/cost_adjustment.js
+++ b/app/javascript/component/prior_authority/cost_adjustment.js
@@ -36,14 +36,14 @@ export default class CostAdjustment {
   }
 
   calculateTimeCost() {
+    if(isNaN(this.hoursField?.value) || isNaN(this.minutesField?.value) || isNaN(this.costPerHourField?.value)) {
+      return '--';
+    }
+
     const unitPrice = parseFloat(this.costPerHourField.value)
     let minutes
 
     this.checkMinutesThreshold();
-
-    if(isNaN(this.hoursField?.value) || isNaN(this.minutesField?.value)){
-      return '--';
-    }
 
     if(this.hoursField?.value && this.minutesField?.value){
       minutes = (parseInt(this.hoursField.value) * 60) + parseInt(this.minutesField.value);
@@ -54,8 +54,13 @@ export default class CostAdjustment {
   }
 
   calculateItemCost() {
+    if(isNaN(this.itemsField?.value) || isNaN(this.costPerItemField?.value)){
+      return '--';
+    }
+
     const items = parseInt(this.itemsField.value)
     const unitPrice = parseFloat(this.costPerItemField.value)
+
 
     // rounding to two decimal places
     return (`${(items * unitPrice).toFixed(2)}`);

--- a/app/javascript/component/prior_authority/service_cost_adjustment.js
+++ b/app/javascript/component/prior_authority/service_cost_adjustment.js
@@ -2,8 +2,8 @@ import CostAdjustment from './cost_adjustment.js'
 
 function init() {
   const fields = [
-    document.getElementById('prior_authority_service_cost_form_period_1i'),
-    document.getElementById('prior_authority_service_cost_form_period_2i'),
+    document.getElementById('prior_authority_service_cost_form_period_1'),
+    document.getElementById('prior_authority_service_cost_form_period_2'),
     document.getElementById('prior-authority-service-cost-form-cost-per-hour-field'),
     document.getElementById('prior-authority-service-cost-form-items-field'),
     document.getElementById('prior-authority-service-cost-form-cost-per-item-field'),

--- a/app/javascript/component/prior_authority/travel_cost_adjustment.js
+++ b/app/javascript/component/prior_authority/travel_cost_adjustment.js
@@ -20,15 +20,15 @@ function init() {
   }
 
   function calculateAdjustedCost() {
+    if(isNaN(hoursField?.value) || isNaN(minutesField?.value) || isNaN(costPerHourField?.value)) {
+      return '--';
+    }
+
     const unitPrice = parseFloat(costPerHourField.value)
 
     checkMinutesThreshold();
 
     var minutes = calculateChangeButton?.getAttribute('data-provider-time-spent');
-
-    if(isNaN(hoursField?.value) || isNaN(minutesField?.value)){
-      return '--';
-    }
 
     if(hoursField?.value && minutesField?.value){
       minutes = (parseInt(hoursField.value) * 60) + parseInt(minutesField.value);

--- a/app/javascript/component/prior_authority/travel_cost_adjustment.js
+++ b/app/javascript/component/prior_authority/travel_cost_adjustment.js
@@ -1,6 +1,6 @@
 function init() {
-  const hoursField = document.getElementById('prior_authority_travel_cost_form_travel_time_1i');
-  const minutesField = document.getElementById('prior_authority_travel_cost_form_travel_time_2i')
+  const hoursField = document.getElementById('prior_authority_travel_cost_form_travel_time_1');
+  const minutesField = document.getElementById('prior_authority_travel_cost_form_travel_time_2')
   const costPerHourField = document.getElementById('prior-authority-travel-cost-form-travel-cost-per-hour-field')
   const calculateChangeButton = document.getElementById('calculate_change_button');
   const adjustedCost = document.getElementById('adjusted-cost');

--- a/app/view_models/prior_authority/v1/quote.rb
+++ b/app/view_models/prior_authority/v1/quote.rb
@@ -31,6 +31,8 @@ module PriorAuthority
       attribute :related_to_post_mortem, :boolean
       attribute :document
 
+      attribute :travel_adjustment_comment
+
       def total_cost
         base_cost + travel_costs + total_additional_costs
       end

--- a/app/views/prior_authority/adjustments/_additional_costs.html.erb
+++ b/app/views/prior_authority/adjustments/_additional_costs.html.erb
@@ -2,6 +2,12 @@
 
   <h2 class="govuk-heading-m"><%= t('.additional_cost', n: index + 1) %></h2>
 
+  <% if additional_cost.adjustment_comment %>
+    <div class="govuk-inset-text">
+      <%= additional_cost.adjustment_comment %>
+    </div>
+  <% end %>
+
   <p class="govuk-text"><%= t(".cost_description", name: additional_cost.name, description: additional_cost.description) %></p>
 
   <%= govuk_table(id: "additional_cost_#{index + 1}") do |table|

--- a/app/views/prior_authority/adjustments/_service_costs.html.erb
+++ b/app/views/prior_authority/adjustments/_service_costs.html.erb
@@ -2,6 +2,12 @@
 
 <% service_cost = application_summary.service_cost %>
 
+<% if service_cost.adjustment_comment %>
+  <div class="govuk-inset-text">
+    <%= service_cost.adjustment_comment %>
+  </div>
+<% end %>
+
 <%= govuk_table(id: 'service_costs') do |table|
       table.with_head do |head|
         head.with_row do |row|

--- a/app/views/prior_authority/adjustments/_travel_costs.erb
+++ b/app/views/prior_authority/adjustments/_travel_costs.erb
@@ -2,6 +2,12 @@
 
 <% quote = application_summary.travel_cost %>
 
+<% if quote.travel_adjustment_comment %>
+  <div class="govuk-inset-text">
+    <%= quote.travel_adjustment_comment %>
+  </div>
+<% end %>
+
 <% if quote.travel_cost_reason %>
   <p class="govuk-text"><%= t(".cost_description", description: quote.travel_cost_reason) %></p>
 <% end %>

--- a/app/views/prior_authority/adjustments/index.html.erb
+++ b/app/views/prior_authority/adjustments/index.html.erb
@@ -19,7 +19,7 @@
 
     <%= render 'additional_costs', additional_costs: core_cost_summary.additional_costs, application:, editable: %>
     <% if editable %>
-      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-9">
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
       <div class="govuk-button-group">
         <%= govuk_button_link_to(t('.make_a_decision'), '#') %>
         <%= govuk_button_link_to(t('.save_and_exit'), your_prior_authority_applications_path, secondary: true) %>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -4,9 +4,14 @@ en:
     blank: Enter the time
     blank_hours: Enter number of hours
     blank_minutes: Enter number of minutes
+    invalid: Time must be valid
     invalid_hours: Hours must be greater than 0
     invalid_minutes: Minutes must be between 0 and 59
-    invalid: Time must be valid
+    invalid_period: Time must be more than 0
+    non_integer_hours: The number of hours must be a whole number
+    non_integer_minutes: The number of minutes must be a whole number
+    non_numerical_hours: The number of hours must be a number
+    non_numerical_minutes: The number of minutes must be a number
     zero_time_period: Time must be more than 0
 
   errors:

--- a/config/locales/en/prior_authority/application_details.yml
+++ b/config/locales/en/prior_authority/application_details.yml
@@ -60,4 +60,4 @@ en:
       case_contact: Case contact
       firm_details: Firm details
       no_alternative_quote_reason: Reason for no alternative quotes
-      primary_quote_postcode: Expert postcode
+      primary_quote_postcode: Service provider postcode

--- a/lib/govuk_design_system_formbuilder/elements/period.rb
+++ b/lib/govuk_design_system_formbuilder/elements/period.rb
@@ -13,7 +13,7 @@ module GOVUKDesignSystemFormBuilder
       DEFAULT_WIDTH = 2
 
       def segement_id(key)
-        "#{FIELDS.index(key) + 1}i"
+        (FIELDS.index(key) + 1).to_s
       end
 
       def multiparameter_key(key)

--- a/spec/system/prior_authority/adjust_additional_costs_spec.rb
+++ b/spec/system/prior_authority/adjust_additional_costs_spec.rb
@@ -71,8 +71,11 @@ RSpec.describe 'Adjust additional costs' do
 
       fill_in 'Number of items', with: 100
       fill_in 'What is the cost per item?', with: '3.00'
-      fill_in 'Explain your decision', with: 'maximum mileage claimable is 100, and cost per mile is 3.00'
+      fill_in 'Explain your decision', with: 'additional cost 1 explanation'
       click_on 'Save changes'
+
+      expect(page).to have_title('Adjustments')
+      expect(page).to have_css('.govuk-inset-text', text: 'additional cost 1 explanation')
 
       within('.govuk-table#additional_cost_1') do
         expect(page)
@@ -99,8 +102,11 @@ RSpec.describe 'Adjust additional costs' do
       fill_in 'Hours', with: 1
       fill_in 'Minutes', with: 30
       fill_in 'What is the hourly cost?', with: '40.00'
-      fill_in 'Explain your decision', with: 'maximums breached'
+      fill_in 'Explain your decision', with: 'additional cost 2 explanation'
       click_on 'Save changes'
+
+      expect(page).to have_title('Adjustments')
+      expect(page).to have_css('.govuk-inset-text', text: 'additional cost 2 explanation')
 
       within('.govuk-table#additional_cost_2') do
         expect(page)

--- a/spec/system/prior_authority/adjust_service_costs_spec.rb
+++ b/spec/system/prior_authority/adjust_service_costs_spec.rb
@@ -83,11 +83,16 @@ RSpec.describe 'Adjust service costs' do
     end
 
     it 'allows me to recalculate the values on the page', :javascript do
+      expect(page).to have_css('#adjusted-cost', text: '0.00')
+
+      fill_in 'Hours', with: 'a'
+      click_on 'Calculate my changes'
+      expect(page).to have_css('#adjusted-cost', text: '--')
+
       fill_in 'Hours', with: 20
       fill_in 'Minutes', with: 0
       fill_in 'Hourly cost', with: '1.50'
 
-      expect(page).to have_css('#adjusted-cost', text: '0.00')
       click_on 'Calculate my changes'
       expect(page).to have_css('#adjusted-cost', text: '30.00')
     end
@@ -104,6 +109,19 @@ RSpec.describe 'Adjust service costs' do
     it 'allows me to cancel and return to adjustments page' do
       click_on 'Cancel'
       expect(page).to have_title('Adjustments')
+    end
+
+    it 'displays erroroneous values with appropriate message' do
+      fill_in 'Hours', with: 'a'
+      fill_in 'Hourly cost', with: 'b'
+
+      click_on 'Save changes'
+
+      expect(page)
+        .to have_content('The number of hours must be a number')
+        .and have_content('The cost per hour must be a number')
+        .and have_field('Hours', with: 'a')
+        .and have_field('Hourly cost', with: 'b')
     end
   end
 
@@ -162,10 +180,14 @@ RSpec.describe 'Adjust service costs' do
     end
 
     it 'allows me to calculate the values on the page', :javascript do
+      expect(page).to have_css('#adjusted-cost', text: '0.00')
+
+      fill_in 'What is the cost per minute?', with: 'a'
+      click_on 'Calculate my changes'
+      expect(page).to have_css('#adjusted-cost', text: '--')
+
       fill_in 'Number of minutes', with: 60
       fill_in 'What is the cost per minute?', with: 2.50
-
-      expect(page).to have_css('#adjusted-cost', text: '0.00')
       click_on 'Calculate my changes'
       expect(page).to have_css('#adjusted-cost', text: '150.00')
     end

--- a/spec/system/prior_authority/adjust_service_costs_spec.rb
+++ b/spec/system/prior_authority/adjust_service_costs_spec.rb
@@ -55,10 +55,12 @@ RSpec.describe 'Adjust service costs' do
 
       fill_in 'Hours', with: 10
       fill_in 'Minutes', with: 30
-      fill_in 'Explain your decision', with: 'they worked longer'
+      fill_in 'Explain your decision', with: 'service cost adjustment explanation'
       click_on 'Save changes'
 
       expect(page).to have_title('Adjustments')
+      expect(page).to have_css('.govuk-inset-text', text: 'service cost adjustment explanation')
+
       within('.govuk-table#service_costs') do
         expect(page)
           .to have_content('Amount3 hours 0 minutes10 hours 30 minutes')
@@ -69,10 +71,11 @@ RSpec.describe 'Adjust service costs' do
 
     it 'allows me to adjust the cost per hour' do
       fill_in 'Hourly cost', with: '5.50'
-      fill_in 'Explain your decision', with: 'rates have risen'
+      fill_in 'Explain your decision', with: 'service cost adjustment explanation'
       click_on 'Save changes'
 
       expect(page).to have_title('Adjustments')
+      expect(page).to have_css('.govuk-inset-text', text: 'service cost adjustment explanation')
 
       within('.govuk-table#service_costs') do
         expect(page)

--- a/spec/system/prior_authority/adjust_travel_costs_spec.rb
+++ b/spec/system/prior_authority/adjust_travel_costs_spec.rb
@@ -51,10 +51,12 @@ RSpec.describe 'Adjust travel costs' do
   it 'allows me to adjust the travel time' do
     fill_in 'Hours', with: 1
     fill_in 'Minutes', with: 0
-    fill_in 'Explain your decision', with: 'estimated time of jourmey from googlemaps without traffic'
+    fill_in 'Explain your decision', with: 'travel cost adjustment explanation'
     click_on 'Save changes'
 
     expect(page).to have_title('Adjustments')
+    expect(page).to have_css('.govuk-inset-text', text: 'travel cost adjustment explanation')
+
     within('.govuk-table#travel_costs') do
       expect(page)
         .to have_content('Time1 hour 30 minutes1 hour 0 minutes')
@@ -65,10 +67,11 @@ RSpec.describe 'Adjust travel costs' do
 
   it 'allows me to adjust the cost per hour' do
     fill_in 'Hourly cost', with: '90.00'
-    fill_in 'Explain your decision', with: 'maximum travel per hour rate exceeded'
+    fill_in 'Explain your decision', with: 'travel cost adjustment explanation'
     click_on 'Save changes'
 
     expect(page).to have_title('Adjustments')
+    expect(page).to have_css('.govuk-inset-text', text: 'travel cost adjustment explanation')
 
     within('.govuk-table#travel_costs') do
       expect(page)

--- a/spec/system/prior_authority/view_adjust_quote_spec.rb
+++ b/spec/system/prior_authority/view_adjust_quote_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe 'View Adjust quote tab' do
         expect(page)
           .to have_css('.govuk-summary-card__title', text: 'Key information')
           .and have_content('Main offenceRobbery')
-          .and have_content('Expert postcodeSW1 1AA')
+          .and have_content('Service provider postcodeSW1 1AA')
       end
     end
 


### PR DESCRIPTION
## Description of change
QA changes to "Adjust quotes" functionality

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-992)

- Amend postcode field content
- Remove unnecessary padding on `hr` tag
- Add alpha character error handling for time period
- Handle NaN JS errors by displaying £ --
- Display adjustment comments on "Adjust quote" tab

## Screenshots of changes (if applicable)
Most significant change is the display of the explanation for each type of cost
![localhost_3002_prior_authority_applications_adf857b2-39dd-40a5-a071-8b4538077e70_adjustments (1)](https://github.com/ministryofjustice/laa-assess-crime-forms/assets/7016425/3edac259-f2fa-45c0-be9c-505060ec8220)


