### PR TITLE
CRM457-992: Add item cost error messages

### DIFF
--- a/app/forms/prior_authority/base_cost_adjustment_form.rb
+++ b/app/forms/prior_authority/base_cost_adjustment_form.rb
@@ -11,8 +11,8 @@ module PriorAuthority
     attribute :cost_per_hour, :gbp
 
     with_options if: :per_item? do
-      validates :items, presence: true, numericality: { greater_than: 0 }, is_a_number: true
-      validates :cost_per_item, presence: true, numericality: { greater_than: 0 }, is_a_number: true
+      validates :items, item_type_dependant: { pluralize: true }
+      validates :cost_per_item, item_type_dependant: true
     end
 
     with_options if: :per_hour? do

--- a/app/validators/item_type_dependant_validator.rb
+++ b/app/validators/item_type_dependant_validator.rb
@@ -1,0 +1,14 @@
+class ItemTypeDependantValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    item_type = item_type_for(record)
+    item_type = item_type.pluralize if options[:pluralize]
+
+    record.errors.add(attribute, :blank, item_type:) if value.blank?
+    record.errors.add(attribute, :not_a_number, item_type:) if value.is_a?(String)
+    record.errors.add(attribute, :greater_than, item_type:) if value.to_i <= 0
+  end
+
+  def item_type_for(record)
+    record.respond_to?(:item_type) ? record.item_type || 'item' : 'item'
+  end
+end

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -13,6 +13,18 @@ en:
     non_numerical_hours: The number of hours must be a number
     non_numerical_minutes: The number of minutes must be a number
     zero_time_period: Time must be more than 0
+  shared_cost_per_hour_errors: &shared_cost_per_hour_errors
+    blank: The hourly cost must be more than 0
+    greater_than: The hourly cost must be more than 0
+    not_a_number: The cost per hour must be a number, like 25
+  shared_cost_per_item_errors: &shared_cost_per_item_errors
+    blank: Enter the cost per %{item_type}
+    greater_than: The cost per %{item_type} must be more than 0
+    not_a_number: The cost per %{item_type} must be a number, like 25
+  shared_items_errors: &shared_items_errors
+    blank: Enter the number of %{item_type}
+    greater_than: The number of %{item_type} must be more than 0
+    not_a_number: The number of  %{item_type} must be a number, like 25
 
   errors:
     format: "%{message}"
@@ -69,19 +81,21 @@ en:
             base:
               no_change: There are no changes to save. Select cancel if you do not want to make any changes.
             period: *shared_time_errors
+            cost_per_hour: *shared_cost_per_hour_errors
+            items: *shared_items_errors
+            cost_per_item: *shared_cost_per_item_errors
             explanation:
               blank: Explain your decision for adjusting the costs
         prior_authority/service_cost_form:
           attributes:
             base:
               no_change: There are no changes to save. Select cancel if you do not want to make any changes.
+            period: *shared_time_errors
+            cost_per_hour: *shared_cost_per_hour_errors
+            items: *shared_items_errors
+            cost_per_item: *shared_cost_per_item_errors
             explanation:
               blank: Explain your decision for adjusting the costs
-            period: *shared_time_errors
-            cost_per_hour:
-              blank: The hourly cost must be more than 0
-              greater_than: The hourly cost must be more than 0
-              not_a_number: The cost per hour must be a number, like 25
         prior_authority/travel_cost_form:
           attributes:
             base:
@@ -89,7 +103,4 @@ en:
             explanation:
               blank: Explain your decision for adjusting the costs
             travel_time: *shared_time_errors
-            travel_cost_per_hour:
-              blank: The hourly cost must be more than 0
-              greater_than: The hourly cost must be more than 0
-              not_a_number: The cost per hour must be a number, like 25
+            travel_cost_per_hour: *shared_cost_per_hour_errors

--- a/spec/system/prior_authority/adjust_service_costs_spec.rb
+++ b/spec/system/prior_authority/adjust_service_costs_spec.rb
@@ -194,5 +194,30 @@ RSpec.describe 'Adjust service costs' do
       click_on 'Calculate my changes'
       expect(page).to have_css('#adjusted-cost', text: '150.00')
     end
+
+    it 'displays erroroneous values with appropriate message' do
+      fill_in 'Number of minutes', with: ''
+      fill_in 'What is the cost per minute?', with: ''
+
+      click_on 'Save changes'
+      expect(page)
+        .to have_content('Enter the number of minutes')
+        .and have_content('Enter the cost per minute')
+
+      fill_in 'Number of minutes', with: 0
+      fill_in 'What is the cost per minute?', with: 0
+
+      click_on 'Save changes'
+      expect(page)
+        .to have_content('The number of minutes must be more than 0')
+        .and have_content('The cost per minute must be more than 0')
+
+      fill_in 'What is the cost per minute?', with: 'a'
+
+      click_on 'Save changes'
+      expect(page)
+        .to have_content('The cost per minute must be a number, like 25')
+        .and have_field('What is the cost per minute?', with: 'a')
+    end
   end
 end

--- a/spec/validators/item_type_dependant_validator_spec.rb
+++ b/spec/validators/item_type_dependant_validator_spec.rb
@@ -1,0 +1,104 @@
+require 'rails_helper'
+
+RSpec.describe ItemTypeDependantValidator do
+  subject(:instance) { klass.new(items:, cost_per_item:) }
+
+  let(:klass) do
+    Class.new do
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+
+      def self.model_name
+        ActiveModel::Name.new(self, nil, 'temp')
+      end
+
+      attribute :items
+      attribute :cost_per_item, :gbp
+
+      validates :items, item_type_dependant: { pluralize: true }
+      validates :cost_per_item, item_type_dependant: true
+    end
+  end
+
+  context 'when attribute is a positive number' do
+    let(:items) { 1 }
+    let(:cost_per_item) { 100 }
+
+    it 'form object is valid' do
+      expect(instance).to be_valid
+    end
+  end
+
+  context 'when attribute is nil' do
+    let(:items) { nil }
+    let(:cost_per_item) { nil }
+
+    it 'adds blank error' do
+      expect(instance).not_to be_valid
+      expect(instance.errors.of_kind?(:items, :blank)).to be(true)
+      expect(instance.errors.of_kind?(:cost_per_item, :blank)).to be(true)
+    end
+
+    it 'adds item_type option to error object' do
+      instance.validate
+      expect(instance.errors.map(&:options)).to all(include(:item_type))
+    end
+  end
+
+  context 'when attribute is a string' do
+    let(:items) { 'one' }
+    let(:cost_per_item) { '100 hundred' }
+
+    it 'adds not_a_number error' do
+      expect(instance).not_to be_valid
+      expect(instance.errors.of_kind?(:items, :not_a_number)).to be(true)
+      expect(instance.errors.of_kind?(:cost_per_item, :not_a_number)).to be(true)
+    end
+  end
+
+  context 'when attribute is less zero or less' do
+    let(:items) { 0 }
+    let(:cost_per_item) { 0 }
+
+    it 'adds greater_than error' do
+      expect(instance).not_to be_valid
+      expect(instance.errors.of_kind?(:items, :greater_than)).to be(true)
+      expect(instance.errors.of_kind?(:cost_per_item, :greater_than)).to be(true)
+    end
+  end
+
+  context 'when model has an item_type attribute' do
+    subject(:instance) { klass.new(items:, cost_per_item:, item_type:) }
+
+    let(:klass) do
+      Class.new do
+        include ActiveModel::Model
+        include ActiveModel::Attributes
+
+        def self.model_name
+          ActiveModel::Name.new(self, nil, 'temp')
+        end
+
+        attribute :item_type, :string
+
+        attribute :items
+        attribute :cost_per_item, :gbp
+
+        validates :items, item_type_dependant: { pluralize: true }
+        validates :cost_per_item, item_type_dependant: true
+      end
+    end
+
+    context 'when attribute is nil' do
+      let(:items) { nil }
+      let(:cost_per_item) { nil }
+      let(:item_type) { 'word' }
+
+      it 'include item type option from model, pluralizing if option set' do
+        instance.validate
+        expect(instance.errors.details[:items].flat_map(&:values)).to include('words')
+        expect(instance.errors.details[:cost_per_item].flat_map(&:values)).to include('word')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Add item cost error messages

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-992)

Inline designs/content for error messages and QA feedback. This can/ should also be applied to provider

## Screenshots of changes (if applicable)

BLANK
<img width="726" alt="Screenshot 2024-03-13 at 20 59 02" src="https://github.com/ministryofjustice/laa-assess-crime-forms/assets/7016425/fdb08a29-ed8f-45b4-b152-b1215772e876">

ZERO
<img width="694" alt="Screenshot 2024-03-13 at 20 59 43" src="https://github.com/ministryofjustice/laa-assess-crime-forms/assets/7016425/4f086db0-44b8-44ff-bd93-2011ab3f36a5">

NOT A NUMBER
<img width="709" alt="Screenshot 2024-03-13 at 21 00 49" src="https://github.com/ministryofjustice/laa-assess-crime-forms/assets/7016425/3180d567-17e8-4443-87ee-8c247c45c75e">



