### PR TITLE
CRM457-1005: Prior authority application history

### DIFF
--- a/app/controllers/prior_authority/events_controller.rb
+++ b/app/controllers/prior_authority/events_controller.rb
@@ -1,0 +1,14 @@
+module PriorAuthority
+  class EventsController < PriorAuthority::BaseController
+    def index
+      application = PriorAuthorityApplication.find(params[:application_id])
+      application_summary = BaseViewModel.build(:application_summary, application)
+      editable = application_summary.can_edit?(current_user)
+
+      pagy, records = pagy(application.events.history.order(created_at: :desc))
+      events = records.map { V1::EventSummary.new(event: _1) }
+
+      render locals: { application_summary:, editable:, pagy:, events: }
+    end
+  end
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -8,6 +8,7 @@ class Event < ApplicationRecord
   HISTORY_EVENTS = [
     'Event::Assignment',
     'Event::Decision',
+    'Event::DraftDecision',
     'Event::ChangeRisk',
     'Event::NewVersion',
     'Event::Note',

--- a/app/models/event/draft_decision.rb
+++ b/app/models/event/draft_decision.rb
@@ -1,0 +1,17 @@
+class Event
+  class DraftDecision < Event
+    def self.build(submission:, next_state:, comment:, current_user:)
+      create!(
+        submission: submission,
+        submission_version: submission.current_version,
+        primary_user: current_user,
+        details: {
+          field: 'state',
+          from: submission.state,
+          to: next_state,
+          comment: comment
+        }
+      )
+    end
+  end
+end

--- a/app/view_models/prior_authority/v1/event_summary.rb
+++ b/app/view_models/prior_authority/v1/event_summary.rb
@@ -21,18 +21,10 @@ module PriorAuthority
       end
 
       def heading
-        case event.event_type
-        when 'Event::NewVersion'
-          I18n.t('prior_authority.events.received')
-        when 'Event::Assignment'
-          assignment_heading
-        when 'Event::Unassignment'
-          I18n.t('prior_authority.events.unassigned', caseworker:)
-        when 'Event::Decision'
-          I18n.t("prior_authority.events.decision_#{event.details['to']}")
-        else
-          raise "Prior Authority event summaries don't know how to display events of type #{event.event_type}"
-        end
+        key = heading_keys[event.event_type]
+        raise "Prior Authority event summaries don't know how to display events of type #{event.event_type}" unless key
+
+        I18n.t(key, caseworker:)
       end
 
       def details?
@@ -45,11 +37,21 @@ module PriorAuthority
 
       private
 
-      def assignment_heading
+      def heading_keys
+        {
+          'Event::NewVersion' => 'prior_authority.events.received',
+          'Event::Assignment' => assignment_heading_key,
+          'Event::Unassignment' => 'prior_authority.events.unassigned',
+          'Event::DraftDecision' => 'prior_authority.events.draft_decision',
+          'Event::Decision' => "prior_authority.events.decision_#{event.details['to']}"
+        }
+      end
+
+      def assignment_heading_key
         if details?
-          I18n.t('prior_authority.events.self_assigned', caseworker:)
+          'prior_authority.events.self_assigned'
         else
-          I18n.t('prior_authority.events.assigned', caseworker:)
+          'prior_authority.events.assigned'
         end
       end
     end

--- a/app/view_models/prior_authority/v1/event_summary.rb
+++ b/app/view_models/prior_authority/v1/event_summary.rb
@@ -1,0 +1,57 @@
+module PriorAuthority
+  module V1
+    class EventSummary
+      include ActiveModel::Model
+      include ActiveModel::Attributes
+      include ActionView::Helpers::TagHelper
+      include ActionView::Helpers::OutputSafetyHelper
+
+      attribute :event
+
+      def timestamp
+        safe_join([
+                    event.created_at.to_fs(:stamp),
+                    tag.br,
+                    event.created_at.to_fs(:time_of_day)
+                  ])
+      end
+
+      def caseworker
+        event.primary_user&.display_name || I18n.t('prior_authority.events.na')
+      end
+
+      def heading
+        case event.event_type
+        when 'Event::NewVersion'
+          I18n.t('prior_authority.events.received')
+        when 'Event::Assignment'
+          assignment_heading
+        when 'Event::Unassignment'
+          I18n.t('prior_authority.events.unassigned', caseworker:)
+        when 'Event::Decision'
+          I18n.t("prior_authority.events.decision_#{event.details['to']}")
+        else
+          raise "Prior Authority event summaries don't know how to display events of type #{event.event_type}"
+        end
+      end
+
+      def details?
+        details.present?
+      end
+
+      def details
+        event.details['comment']
+      end
+
+      private
+
+      def assignment_heading
+        if details?
+          I18n.t('prior_authority.events.self_assigned', caseworker:)
+        else
+          I18n.t('prior_authority.events.assigned', caseworker:)
+        end
+      end
+    end
+  end
+end

--- a/app/view_models/prior_authority/v1/event_summary.rb
+++ b/app/view_models/prior_authority/v1/event_summary.rb
@@ -27,11 +27,11 @@ module PriorAuthority
         I18n.t(key, caseworker:)
       end
 
-      def details?
-        details.present?
+      def comment?
+        comment.present?
       end
 
-      def details
+      def comment
         event.details['comment']
       end
 
@@ -48,7 +48,7 @@ module PriorAuthority
       end
 
       def assignment_heading_key
-        if details?
+        if comment?
           'prior_authority.events.self_assigned'
         else
           'prior_authority.events.assigned'

--- a/app/views/prior_authority/events/index.html.erb
+++ b/app/views/prior_authority/events/index.html.erb
@@ -1,0 +1,65 @@
+<% content_for(:primary_navigation) do %>
+  <% render 'layouts/prior_authority/primary_navigation', current: application_summary.current_section(current_user) %>
+<% end %>
+<% title t('.page_title') %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+      <%= render 'prior_authority/shared/application_nav', application_summary:, current_page: 'application_history' %>
+  </div>
+  <div class="govuk-grid-column-full">
+    <h2 class="govuk-heading-m"><%= t('.page_title') %></h2>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+          <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="page-title">
+            <thead class="govuk-table__head">
+              <tr class="govuk-table__row">
+                <th class='govuk-table__header' scope='col'>
+                  <%= t('.date') %>
+                </th>
+                <th class='govuk-table__header' scope='col'>
+                  <%= t('.caseworker') %>
+                </th>
+                <th class='govuk-table__header' scope='col'>
+                  <%= t('.update') %>
+                </th>
+              </tr>
+            </thead>
+
+            <tbody class="govuk-table__body app-task-list__items">
+              <% events.each do |event| %>
+                <tr class="govuk-table__row app-task-list__item">
+                  <td class="govuk-table__cell">
+                    <%= event.timestamp %>
+                  </td>
+                  <td class="govuk-table__cell">
+                    <%= event.caseworker %>
+                  </td>
+                  <td class="govuk-table__cell">
+                    <strong>
+                      <%= event.heading %>
+                    </strong>
+                    <% if event.details? %>
+                      <br>
+                      <%= event.details %>
+                    <% end %>
+                  </td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+          <%= render 'shared/pagination', pagy: pagy, item: t("prior_authority.applications.table.table_info_item") %>
+      </div>
+    </div>
+
+    <% if editable %>
+      <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-9">
+      <div class="govuk-button-group">
+        <%= govuk_button_link_to(t('.make_a_decision'), '#') %>
+        <%= govuk_button_link_to(t('.save_and_exit'), your_prior_authority_applications_path, secondary: true) %>
+      </div>
+    <% end %>
+  </div>
+</div>
+

--- a/app/views/prior_authority/events/index.html.erb
+++ b/app/views/prior_authority/events/index.html.erb
@@ -40,9 +40,9 @@
                     <strong>
                       <%= event.heading %>
                     </strong>
-                    <% if event.details? %>
+                    <% if event.comment? %>
                       <br>
-                      <%= event.details %>
+                      <%= event.comment %>
                     <% end %>
                   </td>
                 </tr>

--- a/app/views/prior_authority/shared/_application_nav.html.erb
+++ b/app/views/prior_authority/shared/_application_nav.html.erb
@@ -44,7 +44,7 @@
       <%= link_to t('.related_applications'), prior_authority_application_related_applications_path(application_summary.id), class: 'moj-sub-navigation__link', 'aria-current': (current_page == 'related_applications' ? "page" : nil) %>
     </li>
     <li class="moj-sub-navigation__item">
-      <%= link_to t('.application_history'), '#', class: 'moj-sub-navigation__link', 'aria-current': (current_page == 'application_history' ? "page" : nil) %>
+      <%= link_to t('.application_history'), prior_authority_application_events_path(application_summary.id), class: 'moj-sub-navigation__link', 'aria-current': (current_page == 'application_history' ? "page" : nil) %>
     </li>
   </ul>
 </nav>

--- a/config/initializers/date_and_time_formats.rb
+++ b/config/initializers/date_and_time_formats.rb
@@ -5,3 +5,4 @@
 #
 Date::DATE_FORMATS[:stamp] = '%d %B %Y' # DD MONTH YYYY
 Time::DATE_FORMATS[:stamp] = '%d %B %Y' # DD MONTH YYYY
+Time::DATE_FORMATS[:time_of_day] = '%-I:%M%P' # H:MM with am/pm

--- a/config/locales/en/prior_authority/events.yml
+++ b/config/locales/en/prior_authority/events.yml
@@ -5,6 +5,7 @@ en:
       assigned: Assigned to %{caseworker}
       unassigned: Unassigned by %{caseworker}
       self_assigned: Self-assigned by %{caseworker}
+      draft_decision: '%{caseworker} saved a draft decision'
       decision_granted: Granted
       decision_part_grant: Part granted
       decision_rejected: Rejected

--- a/config/locales/en/prior_authority/events.yml
+++ b/config/locales/en/prior_authority/events.yml
@@ -1,0 +1,18 @@
+en:
+  prior_authority:
+    events:
+      received: Received
+      assigned: Assigned to %{caseworker}
+      unassigned: Unassigned by %{caseworker}
+      self_assigned: Self-assigned by %{caseworker}
+      decision_granted: Granted
+      decision_part_grant: Part granted
+      decision_rejected: Rejected
+      na: N/A
+      index:
+        page_title: Application history
+        date: Date
+        caseworker: Caseworker
+        update: Update
+        make_a_decision: Make a decision
+        save_and_exit: Save and exit

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,6 +101,7 @@ Rails.application.routes.draw do
       resources :manual_assignments, only: %i[new create]
       resources :unassignments, only: %i[new create]
       resource :decision, only: %i[new create show]
+      resources :events, path: :history, only: :index
     end
     resources :auto_assignments, only: [:create]
     resources :downloads, only: :show

--- a/spec/system/prior_authority/history_spec.rb
+++ b/spec/system/prior_authority/history_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe 'History events' do
+  let(:caseworker) { create(:caseworker) }
+  let(:application) { create(:prior_authority_application, state: 'granted') }
+  let(:fixed_arbitrary_date) { Time.zone.local(2023, 2, 1, 9, 0) }
+  let(:supervisor) { create(:supervisor) }
+
+  before do
+    travel_to fixed_arbitrary_date
+    application
+    sign_in caseworker
+
+    Event::NewVersion.build(submission: application).update(created_at: 10.hours.ago)
+    Event::Assignment.build(submission: application, current_user: caseworker).update(created_at: 9.hours.ago)
+    Event::Unassignment.build(submission: application, user: caseworker, current_user: supervisor,
+                              comment: 'unassignment comment').update(created_at: 8.hours.ago)
+    Event::Assignment.build(submission: application, current_user: supervisor,
+                            comment: 'manual assignment comment').update(created_at: 7.hours.ago)
+    Event::Decision.build(submission: application, current_user: caseworker, previous_state: 'submitted',
+                          comment: 'decision comment').update(created_at: 6.hours.ago)
+  end
+
+  it 'shows all (visible) events in the history' do
+    visit prior_authority_application_events_path(application)
+
+    doc = Nokogiri::HTML(page.html)
+    history = doc.css(
+      '.govuk-table__cell'
+    ).map { _1.text.strip.gsub(/\s+/, ' ') }
+
+    expect(history).to eq(
+      ['01 February 20233:00am', 'case worker', 'Granted decision comment',
+       '01 February 20232:00am', 'super visor', 'Self-assigned by super visor manual assignment comment',
+       '01 February 20231:00am', 'case worker', 'Unassigned by case worker unassignment comment',
+       '01 February 202312:00am', 'case worker', 'Assigned to case worker',
+       '31 January 202311:00pm', 'N/A', 'Received']
+    )
+  end
+end

--- a/spec/system/prior_authority/history_spec.rb
+++ b/spec/system/prior_authority/history_spec.rb
@@ -17,8 +17,10 @@ RSpec.describe 'History events' do
                               comment: 'unassignment comment').update(created_at: 8.hours.ago)
     Event::Assignment.build(submission: application, current_user: supervisor,
                             comment: 'manual assignment comment').update(created_at: 7.hours.ago)
+    Event::DraftDecision.build(submission: application, current_user: caseworker, next_state: 'rejected',
+                               comment: 'draft decision comment').update(created_at: 6.hours.ago)
     Event::Decision.build(submission: application, current_user: caseworker, previous_state: 'submitted',
-                          comment: 'decision comment').update(created_at: 6.hours.ago)
+                          comment: 'decision comment').update(created_at: 5.hours.ago)
   end
 
   it 'shows all (visible) events in the history' do
@@ -30,7 +32,8 @@ RSpec.describe 'History events' do
     ).map { _1.text.strip.gsub(/\s+/, ' ') }
 
     expect(history).to eq(
-      ['01 February 20233:00am', 'case worker', 'Granted decision comment',
+      ['01 February 20234:00am', 'case worker', 'Granted decision comment',
+       '01 February 20233:00am', 'case worker', 'case worker saved a draft decision draft decision comment',
        '01 February 20232:00am', 'super visor', 'Self-assigned by super visor manual assignment comment',
        '01 February 20231:00am', 'case worker', 'Unassigned by case worker unassignment comment',
        '01 February 202312:00am', 'case worker', 'Assigned to case worker',

--- a/spec/view_models/prior_authority/v1/event_summary_spec.rb
+++ b/spec/view_models/prior_authority/v1/event_summary_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe PriorAuthority::V1::EventSummary do
+  describe '#heading' do
+    subject(:summary) { described_class.new(event:) }
+
+    context 'when event type is not recognised'
+    let(:event) { create(:event, :note) }
+
+    it 'raises an error' do
+      expect { summary.heading }.to raise_error(
+        "Prior Authority event summaries don't know how to display events of type Event::Note"
+      )
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Add new application history page for PA, showing relevant events.

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1005)


## Screenshots of changes
<img width="1147" alt="Screenshot 2024-03-14 at 15 36 16" src="https://github.com/ministryofjustice/laa-assess-crime-forms/assets/113888736/56211883-afeb-424b-90c9-1588b7e748a1">

