### PR TITLE
Move docker image scan to run in parrallel to tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -342,7 +342,7 @@ workflows:
             - rspec-tests
       - scan-docker-image:
           requires:
-            - rspec-tests
+             - build-test-container
 
   build-opened-pr:
     jobs:


### PR DESCRIPTION
## Description of change
Move docker image scan to run in parrallel to tests

To reduce the timeoverhead since the scan takes as long or longer
than the test suite run.

## Screenshots of changes (if applicable)

![Screenshot 2024-03-15 at 13 12 09](https://github.com/ministryofjustice/laa-assess-crime-forms/assets/7016425/fe65a771-168e-4bb0-90b7-322fcca8c52a)

