### PR TITLE
CRM457-992: Correct expected behaviour of `items` field for adjustments

### DIFF
--- a/app/attributes/type/fully_validatable_integer.rb
+++ b/app/attributes/type/fully_validatable_integer.rb
@@ -1,0 +1,13 @@
+module Type
+  class FullyValidatableInteger < ActiveModel::Type::Integer
+    def cast(value)
+      if value.is_a?(Integer) || value.blank? || value.strip.gsub(/[0-9,-]/, '').empty?
+        super(value&.to_s&.delete(','))
+      else
+        # If the user has entered a string that is not straightforwardly parseable
+        # as an integer, retain the original value so we can display it back to the user
+        value
+      end
+    end
+  end
+end

--- a/app/forms/prior_authority/base_cost_adjustment_form.rb
+++ b/app/forms/prior_authority/base_cost_adjustment_form.rb
@@ -5,7 +5,7 @@ module PriorAuthority
 
     attribute :id, :string
 
-    attribute :items, :integer
+    attribute :items, :fully_validatable_integer
     attribute :cost_per_item, :gbp
     attribute :period, :time_period
     attribute :cost_per_hour, :gbp

--- a/app/views/prior_authority/additional_costs/_cost_fields.html.erb
+++ b/app/views/prior_authority/additional_costs/_cost_fields.html.erb
@@ -1,6 +1,8 @@
 <% if form.object.per_item? %>
-  <%= form.govuk_number_field :items,
+  <%= form.govuk_text_field :items,
                               width: 5,
+                              inputmode: "numeric",
+                              pattern: "[0-9]*",
                               label: {
                                 text: t('.items'),
                                 size: 's'

--- a/app/views/prior_authority/service_costs/_cost_fields.html.erb
+++ b/app/views/prior_authority/service_costs/_cost_fields.html.erb
@@ -1,6 +1,8 @@
 <% if form.object.per_item? %>
-  <%= form.govuk_number_field :items,
+  <%= form.govuk_text_field :items,
                               width: 5,
+                              inputmode: "numeric",
+                              pattern: "[0-9]*",
                               label: {
                                 text: t('.items', items: t(".#{form.object.item_type}").pluralize(2)),
                                 size: 's'

--- a/config/initializers/attribute_types.rb
+++ b/config/initializers/attribute_types.rb
@@ -3,3 +3,4 @@ Dir["#{File.join(__dir__, '../../app/attributes/type')}/*.rb"].each { |f| requir
 ActiveModel::Type.register(:translated, Type::TranslatedObject)
 ActiveModel::Type.register(:time_period, Type::TimePeriod)
 ActiveModel::Type.register(:gbp, Type::Gbp)
+ActiveModel::Type.register(:fully_validatable_integer, Type::FullyValidatableInteger)

--- a/spec/attributes/type/fully_validatable_integer_spec.rb
+++ b/spec/attributes/type/fully_validatable_integer_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe Type::FullyValidatableInteger do
+  subject { described_class.new }
+
+  let(:coerced_value) { subject.cast(value) }
+
+  describe 'when value is `nil`' do
+    let(:value) { nil }
+
+    it { expect(coerced_value).to be_nil }
+  end
+
+  describe 'when value is a number' do
+    let(:value) { 12_345 }
+
+    it { expect(coerced_value).to eq(12_345) }
+  end
+
+  describe 'when value is an empty string' do
+    let(:value) { '' }
+
+    it { expect(coerced_value).to be_nil }
+  end
+
+  describe 'when value is an integery string' do
+    let(:value) { '123' }
+
+    it { expect(coerced_value).to eq 123 }
+  end
+
+  describe 'when value is an floaty string' do
+    let(:value) { '123.45' }
+
+    it { expect(coerced_value).to eq '123.45' }
+  end
+
+  describe 'when value is an numbery string with commas' do
+    let(:value) { '1,234' }
+
+    it { expect(coerced_value).to eq 1234 }
+  end
+
+  describe 'when value is non-numbery string' do
+    let(:value) { 'four thousand' }
+
+    it { expect(coerced_value).to eq 'four thousand' }
+  end
+end

--- a/spec/system/prior_authority/adjust_additional_costs_spec.rb
+++ b/spec/system/prior_authority/adjust_additional_costs_spec.rb
@@ -120,12 +120,47 @@ RSpec.describe 'Adjust additional costs' do
 
       expect(page).to have_title('Adjust additional cost 1')
 
+      expect(page).to have_css('#adjusted-cost', text: '0.00')
+      fill_in 'Number of items', with: 'a'
+      fill_in 'What is the cost per item?', with: 'a'
+      click_on 'Calculate my changes'
+      expect(page).to have_css('#adjusted-cost', text: '--')
+
       fill_in 'Number of items', with: 100
       fill_in 'What is the cost per item?', with: '3.00'
 
-      expect(page).to have_css('#adjusted-cost', text: '0.00')
       click_on 'Calculate my changes'
       expect(page).to have_css('#adjusted-cost', text: '300.00')
+    end
+
+    it 'displays erroroneous values with appropriate message for the first additional cost (item)' do
+      click_on 'Adjust additional cost', match: :first
+
+      fill_in 'Number of items', with: ''
+      fill_in 'What is the cost per item?', with: ''
+
+      click_on 'Save changes'
+      expect(page)
+        .to have_content('Enter the number of items')
+        .and have_content('Enter the cost per item')
+
+      fill_in 'Number of items', with: 0
+      fill_in 'What is the cost per item?', with: 0
+
+      click_on 'Save changes'
+      expect(page)
+        .to have_content('The number of items must be more than 0')
+        .and have_content('The cost per item must be more than 0')
+
+      fill_in 'Number of items', with: 'a'
+      fill_in 'What is the cost per item?', with: 'a'
+
+      click_on 'Save changes'
+      expect(page)
+        .to have_content('The number of items must be a number, like 25')
+        .and have_content('The cost per item must be a number, like 25')
+        .and have_field('Number of items', with: 'a')
+        .and have_field('What is the cost per item?', with: 'a')
     end
 
     it 'allows me to recalculate the time cost on the page', :javascript do
@@ -140,6 +175,23 @@ RSpec.describe 'Adjust additional costs' do
       expect(page).to have_css('#adjusted-cost', text: '0.00')
       click_on 'Calculate my changes'
       expect(page).to have_css('#adjusted-cost', text: '60.00')
+    end
+
+    it 'displays erroroneous values with appropriate message for the second additional cost (time)' do
+      page.click_on(id: 'additional_cost_2', text: 'Adjust additional cost', exact: true)
+
+      fill_in 'Hours', with: 'a'
+      fill_in 'Minutes', with: 'b'
+      fill_in 'What is the hourly cost?', with: 'c'
+
+      click_on 'Save changes'
+
+      expect(page)
+        .to have_content('The number of hours must be a number')
+        .and have_content('The cost per hour must be a number, like 25')
+        .and have_field('Hours', with: 'a')
+        .and have_field('Minutes', with: 'b')
+        .and have_field('What is the hourly cost?', with: 'c')
     end
 
     it 'warns me that I have not made any changes' do

--- a/spec/system/prior_authority/adjust_service_costs_spec.rb
+++ b/spec/system/prior_authority/adjust_service_costs_spec.rb
@@ -211,11 +211,14 @@ RSpec.describe 'Adjust service costs' do
         .to have_content('The number of minutes must be more than 0')
         .and have_content('The cost per minute must be more than 0')
 
+      fill_in 'Number of minutes', with: 'a'
       fill_in 'What is the cost per minute?', with: 'a'
 
       click_on 'Save changes'
       expect(page)
-        .to have_content('The cost per minute must be a number, like 25')
+        .to have_content('The number of minutes must be a number, like 25')
+        .and have_content('The cost per minute must be a number, like 25')
+        .and have_field('Number of minutes', with: 'a')
         .and have_field('What is the cost per minute?', with: 'a')
     end
   end


### PR DESCRIPTION
## Description of change
Correct expected behaviour of `items` field for adjustments

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-992)

From QA feedback and inline with forms in provider app, this changes the items field to be a text field that is
validated as an integer. This conforms to GDS standards as [covered in this blog](https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/)

## Screenshots of changes (if applicable)

![Screenshot 2024-03-18 at 15 27 37](https://github.com/ministryofjustice/laa-assess-crime-forms/assets/7016425/01575708-41dd-4544-adae-c185fa98bc1e)

