### PR TITLE
CRM457-993: correct no records content para

### DIFF
--- a/app/views/prior_authority/applications/assessed.html.erb
+++ b/app/views/prior_authority/applications/assessed.html.erb
@@ -7,7 +7,7 @@
   <div class="govuk-grid-column-full">
     <h1 id="page-title" class="govuk-heading-xl"><%= t('.page_title') %></h1>
     <% if @applications.none? %>
-      <h2 class="govuk-body-l"><%= t('.no_applications') %></h2>
+      <p class="govuk-body-m"><%= t('.no_applications') %></p>
     <% else %>
       <%= render 'table',
                  path: assessed_prior_authority_applications_path,

--- a/app/views/prior_authority/applications/open.html.erb
+++ b/app/views/prior_authority/applications/open.html.erb
@@ -7,7 +7,7 @@
   <div class="govuk-grid-column-full">
     <h1 id="page-title" class="govuk-heading-xl"><%= t('.page_title') %></h1>
     <% if @applications.none? %>
-      <h2 class="govuk-body-l"><%= t('.no_applications') %></h2>
+      <p class="govuk-body-m"><%= t('.no_applications') %></p>
     <% else %>
       <%= render 'table',
                  path: open_prior_authority_applications_path,

--- a/app/views/prior_authority/applications/your.html.erb
+++ b/app/views/prior_authority/applications/your.html.erb
@@ -7,7 +7,7 @@
   <div class="govuk-grid-column-full">
     <h1 id="page-title" class="govuk-heading-xl"><%= t('.page_title') %></h1>
     <% if @applications.none? %>
-      <h2 class="govuk-body-l"><%= t('.no_applications') %></h2>
+      <p class="govuk-body-m"><%= t('.no_applications') %></p>
     <% end %>
     <div class="govuk-button-group">
       <%= govuk_button_to(t('.next_application'), prior_authority_auto_assignments_path) %>

--- a/app/views/prior_authority/related_applications/index.html.erb
+++ b/app/views/prior_authority/related_applications/index.html.erb
@@ -13,7 +13,7 @@
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
         <% if @applications.none? %>
-          <div class="govuk-body-l"><%= t('.no_applications') %></div>
+          <p class="govuk-body-m"><%= t('.no_applications') %></p>
         <% else %>
           <%= render 'table',
                     path: prior_authority_application_related_applications_path,


### PR DESCRIPTION
## Description of change
Correct no application content style

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-993)

Inline with QA feedback and retrospectivelly applied to Your, Open and Assessed application
pages too.

## Before
![Screenshot 2024-03-18 at 20 27 17](https://github.com/ministryofjustice/laa-assess-crime-forms/assets/7016425/dd42c2ba-7f25-443e-abec-70ba9b2ed5f0)

## After
![Screenshot 2024-03-18 at 20 27 31](https://github.com/ministryofjustice/laa-assess-crime-forms/assets/7016425/6418fc88-343c-4957-b004-d40a92bfbd1f)
