### PR TITLE
CRM457-980: Add caseworker comments to further info request mailer

### DIFF
--- a/app/mailers/prior_authority/feedback_messages/further_information_request_feedback.rb
+++ b/app/mailers/prior_authority/feedback_messages/further_information_request_feedback.rb
@@ -19,6 +19,20 @@ module PriorAuthority
           feedback_url: feedback_url
         }
       end
+
+      protected
+
+      def comments
+        [incorrect_information_explanation, further_information_explanation].compact_blank.join("\n\n")
+      end
+
+      def incorrect_information_explanation
+        @submission.data['incorrect_information_explanation']
+      end
+
+      def further_information_explanation
+        @submission.data['further_information_explanation']
+      end
     end
   end
 end

--- a/app/mailers/prior_authority/submission_feedback_mailer.rb
+++ b/app/mailers/prior_authority/submission_feedback_mailer.rb
@@ -4,6 +4,13 @@ module PriorAuthority
   class SubmissionFeedbackMailer < GovukNotifyRails::Mailer
     class InvalidState < StandardError; end
 
+    FEEDBACK_MESSAGE_KLASSES = {
+      PriorAuthorityApplication::GRANTED => FeedbackMessages::GrantedFeedback,
+      PriorAuthorityApplication::PART_GRANT => FeedbackMessages::PartGrantedFeedback,
+      PriorAuthorityApplication::REJECTED => FeedbackMessages::RejectedFeedback,
+      PriorAuthorityApplication::SENT_BACK => FeedbackMessages::FurtherInformationRequestFeedback,
+    }.freeze
+
     def notify(submission)
       feedback_template = feedback_message(submission)
       set_template(feedback_template.template)
@@ -14,18 +21,8 @@ module PriorAuthority
     private
 
     def feedback_message(submission)
-      case submission.state
-      when 'granted'
-        FeedbackMessages::GrantedFeedback.new(submission)
-      when 'part_grant'
-        FeedbackMessages::PartGrantedFeedback.new(submission)
-      when 'rejected'
-        FeedbackMessages::RejectedFeedback.new(submission)
-      when 'sent_back'
-        FeedbackMessages::FurtherInformationRequestFeedback.new(submission)
-      else
-        raise_message_for(submission)
-      end
+      klass = FEEDBACK_MESSAGE_KLASSES[submission.state]
+      klass ? klass.new(submission) : raise_message_for(submission)
     end
 
     def raise_message_for(submission)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -21,7 +21,7 @@ class Event < ApplicationRecord
   # simplifies the rehydrate process
   attribute :public
 
-  # Make these methods private to ensure tehy are created via the various `build` methods`
+  # Make these methods private to ensure they are created via the various `build` methods`
   class << self
     protected :new
     private :create


### PR DESCRIPTION
## Description of change
Add caseworker comments to further info request mailer

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-980)

## Screenshots of changes (if applicable)
![Screenshot 2024-03-19 at 11 53 31](https://github.com/ministryofjustice/laa-assess-crime-forms/assets/7016425/368a840e-d0cb-40f5-99b5-fff88a061f2c)


## How to manually test the feature

Either on dev environment or locally using the assess dev api keys 

- create/update a caseworker application with your own email address as the providers email
- add your email to the govuk notify team members list
- assign the app to yourself as a case worker
- click the send back to provider on the app overview page
- add the comments
- Save and continue


