### PR TITLE
CRM457-1186: Add resubmission deadline

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -70,6 +70,7 @@ module LaaAssessNonStandardMagistrateFee
     config.x.analytics.cookies_consent_expiration = 1.year
     config.x.analytics.analytics_consent_name = 'analytics_preferences_set'
     config.x.analytics.analytics_consent_expiration = 1.year
+    config.x.rfi.resubmission_window = 14.days
 
     config.x.contact.feedback_url = 'tbc'
     #time to wait for requests to be made to app store for db consistency


### PR DESCRIPTION
## Description of change
We already are sending almost everything we need to the app store when we send back an RFI. This PR just:
- Adds the resubmission deadline for display in provider UI as per the ticket
- Tidies up the code
- Adds tests to prove the right info is stored.

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1186)

