### PR TITLE
Automate deployment to prod for main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -382,20 +382,8 @@ workflows:
           context: laa-assess-crime-forms-dev
           requires:
             - build-to-ecr
-      - hold-uat:
-          type: approval
-          requires:
-            - build-to-ecr
-          filters:
-            branches:
-              only:
-                - main
       - deploy-uat:
           context: laa-assess-crime-forms-uat
-          requires:
-            - hold-uat
-      - hold-prod:
-          type: approval
           requires:
             - build-to-ecr
           filters:
@@ -405,4 +393,8 @@ workflows:
       - deploy-prod:
           context: laa-assess-crime-forms-production
           requires:
-            - hold-prod
+            - deploy-uat
+          filters:
+            branches:
+              only:
+                - main


### PR DESCRIPTION
## Description of change
Automate deployment to prod for main

Until we go to private beta, and perhaps even after that,
we might as well deploy to UAT and then production automatically.

This will:
- expose any deployment issues immediatley on a per merge basis
- not incur overhead of devs remebering to deploy