### PR TITLE
CRM457-1187: Tidy states and UI for showing sent back applications

### DIFF
--- a/app/controllers/prior_authority/applications_controller.rb
+++ b/app/controllers/prior_authority/applications_controller.rb
@@ -3,21 +3,21 @@ module PriorAuthority
     before_action :set_default_table_sort_options, only: %i[your open assessed]
 
     def your
-      @pagy, applications = order_and_paginate(PriorAuthorityApplication.pending_and_assigned_to(current_user))
+      @pagy, applications = order_and_paginate(PriorAuthorityApplication.open_and_assigned_to(current_user))
       @applications = applications.map do |application|
         BaseViewModel.build(:table_row, application)
       end
     end
 
     def open
-      @pagy, applications = order_and_paginate(PriorAuthorityApplication.pending_decision)
+      @pagy, applications = order_and_paginate(PriorAuthorityApplication.open)
       @applications = applications.map do |application|
         BaseViewModel.build(:table_row, application)
       end
     end
 
     def assessed
-      @pagy, applications = order_and_paginate(PriorAuthorityApplication.decision_made)
+      @pagy, applications = order_and_paginate(PriorAuthorityApplication.assessed)
       @applications = applications.map do |application|
         BaseViewModel.build(:table_row, application)
       end

--- a/app/forms/prior_authority/decision_form.rb
+++ b/app/forms/prior_authority/decision_form.rb
@@ -76,7 +76,7 @@ module PriorAuthority
     end
 
     def not_yet_assessed
-      return unless submission.state.in?(PriorAuthorityApplication::ASSESSED_STATES)
+      return if submission.state.in?(PriorAuthorityApplication::ASSESSABLE_STATES)
 
       errors.add(:base, :already_assessed)
     end

--- a/app/forms/prior_authority/send_back_form.rb
+++ b/app/forms/prior_authority/send_back_form.rb
@@ -85,7 +85,7 @@ module PriorAuthority
     end
 
     def not_yet_assessed
-      return unless submission.state.in?(PriorAuthorityApplication::ASSESSED_STATES)
+      return if submission.state.in?(PriorAuthorityApplication::ASSESSABLE_STATES)
 
       errors.add(:base, :already_assessed)
     end

--- a/app/models/prior_authority_application.rb
+++ b/app/models/prior_authority_application.rb
@@ -1,19 +1,32 @@
 class PriorAuthorityApplication < Submission
   default_scope -> { where(application_type: APPLICATION_TYPES[:prior_authority]) }
 
-  STATES = [
-    (PENDING_STATES = [
+  STATES = (
+    (ASSESSABLE_STATES = [
       SUBMITTED = 'submitted'.freeze,
       PROVIDER_UPDATED = 'provider_updated'.freeze
     ].freeze) +
       (ASSESSED_STATES = [
         GRANTED = 'granted'.freeze,
         PART_GRANT = 'part_grant'.freeze,
-        REJECTED = 'rejected'.freeze,
-        SENT_BACK = 'sent_back'.freeze
-      ].freeze)
-  ].freeze
+        REJECTED = 'rejected'.freeze
+      ].freeze) +
+      [SENT_BACK = 'sent_back'.freeze]
+  ).freeze
 
-  scope :pending_decision, -> { where(state: PENDING_STATES) }
-  scope :decision_made, -> { where(state: ASSESSED_STATES) }
+  enum :state, STATES.to_h { [_1, _1] }
+
+  scope :open, -> { where(state: ASSESSABLE_STATES + [SENT_BACK]) }
+  scope :assessed, -> { where(state: ASSESSED_STATES) }
+  scope :open_and_assigned_to, lambda { |user|
+    open.joins(:assignments).where(assignments: { user_id: user.id })
+  }
+  scope :assignable, lambda { |user|
+    where(state: ASSESSABLE_STATES)
+      .where.missing(:assignments)
+      .where.not(id: Event::Unassignment.where(primary_user_id: user.id).select(:submission_id))
+  }
+  scope :related_applications, lambda { |ufn, account_number|
+    PriorAuthority::RelatedApplications.call(ufn, account_number)
+  }
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -10,21 +10,6 @@ class Submission < ApplicationRecord
   validates :current_version, numericality: { only_integer: true, greater_than: 0 }
   validates :application_type, inclusion: { in: APPLICATION_TYPES.values }
 
-  scope :related_applications, lambda { |ufn, account_number|
-    PriorAuthority::RelatedApplications.call(ufn, account_number)
-  }
-
-  scope :pending_and_assigned_to, lambda { |user|
-    pending_decision
-      .joins(:assignments)
-      .where(assignments: { user_id: user.id })
-  }
-  scope :unassigned, lambda { |user|
-    pending_decision
-      .where.missing(:assignments)
-      .where.not(id: Event::Unassignment.where(primary_user_id: user.id).select(:submission_id))
-  }
-
   def namespace
     Submission::APPLICATION_TYPES.invert[application_type].to_s.camelcase.constantize
   end

--- a/app/services/prior_authority/choose_application_for_assignment.rb
+++ b/app/services/prior_authority/choose_application_for_assignment.rb
@@ -7,7 +7,7 @@ module PriorAuthority
           CASE WHEN data->>'service_type' = 'pathologist_report' THEN 0 ELSE 1 END as pathologist_report
         SQL
 
-        PriorAuthorityApplication.unassigned(user)
+        PriorAuthorityApplication.assignable(user)
                                  .select('submissions.*', criminal_court, pathologist_report)
                                  .order(criminal_court: :asc, pathologist_report: :asc, created_at: :asc)
                                  .first

--- a/app/view_models/prior_authority/v1/application_details.rb
+++ b/app/view_models/prior_authority/v1/application_details.rb
@@ -19,6 +19,9 @@ module PriorAuthority
       attribute :psychiatric_liaison_reason_not, :string
       attribute :youth_court, :boolean
       attribute :no_alternative_quote_reason, :string
+      attribute :further_information_explanation, :string
+      attribute :incorrect_information_explanation, :string
+      attribute :updates_needed, array: true
 
       def overview_card
         OverviewCard.new(self)
@@ -63,6 +66,14 @@ module PriorAuthority
 
       def assessment_comment
         @assessment_comment ||= submission.latest_decision_event&.details&.dig('comment')
+      end
+
+      def further_information_requested?
+        updates_needed.include?(SendBackForm::FURTHER_INFORMATION)
+      end
+
+      def corrections_requested?
+        updates_needed.include?(SendBackForm::INCORRECT_INFORMATION)
       end
     end
   end

--- a/app/view_models/prior_authority/v1/application_summary.rb
+++ b/app/view_models/prior_authority/v1/application_summary.rb
@@ -84,7 +84,7 @@ module PriorAuthority
       end
 
       def current_section(current_user)
-        if !pending?
+        if assessed?
           :assessed
         elsif submission.assignments.find_by(user: current_user)
           :your
@@ -94,20 +94,26 @@ module PriorAuthority
       end
 
       def can_edit?(caseworker)
-        pending? && submission.assignments.find_by(user: caseworker)
+        assessable? && submission.assignments.find_by(user: caseworker)
       end
 
       def unassignable?
-        pending? && submission.assignments.any?
+        assessable? && submission.assignments.any?
       end
 
       def assignable?
-        pending? && submission.assignments.none?
+        assessable? && submission.assignments.none?
       end
 
-      def pending?
-        submission.state.in?(PriorAuthorityApplication::PENDING_STATES)
+      def assessable?
+        submission.state.in?(PriorAuthorityApplication::ASSESSABLE_STATES)
       end
+
+      def assessed?
+        submission.state.in?(PriorAuthorityApplication::ASSESSED_STATES)
+      end
+
+      delegate :sent_back?, to: :submission
 
       def caseworker
         submission.assignments.first.display_name

--- a/app/views/prior_authority/applications/show.html.erb
+++ b/app/views/prior_authority/applications/show.html.erb
@@ -17,6 +17,24 @@
           <p> <%= link_to t('.review_adjustments'), prior_authority_application_adjustments_path(@summary.id) %></p>
         <% end %>
       </div>
+    <% elsif @summary.sent_back? %>
+      <div class="govuk-inset-text">
+        <p><strong><%= t(".sent_back", date: @summary.date_updated_str) %></strong></p>
+        <% if @details.further_information_requested? %>
+          <p>
+            <%= t('.further_information') %>
+            <br>
+            <%= @details.further_information_explanation %>
+          </p>
+        <% end %>
+        <% if @details.corrections_requested? %>
+          <p>
+            <%= t('.incorrect_information') %>
+            <br>
+            <%= @details.incorrect_information_explanation %>
+          </p>
+        <% end %>
+      </div>
     <% end %>
     <%= render 'overview_card', model: @details.overview_card %>
 

--- a/app/views/prior_authority/shared/_application_nav.html.erb
+++ b/app/views/prior_authority/shared/_application_nav.html.erb
@@ -8,7 +8,7 @@
 <p class="govuk-body-l">
   <strong><%= t('.requested') %></strong>
   <%= application_summary.formatted_original_total_cost %><br>
-  <% if application_summary.adjustments_made? || !application_summary.pending? %>
+  <% if application_summary.adjustments_made? || application_summary.assessed? %>
     <strong><%= t('.allowed') %></strong>
     <% if application_summary.submission.state == 'rejected' %>
       <%= NumberTo.pounds(0) %><br>
@@ -32,9 +32,12 @@
   <% if application_summary.unassignable? %>
     <br>
     <strong><%= t('.caseworker') %></strong> <%= application_summary.caseworker %>
-  <% elsif !application_summary.pending? %>
+  <% elsif application_summary.assessed? %>
     <br>
     <strong><%= t('.date_assessed') %></strong> <%= application_summary.date_updated_str %>
+  <% elsif application_summary.sent_back? %>
+    <br>
+    <strong><%= t('.date_sent_back') %></strong> <%= application_summary.date_updated_str %>
   <% end %>
 </p>
 

--- a/config/locales/en/prior_authority.yml
+++ b/config/locales/en/prior_authority.yml
@@ -12,6 +12,7 @@ en:
         rep_order_date: 'Representation order date:'
         date_received: 'Date received:'
         date_assessed: 'Date assessed:'
+        date_sent_back: 'Date sent back to provider:'
         caseworker: 'Caseworker:'
         remove_from_list: Remove from list
         add_to_my_list: Add to my list

--- a/config/locales/en/prior_authority/applications.yml
+++ b/config/locales/en/prior_authority/applications.yml
@@ -39,6 +39,9 @@ en:
           rejected: Rejected
           part_grant: Part granted
           granted: Granted
+        sent_back: Sent back to provider %{date}
+        further_information: 'Further information:'
+        incorrect_information: 'Incorrect information:'
         review_adjustments: Review quote adjustments
         about_the_request: About the request
         about_the_case: About the case

--- a/spec/mailers/prior_authority/submission_feedback_mailer_spec.rb
+++ b/spec/mailers/prior_authority/submission_feedback_mailer_spec.rb
@@ -159,11 +159,11 @@ RSpec.describe PriorAuthority::SubmissionFeedbackMailer, type: :mailer do
     include_examples 'creates a prior authority feedback mailer'
   end
 
-  context 'with other state for further information request' do
+  context 'with an unhandled state' do
     let(:application) do
       create(
         :prior_authority_application,
-        state: 'fake',
+        state: 'submitted',
         data: build(
           :prior_authority_data,
           laa_reference: 'LAA-FHaMVK',

--- a/spec/system/prior_authority/view_applications_spec.rb
+++ b/spec/system/prior_authority/view_applications_spec.rb
@@ -264,4 +264,21 @@ RSpec.describe 'View applications' do
       expect(page).to have_content 'Date assessed: 05 June 2023'
     end
   end
+
+  context 'when application has been sent back' do
+    before do
+      application.data['updates_needed'] = ['further_information']
+      application.data['further_information_explanation'] = 'Set the scene a little more'
+      application.update(state: 'sent_back', updated_at: DateTime.new(2023, 6, 5, 4, 3, 2))
+      click_on 'LAA-1234'
+    end
+
+    it 'shows the relevant comment' do
+      expect(page).to have_content 'Set the scene a little more'
+    end
+
+    it 'shows the rejection date' do
+      expect(page).to have_content 'Date sent back to provider: 05 June 2023'
+    end
+  end
 end

--- a/spec/system/prior_authority/view_related_applications_spec.rb
+++ b/spec/system/prior_authority/view_related_applications_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe 'View related applications' do
   let(:in_progress) do
     create(
       :prior_authority_application,
-      state: 'in_progress',
+      state: 'submitted',
       created_at: 3.days.ago,
       data: build(
         :prior_authority_data,


### PR DESCRIPTION
## Description of change
Adjust UI for showing applications to accommodate 'sent_back' state
Moved sent_back applications to the 'Open' table, not the 'Assessed' table

Tried to standardise naming around states. As these have now diverged quite a lot from NSM states, moved state-specific scopes into submission subclasses

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1187)

## Screenshots of changes (if applicable)
<img width="1054" alt="Screenshot 2024-03-20 at 11 18 36" src="https://github.com/ministryofjustice/laa-assess-crime-forms/assets/113888736/e07a5949-ad3d-4412-8e87-65bae6753614">

