### PR TITLE
CRM457-1235: Delete adjustments

### DIFF
--- a/app/controllers/prior_authority/additional_costs_controller.rb
+++ b/app/controllers/prior_authority/additional_costs_controller.rb
@@ -31,6 +31,21 @@ module PriorAuthority
       end
     end
 
+    def confirm_deletion
+      submission = PriorAuthorityApplication.find(params[:application_id])
+      index = submission.data['additional_costs'].index { _1['id'] == params[:id] }
+      render 'prior_authority/shared/confirm_delete_adjustment',
+             locals: {
+               item_name: t('.additional_cost', n: index + 1),
+               deletion_path: prior_authority_application_additional_cost_path(params[:application_id], params[:id])
+             }
+    end
+
+    def destroy
+      AdjustmentDeleter.new(params, :additional_cost, current_user).call
+      redirect_to prior_authority_application_adjustments_path(params[:application_id])
+    end
+
     private
 
     def form_params

--- a/app/controllers/prior_authority/service_costs_controller.rb
+++ b/app/controllers/prior_authority/service_costs_controller.rb
@@ -30,6 +30,19 @@ module PriorAuthority
       end
     end
 
+    def confirm_deletion
+      submission = PriorAuthorityApplication.find(params[:application_id])
+      service_type = t(submission.data['service_type'], scope: 'prior_authority.service_types')
+      render 'prior_authority/shared/confirm_delete_adjustment',
+             locals: { item_name: t('.service_type_cost', service_type:),
+                       deletion_path: prior_authority_application_service_cost_path(submission, params[:id]) }
+    end
+
+    def destroy
+      AdjustmentDeleter.new(params, :service_cost, current_user).call
+      redirect_to prior_authority_application_adjustments_path(params[:application_id])
+    end
+
     private
 
     def form_params

--- a/app/controllers/prior_authority/travel_costs_controller.rb
+++ b/app/controllers/prior_authority/travel_costs_controller.rb
@@ -30,6 +30,18 @@ module PriorAuthority
       end
     end
 
+    def confirm_deletion
+      render 'prior_authority/shared/confirm_delete_adjustment',
+             locals: { item_name: t('.travel_cost'),
+                       deletion_path: prior_authority_application_travel_cost_path(params[:application_id],
+                                                                                   params[:id]) }
+    end
+
+    def destroy
+      AdjustmentDeleter.new(params, :travel_cost, current_user).call
+      redirect_to prior_authority_application_adjustments_path(params[:application_id])
+    end
+
     private
 
     def form_params

--- a/app/models/event/undo_edit.rb
+++ b/app/models/event/undo_edit.rb
@@ -1,0 +1,4 @@
+class Event
+  class UndoEdit < Edit
+  end
+end

--- a/app/services/prior_authority/adjustment_deleter.rb
+++ b/app/services/prior_authority/adjustment_deleter.rb
@@ -66,7 +66,7 @@ module PriorAuthority
     def create_event(field, type, from, to_field, id_field)
       linked = { type: type, id: id_field }
       details = { field: field, from: from, to: to_field }
-      Event::UndoEdit.build(submission:, linked:, details:, current_user:)
+      ::Event::UndoEdit.build(submission:, linked:, details:, current_user:)
     end
   end
 end

--- a/app/services/prior_authority/adjustment_deleter.rb
+++ b/app/services/prior_authority/adjustment_deleter.rb
@@ -1,0 +1,72 @@
+module PriorAuthority
+  class AdjustmentDeleter
+    attr_reader :params, :adjustment_type, :current_user, :submission
+
+    def initialize(params, adjustment_type, current_user)
+      @params = params
+      @adjustment_type = adjustment_type
+      @current_user = current_user
+      @submission = PriorAuthorityApplication.find(params[:application_id])
+    end
+
+    def call
+      case adjustment_type
+      when :service_cost
+        delete_service_cost_adjustment
+      when :travel_cost
+        delete_travel_cost_adjustment
+      when :additional_cost
+        delete_additional_cost_adjustment
+      else
+        raise "Unknown adjustment type '#{adjustment_type}'"
+      end
+      submission.save!
+    end
+
+    def delete_service_cost_adjustment
+      %w[items cost_per_item period cost_per_hour].each do |field|
+        revert(quote, field, 'quotes')
+      end
+      quote.delete('adjustment_comment')
+    end
+
+    def delete_travel_cost_adjustment
+      %w[travel_time travel_cost_per_hour].each do |field|
+        revert(quote, field, 'quotes')
+      end
+      quote.delete('travel_adjustment_comment')
+    end
+
+    def delete_additional_cost_adjustment
+      %w[items cost_per_item period cost_per_hour].each do |field|
+        revert(additional_cost, field, 'additional_costs')
+      end
+      additional_cost.delete('adjustment_comment')
+    end
+
+    def quote
+      @quote ||= submission.data['quotes'].find { _1['id'] == params[:id] }
+    end
+
+    def additional_cost
+      @additional_cost ||= submission.data['additional_costs'].find { _1['id'] == params[:id] }
+    end
+
+    def revert(object, field, object_type)
+      return unless object["#{field}_original"]
+
+      if object[field] != object["#{field}_original"]
+        create_event(field, object_type, object[field], object["#{field}_original"], object['id'])
+      end
+
+      object[field] = object["#{field}_original"]
+      object.delete("#{field}_original")
+    end
+
+    def create_event(field, type, from, to_field, id_field)
+      linked = { type: type, id: id_field }
+      details = { field: field, from: from, to: to_field }
+      Event::UndoEdit.build(submission:, linked:, details:, current_user:)
+    end
+  end
+end

--- a/app/view_models/prior_authority/additional_costs_with_adjustments.rb
+++ b/app/view_models/prior_authority/additional_costs_with_adjustments.rb
@@ -63,6 +63,10 @@ module PriorAuthority
       NumberTo.pounds(adjusted_cost_total) if any_adjustments?
     end
 
+    def any_adjustments?
+      any_per_item_adjustments? || any_per_hour_adjustments?
+    end
+
     private
 
     def adjusted_formatted_cost_per_unit
@@ -86,10 +90,6 @@ module PriorAuthority
         (period.hours * cost_per_hour) +
         ((period.minutes / 60.0) * cost_per_hour)
       ).round(2)
-    end
-
-    def any_adjustments?
-      any_per_item_adjustments? || any_per_hour_adjustments?
     end
 
     def any_per_item_adjustments?

--- a/app/view_models/prior_authority/service_costs_with_adjustments.rb
+++ b/app/view_models/prior_authority/service_costs_with_adjustments.rb
@@ -69,6 +69,10 @@ module PriorAuthority
       NumberTo.pounds(adjusted_service_cost_total) if any_adjustments?
     end
 
+    def any_adjustments?
+      any_per_item_adjustments? || any_per_hour_adjustments?
+    end
+
     private
 
     def adjusted_formatted_cost_per_unit
@@ -92,10 +96,6 @@ module PriorAuthority
         (period.hours * cost_per_hour) +
         ((period.minutes / 60.0) * cost_per_hour)
       ).round(2)
-    end
-
-    def any_adjustments?
-      any_per_item_adjustments? || any_per_hour_adjustments?
     end
 
     def any_per_item_adjustments?

--- a/app/view_models/prior_authority/travel_costs_with_adjustments.rb
+++ b/app/view_models/prior_authority/travel_costs_with_adjustments.rb
@@ -43,6 +43,10 @@ module PriorAuthority
       NumberTo.pounds(adjusted_travel_costs) if any_travel_adjustments?
     end
 
+    def any_travel_adjustments?
+      travel_time_original || travel_cost_per_hour_original
+    end
+
     private
 
     def adjusted_travel_costs
@@ -50,10 +54,6 @@ module PriorAuthority
         (travel_time.hours * travel_cost_per_hour) +
         ((travel_time.minutes / 60.0) * travel_cost_per_hour)
       ).round(2)
-    end
-
-    def any_travel_adjustments?
-      travel_time_original || travel_cost_per_hour_original
     end
   end
 

--- a/app/view_models/prior_authority/v1/quote.rb
+++ b/app/view_models/prior_authority/v1/quote.rb
@@ -21,7 +21,7 @@ module PriorAuthority
 
       attribute :additional_cost_json
       attribute :additional_cost_list, :string
-      adjustable_attribute :additional_cost_total, :decimal, precision: 10, scale: 2
+      attribute :additional_cost_total, :decimal, precision: 10, scale: 2
 
       attribute :contact_full_name, :string
       attribute :organisation, :string
@@ -111,7 +111,7 @@ module PriorAuthority
         if additional_costs.present?
           additional_costs.sum { _1.total_cost(original:) }
         else
-          (original ? original_additional_cost_total : additional_cost_total).to_f
+          additional_cost_total.to_f
         end
       end
 

--- a/app/views/prior_authority/adjustments/_additional_costs.html.erb
+++ b/app/views/prior_authority/adjustments/_additional_costs.html.erb
@@ -40,10 +40,17 @@
         end
       end %>
   <% if editable %>
-    <%= link_to t(".adjust_additional_cost"),
-                edit_prior_authority_application_additional_cost_path(application, additional_cost.id),
-                class: 'govuk-button govuk-button--secondary',
-                id: "additional_cost_#{index + 1}",
-                data: { turbo: false } %>
+    <div class="govuk-button-group govuk-button-group-vertically-centred">
+      <%= link_to t(".adjust_additional_cost"),
+                  edit_prior_authority_application_additional_cost_path(application, additional_cost.id),
+                  data: { turbo: false },
+                  id: "additional_cost_#{index + 1}",
+                  class: 'govuk-button govuk-button--secondary' %>
+      <% if additional_cost.any_adjustments? %>
+        <%= link_to t(".delete"),
+                    confirm_deletion_prior_authority_application_additional_cost_path(application, additional_cost.id),
+                    class: "govuk-link govuk-link--no-visited-state" %>
+      <% end %>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/prior_authority/adjustments/_service_costs.html.erb
+++ b/app/views/prior_authority/adjustments/_service_costs.html.erb
@@ -38,8 +38,15 @@
       end
     end %>
 <% if editable %>
-  <%= link_to t(".adjust_service_cost"),
-              edit_prior_authority_application_service_cost_path(application, service_cost.id),
-              data: { turbo: false },
-              class: 'govuk-button govuk-button--secondary' %>
+  <div class="govuk-button-group govuk-button-group-vertically-centred">
+    <%= link_to t(".adjust_service_cost"),
+                edit_prior_authority_application_service_cost_path(application, service_cost.id),
+                data: { turbo: false },
+                class: 'govuk-button govuk-button--secondary' %>
+    <% if service_cost.any_adjustments? %>
+      <%= link_to t(".delete"),
+                  confirm_deletion_prior_authority_application_service_cost_path(application, service_cost.id),
+                  class: "govuk-link govuk-link--no-visited-state" %>
+    <% end %>
+  </div>
 <% end %>

--- a/app/views/prior_authority/adjustments/_travel_costs.erb
+++ b/app/views/prior_authority/adjustments/_travel_costs.erb
@@ -42,8 +42,15 @@
       end
     end %>
 <% if editable %>
-  <%= link_to t(".adjust_travel_cost"),
-              edit_prior_authority_application_travel_cost_path(application, quote.id),
-              data: { turbo: false },
-              class: 'govuk-button govuk-button--secondary' %>
+  <div class="govuk-button-group govuk-button-group-vertically-centred">
+    <%= link_to t(".adjust_travel_cost"),
+                edit_prior_authority_application_travel_cost_path(application, quote.id),
+                data: { turbo: false },
+                class: 'govuk-button govuk-button--secondary' %>
+    <% if quote.any_travel_adjustments? %>
+      <%= link_to t(".delete"),
+                  confirm_deletion_prior_authority_application_travel_cost_path(application, quote.id),
+                  class: "govuk-link govuk-link--no-visited-state" %>
+    <% end %>
+  </div>
 <% end %>

--- a/app/views/prior_authority/shared/confirm_delete_adjustment.html.erb
+++ b/app/views/prior_authority/shared/confirm_delete_adjustment.html.erb
@@ -1,0 +1,17 @@
+<%= title t('.page_title') %>
+<% content_for(:primary_navigation) do %>
+  <% render 'layouts/prior_authority/primary_navigation', current: :your %>
+<% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-xl"><%= t('.page_title') %></h1>
+    <p><%= t('.warning_html', item_name: tag.strong(item_name)) %></p>
+    <div class="govuk-button-group govuk-button-group-vertically-centred">
+      <%= govuk_button_to t('.yes_delete'), deletion_path, method: :delete, warning: true %>
+      <%= govuk_button_link_to t('.no_delete'),
+                                prior_authority_application_adjustments_path(params[:application_id]),
+                                secondary: true %>
+
+    </div>
+  </div>
+</div>

--- a/config/locales/en/prior_authority/additional_costs.yml
+++ b/config/locales/en/prior_authority/additional_costs.yml
@@ -15,3 +15,5 @@ en:
         cost_per_item: What is the cost per item?
         items: Number of items
         period: Time
+      confirm_deletion:
+        additional_cost: "Additional cost %{n}"

--- a/config/locales/en/prior_authority/adjustments.yml
+++ b/config/locales/en/prior_authority/adjustments.yml
@@ -16,6 +16,7 @@ en:
         requested: Requested
         time: Time
         total: Total
+        delete: Delete additional cost adjustment
       service_costs:
         adjusted: Caseworker adjusted
         adjust_service_cost: Adjust service costs
@@ -24,6 +25,7 @@ en:
         requested: Requested
         amount: Amount
         total: Total
+        delete: Delete service cost adjustment
       travel_costs:
         adjusted: Caseworker adjusted
         adjust_travel_cost: Adjust travel costs
@@ -34,3 +36,4 @@ en:
         time: Time
         total: Total
         travel_cost: Travel cost
+        delete: Delete travel cost adjustment

--- a/config/locales/en/prior_authority/confirm_deletion.yml
+++ b/config/locales/en/prior_authority/confirm_deletion.yml
@@ -1,0 +1,8 @@
+en:
+  prior_authority:
+    shared:
+      confirm_delete_adjustment:
+        page_title: Are you sure you want to delete this adjustment?
+        warning_html: This will delete adjustments made for %{item_name} and cannot be undone.
+        yes_delete: Yes, delete it
+        no_delete: No, do not delete it

--- a/config/locales/en/prior_authority/service_costs.yml
+++ b/config/locales/en/prior_authority/service_costs.yml
@@ -20,3 +20,5 @@ en:
           label: Explain your decision
         hourly_cost: Hourly cost
         page_title: Adjust service costs
+      confirm_deletion:
+        service_type_cost: "%{service_type} costs"

--- a/config/locales/en/prior_authority/service_types.yml
+++ b/config/locales/en/prior_authority/service_types.yml
@@ -1,7 +1,6 @@
 en:
   prior_authority:
     service_types:
-      service_types:
       ae_consultant: A&E consultant
       accident_reconstruction: Accident reconstruction
       accountant: Accountant

--- a/config/locales/en/prior_authority/travel_costs.yml
+++ b/config/locales/en/prior_authority/travel_costs.yml
@@ -11,3 +11,5 @@ en:
         hourly_cost: Hourly cost
         page_title: Adjust travel costs
         travel_time: Time
+      confirm_deletion:
+        travel_cost: "Travel costs"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -93,9 +93,15 @@ Rails.application.routes.draw do
 
       resources :adjustments, only: :index
       resources :related_applications, only: :index
-      resources :service_costs, only: [:edit, :update]
-      resources :travel_costs, only: [:edit, :update]
-      resources :additional_costs, only: [:edit, :update]
+      resources :service_costs, only: %i[edit update destroy] do
+        member { get :confirm_deletion }
+      end
+      resources :travel_costs, only: %i[edit update destroy] do
+        member { get :confirm_deletion }
+      end
+      resources :additional_costs, only: %i[edit update destroy] do
+        member { get :confirm_deletion }
+      end
       resources :manual_assignments, only: %i[new create]
       resources :unassignments, only: %i[new create]
       resource :decision, only: %i[new create show]

--- a/spec/services/prior_authority/adjustment_deleter_spec.rb
+++ b/spec/services/prior_authority/adjustment_deleter_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+RSpec.describe PriorAuthority::AdjustmentDeleter do
+  describe '.call' do
+    subject(:service) { described_class.new(params, adjustment_type, user) }
+
+    let(:params) { { application_id: application.id, id: item_id } }
+    let(:item_id) { '123' }
+    let(:user) { create(:caseworker) }
+    let(:application) { create(:prior_authority_application) }
+
+    context 'when adjustment type is unknown' do
+      let(:adjustment_type) { :some_new_adjustment }
+
+      it 'raises an appropriate error' do
+        expect { service.call }.to raise_error "Unknown adjustment type 'some_new_adjustment'"
+      end
+    end
+
+    context 'when deleting adjustments' do
+      let(:adjustment_type) { :service_cost }
+      let(:application) do
+        create(:prior_authority_application,
+               data: build(:prior_authority_data,
+                           quotes: [build(:primary_quote,
+                                          id: item_id,
+                                          items: 8,
+                                          items_original: 9,
+                                          adjustment_comment: 'Too many items')]))
+      end
+
+      before { service.call }
+
+      it 'reverts changes' do
+        service.call
+        expect(application.reload.data.dig('quotes', 0, 'items')).to eq 9
+        expect(application.data.dig('quotes', 0, 'items_original')).to be_nil
+        expect(application.data.dig('quotes', 0, 'adjustment_comment')).to be_nil
+      end
+
+      it 'creates relevant events' do
+        service.call
+        event = application.events.last
+        expect(event).to be_a Event::UndoEdit
+        expect(event).to have_attributes(
+          linked_id: item_id,
+          linked_type: 'quotes',
+          details: {
+            'field' => 'items',
+            'from' => 8,
+            'to' => 9,
+          }
+        )
+      end
+    end
+  end
+end

--- a/spec/system/prior_authority/delete_adjustments_spec.rb
+++ b/spec/system/prior_authority/delete_adjustments_spec.rb
@@ -1,0 +1,138 @@
+require 'rails_helper'
+
+RSpec.describe 'Delete adjustments' do
+  let(:caseworker) { create(:caseworker) }
+  let(:application) do
+    create(
+      :prior_authority_application,
+      state: 'submitted',
+      data: build(
+        :prior_authority_data,
+        laa_reference: 'LAA-1234',
+        quotes: [
+          build(:primary_quote),
+          build(:alternative_quote)
+        ],
+        additional_costs: [
+          build(
+            :additional_cost,
+            name: 'Mileage',
+            description: 'fuel is expensive',
+            unit_type: 'per_item',
+            items: 110,
+            cost_per_item: '3.5'
+          ),
+        ],
+      )
+    )
+  end
+
+  before do
+    sign_in caseworker
+    visit '/'
+    click_on 'Accept analytics cookies'
+
+    create(:assignment,
+           user: caseworker,
+           submission: application)
+
+    visit prior_authority_root_path
+    click_on 'LAA-1234'
+    click_on 'Adjust quote'
+  end
+
+  context 'when I have adjusted an additional cost' do
+    before do
+      click_on 'Adjust additional cost'
+      fill_in 'Number of items', with: 100
+      fill_in 'What is the cost per item?', with: '3.26'
+      fill_in 'Explain your decision', with: 'additional cost 1 explanation'
+      click_on 'Save changes'
+
+      expect(page).to have_current_path prior_authority_application_adjustments_path(application)
+      expect(page).to have_content '£3.26'
+      expect(page).to have_content 'additional cost 1 explanation'
+    end
+
+    it 'lets me undo my adjustment' do
+      click_on 'Delete additional cost adjustment'
+      expect(page).to have_content 'Are you sure you want to delete this adjustment?'
+      click_on 'Yes, delete it'
+      expect(page).to have_current_path prior_authority_application_adjustments_path(application)
+      expect(page).to have_no_content '£3.26'
+      expect(page).to have_no_content 'additional cost 1 explanation'
+    end
+
+    it 'lets me cancel my undo' do
+      click_on 'Delete additional cost adjustment'
+      expect(page).to have_content 'Are you sure you want to delete this adjustment?'
+      click_on 'No, do not delete it'
+      expect(page).to have_current_path prior_authority_application_adjustments_path(application)
+      expect(page).to have_content '£3.26'
+      expect(page).to have_content 'additional cost 1 explanation'
+    end
+  end
+
+  context 'when I have adjusted the travel cost' do
+    before do
+      click_on 'Adjust travel costs'
+      fill_in 'Hours', with: 1
+      fill_in 'Minutes', with: 37
+      fill_in 'Explain your decision', with: 'travel cost adjustment explanation'
+      click_on 'Save changes'
+
+      expect(page).to have_current_path prior_authority_application_adjustments_path(application)
+      expect(page).to have_content '1 hour 37 minutes'
+      expect(page).to have_content 'travel cost adjustment explanation'
+    end
+
+    it 'lets me undo my adjustment' do
+      click_on 'Delete travel cost adjustment'
+      expect(page).to have_content 'Are you sure you want to delete this adjustment?'
+      click_on 'Yes, delete it'
+      expect(page).to have_current_path prior_authority_application_adjustments_path(application)
+      expect(page).to have_no_content '1 hour 37 minutes'
+      expect(page).to have_no_content 'travel cost adjustment explanation'
+    end
+
+    it 'lets me cancel my undo' do
+      click_on 'Delete travel cost adjustment'
+      expect(page).to have_content 'Are you sure you want to delete this adjustment?'
+      click_on 'No, do not delete it'
+      expect(page).to have_current_path prior_authority_application_adjustments_path(application)
+      expect(page).to have_content '1 hour 37 minutes'
+      expect(page).to have_content 'travel cost adjustment explanation'
+    end
+  end
+
+  context 'when I have adjusted the service cost' do
+    before do
+      click_on 'Adjust service costs'
+      fill_in 'Number of pages', with: 427
+      fill_in 'Explain your decision', with: 'adjustment explanation'
+      click_on 'Save changes'
+
+      expect(page).to have_current_path prior_authority_application_adjustments_path(application)
+      expect(page).to have_content '427'
+      expect(page).to have_content 'adjustment explanation'
+    end
+
+    it 'lets me undo my adjustment' do
+      click_on 'Delete service cost adjustment'
+      expect(page).to have_content 'Are you sure you want to delete this adjustment?'
+      click_on 'Yes, delete it'
+      expect(page).to have_current_path prior_authority_application_adjustments_path(application)
+      expect(page).to have_no_content '427'
+      expect(page).to have_no_content 'adjustment explanation'
+    end
+
+    it 'lets me cancel my undo' do
+      click_on 'Delete service cost adjustment'
+      expect(page).to have_content 'Are you sure you want to delete this adjustment?'
+      click_on 'No, do not delete it'
+      expect(page).to have_current_path prior_authority_application_adjustments_path(application)
+      expect(page).to have_content '427'
+      expect(page).to have_content 'adjustment explanation'
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Mechanism to revert changes to service, travel and additional costs. Event history is preserved (a new undo event is created to reconcile event log changes with current values)

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1235)

## Screenshots of changes
<img width="1002" alt="Screenshot 2024-03-20 at 16 39 07" src="https://github.com/ministryofjustice/laa-assess-crime-forms/assets/113888736/6e29837e-de44-4e75-a414-53b95de409d7">

---

<img width="766" alt="Screenshot 2024-03-20 at 16 39 00" src="https://github.com/ministryofjustice/laa-assess-crime-forms/assets/113888736/4eddac2d-508a-45be-a59c-a9b762e12844">
