### PR TITLE
CRM457-976: Correct recipient for decision/RFI notifications

### DIFF
--- a/app/mailers/prior_authority/feedback_messages/feedback_base.rb
+++ b/app/mailers/prior_authority/feedback_messages/feedback_base.rb
@@ -16,7 +16,7 @@ module PriorAuthority
       end
 
       def recipient
-        @submission.data['provider']['email']
+        @submission.data['solicitor']['contact_email']
       end
 
       protected

--- a/spec/mailers/prior_authority/feedback_messages/further_information_request_feeback_spec.rb
+++ b/spec/mailers/prior_authority/feedback_messages/further_information_request_feeback_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe PriorAuthority::FeedbackMessages::FurtherInformationRequestFeedba
         :prior_authority_data,
         laa_reference: 'LAA-FHaMVK',
         ufn: '111111/111',
-        provider: { 'email' => 'provider@example.com' },
+        solicitor: { 'contact_email' => 'solicitor-contact@example.com' },
         defendant: { 'last_name' => 'Abrahams', 'first_name' => 'Abe' },
         incorrect_information_explanation: incorrect_information_explanation,
         further_information_explanation: further_information_explanation,
@@ -38,6 +38,12 @@ RSpec.describe PriorAuthority::FeedbackMessages::FurtherInformationRequestFeedba
   describe '#template' do
     it 'has correct template id' do
       expect(feedback.template).to eq(feedback_template)
+    end
+  end
+
+  describe '#recipient' do
+    it 'sets recipient to be the solicitors contact email' do
+      expect(feedback.recipient).to eq('solicitor-contact@example.com')
     end
   end
 
@@ -86,12 +92,6 @@ RSpec.describe PriorAuthority::FeedbackMessages::FurtherInformationRequestFeedba
           caseworker_information_requested: 'Please provide this further info...',
         )
       end
-    end
-  end
-
-  describe '#recipient' do
-    it 'has correct recipient' do
-      expect(feedback.recipient).to eq('provider@example.com')
     end
   end
 end

--- a/spec/mailers/prior_authority/feedback_messages/granted_feedback_spec.rb
+++ b/spec/mailers/prior_authority/feedback_messages/granted_feedback_spec.rb
@@ -12,18 +12,23 @@ RSpec.describe PriorAuthority::FeedbackMessages::GrantedFeedback do
         :prior_authority_data,
         laa_reference: 'LAA-FHaMVK',
         ufn: '111111/111',
-        provider: { 'email' => 'provider@example.com' },
+        solicitor: { 'contact_email' => 'solicitor-contact@example.com' },
         defendant: { 'last_name' => 'Abrahams', 'first_name' => 'Abe' },
       )
     )
   end
 
   let(:feedback_template) { 'd4f3da60-4da5-423e-bc93-d9235ff01a7b' }
-  let(:recipient) { 'provider@example.com' }
 
   describe '#template' do
     it 'has correct template id' do
       expect(feedback.template).to eq(feedback_template)
+    end
+  end
+
+  describe '#recipient' do
+    it 'sets recipient to be the solicitors contact email' do
+      expect(feedback.recipient).to eq('solicitor-contact@example.com')
     end
   end
 
@@ -37,12 +42,6 @@ RSpec.describe PriorAuthority::FeedbackMessages::GrantedFeedback do
         date: DateTime.now.to_fs(:stamp),
         feedback_url: 'tbc',
       )
-    end
-  end
-
-  describe '#recipient' do
-    it 'has correct recipient' do
-      expect(feedback.recipient).to eq(recipient)
     end
   end
 end

--- a/spec/mailers/prior_authority/feedback_messages/part_granted_feedback_spec.rb
+++ b/spec/mailers/prior_authority/feedback_messages/part_granted_feedback_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe PriorAuthority::FeedbackMessages::PartGrantedFeedback do
         :prior_authority_data,
         laa_reference: 'LAA-FHaMVK',
         ufn: '111111/111',
-        provider: { 'email' => 'provider@example.com' },
+        solicitor: { 'contact_email' => 'solicitor-contact@example.com' },
         defendant: { 'last_name' => 'Abrahams', 'first_name' => 'Abe' },
         quotes: [
           build(:primary_quote, :with_adjustments),
@@ -39,6 +39,12 @@ RSpec.describe PriorAuthority::FeedbackMessages::PartGrantedFeedback do
     end
   end
 
+  describe '#recipient' do
+    it 'sets recipient to be the solicitors contact email' do
+      expect(feedback.recipient).to eq('solicitor-contact@example.com')
+    end
+  end
+
   describe '#contents' do
     it 'has expected content' do
       expect(feedback.contents).to include(
@@ -51,12 +57,6 @@ RSpec.describe PriorAuthority::FeedbackMessages::PartGrantedFeedback do
         date: DateTime.now.to_fs(:stamp),
         feedback_url: 'tbc',
       )
-    end
-  end
-
-  describe '#recipient' do
-    it 'has correct recipient' do
-      expect(feedback.recipient).to eq(recipient)
     end
   end
 end

--- a/spec/mailers/prior_authority/feedback_messages/rejected_feedback_spec.rb
+++ b/spec/mailers/prior_authority/feedback_messages/rejected_feedback_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe PriorAuthority::FeedbackMessages::RejectedFeedback do
         :prior_authority_data,
         laa_reference: 'LAA-FHaMVK',
         ufn: '111111/111',
-        provider: { 'email' => 'provider@example.com' },
+        solicitor: { 'contact_email' => 'solicitor-contact@example.com' },
         defendant: { 'last_name' => 'Abrahams', 'first_name' => 'Abe' },
       )
     ).tap do |app|
@@ -36,6 +36,12 @@ RSpec.describe PriorAuthority::FeedbackMessages::RejectedFeedback do
     end
   end
 
+  describe '#recipient' do
+    it 'sets recipient to be the solicitors contact email' do
+      expect(feedback.recipient).to eq('solicitor-contact@example.com')
+    end
+  end
+
   describe '#contents' do
     it 'throws a not implemented exception' do
       expect(subject.contents).to include(
@@ -47,12 +53,6 @@ RSpec.describe PriorAuthority::FeedbackMessages::RejectedFeedback do
         date: DateTime.now.to_fs(:stamp),
         feedback_url: 'tbc',
       )
-    end
-  end
-
-  describe '#recipient' do
-    it 'has correct recipient' do
-      expect(feedback.recipient).to eq(recipient)
     end
   end
 end

--- a/spec/mailers/prior_authority/submission_feedback_mailer_spec.rb
+++ b/spec/mailers/prior_authority/submission_feedback_mailer_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 # rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.describe PriorAuthority::SubmissionFeedbackMailer, type: :mailer do
-  let(:recipient) { 'provider@example.com' }
+  let(:recipient) { 'solicitor-contact@example.com' }
   let(:laa_case_reference) { 'LAA-FHaMVK' }
   let(:ufn) { '111111/111' }
   let(:defendant_name) { 'Abe Abrahams' }
@@ -20,7 +20,7 @@ RSpec.describe PriorAuthority::SubmissionFeedbackMailer, type: :mailer do
         :prior_authority_data,
         laa_reference: 'LAA-FHaMVK',
         ufn: '111111/111',
-        provider: { 'email' => 'provider@example.com' },
+        solicitor: { 'contact_email' => 'solicitor-contact@example.com' },
         defendant: { 'last_name' => 'Abrahams', 'first_name' => 'Abe' },
       )
     ).tap do |app|
@@ -63,7 +63,7 @@ RSpec.describe PriorAuthority::SubmissionFeedbackMailer, type: :mailer do
           :prior_authority_data,
           laa_reference: 'LAA-FHaMVK',
           ufn: '111111/111',
-          provider: { 'email' => 'provider@example.com' },
+          solicitor: { 'contact_email' => 'solicitor-contact@example.com' },
           defendant: { 'last_name' => 'Abrahams', 'first_name' => 'Abe' },
           quotes: [
             build(:primary_quote, :with_adjustments),
@@ -133,7 +133,7 @@ RSpec.describe PriorAuthority::SubmissionFeedbackMailer, type: :mailer do
           :prior_authority_data,
           laa_reference: 'LAA-FHaMVK',
           ufn: '111111/111',
-          provider: { 'email' => 'provider@example.com' },
+          solicitor: { 'contact_email' => 'solicitor-contact@example.com' },
           defendant: { 'last_name' => 'Abrahams', 'first_name' => 'Abe' },
           incorrect_information_explanation: 'Please correct this information...',
           further_information_explanation: 'Please provide this further info...',
@@ -168,7 +168,7 @@ RSpec.describe PriorAuthority::SubmissionFeedbackMailer, type: :mailer do
           :prior_authority_data,
           laa_reference: 'LAA-FHaMVK',
           ufn: '111111/111',
-          provider: { 'email' => 'provider@example.com' },
+          solicitor: { 'contact_email' => 'solicitor-contact@example.com' },
           defendant: { 'last_name' => 'Abrahams', 'first_name' => 'Abe' },
         )
       )

--- a/spec/support/shared_examples/shared_claim_feedback_mailer.rb
+++ b/spec/support/shared_examples/shared_claim_feedback_mailer.rb
@@ -34,7 +34,7 @@ RSpec.shared_examples 'creates a prior authority feedback mailer' do
       expect(mail.delivery_method).to be_a(GovukNotifyRails::Delivery)
     end
 
-    it 'sets the recipient from config' do
+    it 'sets the recipient to be the solicitors contact email' do
       expect(mail.to).to eq([recipient])
     end
 


### PR DESCRIPTION

## Description of change
Correct recipient for decision/RFI notifications

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-976)

Although a provider will be associated with an application
they also specify a solicitor case contact per application.
This contact should be used for notification purposes related
to the case.
