### PR TITLE
Do not inline sidekiq for bin/dev

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
-web: bin/rails server -p 3002
+web: RUN_SIDEKIQ_IN_TEST_MODE=false bin/rails server -p 3002
 js: yarn build --watch
 css: yarn build:css --watch
 sidekiq: DISABLE_SIDEKIQ_ALIVE=true bundle exec sidekiq


### PR DESCRIPTION
## Description of change
Do not inline sidekiq for bin/dev

So it behaves as a hosted environments sidekiq worker
as expected and stats are updated.

without this the job will be processed inline with the side
effect that stats on the webui are not updated.
