### PR TITLE
Make SendBack event public so it can be used in provider

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,7 +4,7 @@ class Event < ApplicationRecord
 
   self.inheritance_column = :event_type
 
-  PUBLIC_EVENTS = ['Event::Decision'].freeze
+  PUBLIC_EVENTS = ['Event::Decision', 'Event::SendBack'].freeze
   HISTORY_EVENTS = [
     'Event::Assignment',
     'Event::Decision',


### PR DESCRIPTION
## Description of change
Make SendBack event public so it can be used in provider

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1193)
