### PR TITLE
CRM457-1044: Make name handling more flexible

### DIFF
--- a/app/controllers/nsm/send_backs_controller.rb
+++ b/app/controllers/nsm/send_backs_controller.rb
@@ -1,5 +1,7 @@
 module Nsm
   class SendBacksController < ApplicationController
+    include NameConstructable
+
     def edit
       send_back = SendBackForm.new(claim:)
       render locals: { claim:, send_back:, defendant_name: }
@@ -30,7 +32,7 @@ module Nsm
     def defendant_name
       defendants = claim.data['defendants']
       main_defendant = defendants.detect { |defendant| defendant['main'] }
-      main_defendant ? main_defendant['full_name'] : ''
+      main_defendant ? construct_name(main_defendant) : ''
     end
 
     def send_back_params

--- a/app/mailers/nsm/feedback_messages/feedback_base.rb
+++ b/app/mailers/nsm/feedback_messages/feedback_base.rb
@@ -3,6 +3,8 @@
 module Nsm
   module FeedbackMessages
     class FeedbackBase
+      include NameConstructable
+
       def initialize(submission, comment = '')
         @submission = submission
         @comment = comment
@@ -27,7 +29,7 @@ module Nsm
       end
 
       def defendant_name
-        main_defendant['full_name']
+        construct_name(main_defendant)
       end
 
       def maat_id

--- a/app/models/concerns/name_constructable.rb
+++ b/app/models/concerns/name_constructable.rb
@@ -1,0 +1,5 @@
+module NameConstructable
+  def construct_name(item, prefix: nil)
+    item["#{prefix}full_name"] || "#{item["#{prefix}first_name"]} #{item["#{prefix}last_name"]}"
+  end
+end

--- a/app/view_models/base_view_model.rb
+++ b/app/view_models/base_view_model.rb
@@ -1,6 +1,7 @@
 class BaseViewModel
   include ActiveModel::Model
   include ActiveModel::Attributes
+  include NameConstructable
 
   ID_FIELDS = %w[id].freeze
 

--- a/app/view_models/nsm/v1/all_claims.rb
+++ b/app/view_models/nsm/v1/all_claims.rb
@@ -9,7 +9,7 @@ module Nsm
 
       def main_defendant_name
         main_defendant = defendants.detect { |defendant| defendant['main'] }
-        main_defendant ? main_defendant['full_name'] : ''
+        main_defendant ? construct_name(main_defendant) : ''
       end
 
       def firm_name

--- a/app/view_models/nsm/v1/assessed_claims.rb
+++ b/app/view_models/nsm/v1/assessed_claims.rb
@@ -10,7 +10,7 @@ module Nsm
 
       def main_defendant_name
         main_defendant = defendants.detect { |defendant| defendant['main'] }
-        main_defendant ? main_defendant['full_name'] : ''
+        main_defendant ? construct_name(main_defendant) : ''
       end
 
       def firm_name

--- a/app/view_models/nsm/v1/claim_summary.rb
+++ b/app/view_models/nsm/v1/claim_summary.rb
@@ -10,7 +10,7 @@ module Nsm
 
       def main_defendant_name
         main_defendant = defendants.detect { |defendant| defendant['main'] }
-        main_defendant ? main_defendant['full_name'] : ''
+        main_defendant ? construct_name(main_defendant) : ''
       end
 
       def assigned_to

--- a/app/view_models/nsm/v1/contact_details.rb
+++ b/app/view_models/nsm/v1/contact_details.rb
@@ -22,7 +22,7 @@ module Nsm
       end
 
       def solicitor_full_name
-        solicitor['full_name']
+        construct_name(solicitor)
       end
 
       def solicitor_ref_number
@@ -30,7 +30,7 @@ module Nsm
       end
 
       def contact_full_name
-        solicitor['contact_full_name']
+        construct_name(solicitor, prefix: 'contact_')
       end
 
       def contact_email

--- a/app/view_models/nsm/v1/defendant_details.rb
+++ b/app/view_models/nsm/v1/defendant_details.rb
@@ -21,7 +21,7 @@ module Nsm
 
       def main_defendant_name
         main_defendant = defendants.detect { |defendant| defendant['main'] }
-        main_defendant['full_name']
+        construct_name(main_defendant)
       end
 
       def main_defendant_maat
@@ -51,7 +51,7 @@ module Nsm
           [
             {
               title: I18n.t(".nsm.claim_details.#{key}.defendant_name", count: index + 1),
-              value: defendant['full_name']
+              value: construct_name(defendant)
             },
             {
               title: I18n.t(".nsm.claim_details.#{key}.defendant_maat", count: index + 1),

--- a/app/view_models/nsm/v1/your_claims.rb
+++ b/app/view_models/nsm/v1/your_claims.rb
@@ -10,7 +10,7 @@ module Nsm
 
       def main_defendant_name
         main_defendant = defendants.detect { |defendant| defendant['main'] }
-        main_defendant ? main_defendant['full_name'] : ''
+        main_defendant ? construct_name(main_defendant) : ''
       end
 
       def firm_name

--- a/app/views/nsm/claims/_claim_summary.html.erb
+++ b/app/views/nsm/claims/_claim_summary.html.erb
@@ -2,7 +2,7 @@
     <div class="govuk-grid-column-two-thirds">
       <% if claim.display_state?  %>
         <p class="govuk-!-margin-bottom-2">
-          <%= govuk_tag(text: t(".status_list.#{claim.state}"), colour: accessed_colour(claim.state)) %>
+          <%= govuk_tag(text: t(".status_list.#{'granted'}"), colour: accessed_colour('granted')) %>
         </p>
       <% end %>
       <p class="govuk-body-l govuk-!-margin-bottom-2">

--- a/db/seeds/de2d6169-c769-4571-b3f2-220bcf8c3ce9/version.json
+++ b/db/seeds/de2d6169-c769-4571-b3f2-220bcf8c3ce9/version.json
@@ -58,7 +58,8 @@
         "maat": "AB12123",
         "main": true,
         "position": 1,
-        "full_name": "Tracy Linklater"
+        "first_name": "Tracy",
+        "last_name": "Linklater"
       }
     ],
     "disability": {

--- a/db/seeds/f1ba0909-020f-4373-a167-9100923bdcaa/version.json
+++ b/db/seeds/f1ba0909-020f-4373-a167-9100923bdcaa/version.json
@@ -48,7 +48,8 @@
                 "maat": "ZZ1234",
                 "main": true,
                 "position": 1,
-                "full_name": "Jim Bob"
+                "first_name": "Jim",
+                "last_name": "Bob"
             }
         ],
         "disability": {

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -158,7 +158,8 @@ FactoryBot.define do
             'maat' =>  'AB12123',
             'main' =>  true,
             'position' =>  1,
-            'full_name' =>  'Tracy Linklater'
+            'first_name' =>  'Tracy',
+            'last_name' => 'Linklater'
           }
         ]
       end

--- a/spec/view_models/nsm/v1/all_claims_spec.rb
+++ b/spec/view_models/nsm/v1/all_claims_spec.rb
@@ -6,7 +6,10 @@ RSpec.describe Nsm::V1::AllClaims, type: :view_model do
   end
 
   let(:laa_reference) { '1234567890' }
-  let(:defendants) { [{ 'full_name' => 'John Doe', 'main' => true }, 'main' => false, 'full_name' => 'jimbob'] }
+  let(:defendants) do
+    [{ 'first_name' => 'John', 'last_name' => 'Doe', 'main' => true },
+     { 'main' => false, 'first_name' => 'jim', 'last_name' => 'bob' }]
+  end
   let(:firm_office) { { 'name' => 'Acme Law Firm' } }
   let(:created_at) { Time.zone.today }
   let(:submission) { build(:claim, id: SecureRandom.uuid) }
@@ -20,7 +23,7 @@ RSpec.describe Nsm::V1::AllClaims, type: :view_model do
     context 'when no main defendant record - shouold not be possible' do
       it 'returns an empty string' do
         defendants = [
-          { 'main' => false, 'full_name' => 'John Doe' },
+          { 'main' => false, 'first_name' => 'John', 'last_name' => 'Doe' },
         ]
         summary = described_class.new('defendants' => defendants)
         expect(summary.main_defendant_name).to eq('')

--- a/spec/view_models/nsm/v1/assessed_claims_spec.rb
+++ b/spec/view_models/nsm/v1/assessed_claims_spec.rb
@@ -6,7 +6,10 @@ RSpec.describe Nsm::V1::AssessedClaims, type: :view_model do
   end
 
   let(:laa_reference) { '1234567890' }
-  let(:defendants) { [{ 'full_name' => 'John Doe', 'main' => true }, 'main' => false, 'full_name' => 'jimbob'] }
+  let(:defendants) do
+    [{ 'first_name' => 'John', 'last_name' => 'Doe', 'main' => true },
+     { 'main' => false, 'first_name' => 'jim', 'last_name' => 'bob' }]
+  end
   let(:firm_office) { { 'name' => 'Acme Law Firm' } }
   let(:updated_at) { Time.zone.yesterday }
   let(:submission) { instance_double(Claim, id: 1, events: events) }
@@ -23,7 +26,7 @@ RSpec.describe Nsm::V1::AssessedClaims, type: :view_model do
     context 'when no main defendant record - shouold not be possible' do
       it 'returns an empty string' do
         defendants = [
-          { 'main' => false, 'full_name' => 'John Doe' },
+          { 'main' => false, 'first_name' => 'John', 'last_name' => 'Doe' },
         ]
         summary = described_class.new('defendants' => defendants)
         expect(summary.main_defendant_name).to eq('')

--- a/spec/view_models/nsm/v1/claim_summary_spec.rb
+++ b/spec/view_models/nsm/v1/claim_summary_spec.rb
@@ -4,17 +4,17 @@ RSpec.describe Nsm::V1::ClaimSummary do
   describe 'main_defendant_name' do
     it 'returns the name attibute from the main defendant' do
       defendants = [
-        { 'main' => false, 'full_name' => 'jimbob' },
-        { 'main' => true, 'full_name' => 'bobjim' },
+        { 'main' => false, 'first_name' => 'John', 'last_name' => 'Doe' },
+        { 'main' => true, 'first_name' => 'John', 'last_name' => 'Roe' },
       ]
       summary = described_class.new('defendants' => defendants)
-      expect(summary.main_defendant_name).to eq('bobjim')
+      expect(summary.main_defendant_name).to eq('John Roe')
     end
 
     context 'when no main defendant record - shouold not be possible' do
       it 'returns an empty string' do
         defendants = [
-          { 'main' => false, 'full_name' => 'jimbob' },
+          { 'main' => false, 'first_name' => 'John', 'last_name' => 'Doe' },
         ]
         summary = described_class.new('defendants' => defendants)
         expect(summary.main_defendant_name).to eq('')

--- a/spec/view_models/nsm/v1/defendant_details_spec.rb
+++ b/spec/view_models/nsm/v1/defendant_details_spec.rb
@@ -18,21 +18,21 @@ RSpec.describe Nsm::V1::DefendantDetails do
                 'maat' => 'AB12123',
                 'main' => true,
                 'position' => 1,
-                'full_name' => 'Main Defendant'
+                'first_name' => 'Main', 'last_name' => 'Defendant'
             },
             {
               'id' => '40fb1f98-6dea-4b03-9087-590436b62dd8',
               'maat' => 'AB454545',
               'main' => false,
               'position' => 2,
-              'full_name' => 'Defendant 1'
+              'first_name' => 'Defendant', 'last_name' => '1'
             },
             {
               'id' => '40fb2f88-6dea-4b03-9087-590436b62dd8',
               'maat' => 'AB676767',
               'main' => false,
               'position' => 3,
-              'full_name' => 'Defendant 2'
+              'first_name' => 'Defendant', 'last_name' => '2'
             }
           ]
         }
@@ -54,21 +54,21 @@ RSpec.describe Nsm::V1::DefendantDetails do
                 'maat' => 'AB12123',
                 'main' => true,
                 'position' => 1,
-                'full_name' => 'Main Defendant'
+                'first_name' => 'Main', 'last_name' => 'Defendant'
             },
             {
               'id' => '40fb1f98-6dea-4b03-9087-590436b62dd8',
               'maat' => 'AB454545',
               'main' => false,
               'position' => 2,
-              'full_name' => 'Defendant 1'
+              'first_name' => 'Defendant', 'last_name' => '1'
             },
             {
               'id' => '40fb2f88-6dea-4b03-9087-590436b62dd8',
               'maat' => 'AB676767',
               'main' => false,
               'position' => 3,
-              'full_name' => 'Defendant 2'
+              'first_name' => 'Defendant', 'last_name' => '2'
             }
           ]
         }
@@ -95,7 +95,7 @@ RSpec.describe Nsm::V1::DefendantDetails do
                 'maat' => 'AB12123',
                 'main' => true,
                 'position' => 1,
-                'full_name' => 'Main Defendant'
+                'first_name' => 'Main', 'last_name' => 'Defendant'
             }
           ]
         }

--- a/spec/view_models/nsm/v1/your_claims_spec.rb
+++ b/spec/view_models/nsm/v1/your_claims_spec.rb
@@ -6,7 +6,10 @@ RSpec.describe Nsm::V1::YourClaims, type: :view_model do
   end
 
   let(:laa_reference) { '1234567890' }
-  let(:defendants) { [{ 'full_name' => 'John Doe', 'main' => true }, 'main' => false, 'full_name' => 'jimbob'] }
+  let(:defendants) do
+    [{ 'first_name' => 'John', 'last_name' => 'Doe', 'main' => true },
+     { 'main' => false, 'first_name' => 'jim', 'last_name' => 'bob' }]
+  end
   let(:firm_office) { { 'name' => 'Acme Law Firm' } }
   let(:created_at) { Time.zone.yesterday }
   let(:submission) { instance_double(Claim, id: 1) }
@@ -21,7 +24,7 @@ RSpec.describe Nsm::V1::YourClaims, type: :view_model do
     context 'when no main defendant record - shouold not be possible' do
       it 'returns an empty string' do
         defendants = [
-          { 'main' => false, 'full_name' => 'John Doe' },
+          { 'main' => false, 'first_name' => 'John', 'last_name' => 'Doe' },
         ]
         summary = described_class.new('defendants' => defendants)
         expect(summary.main_defendant_name).to eq('')


### PR DESCRIPTION
## Description of change
Provider now captures first name and last name for NSM defendants, and will shortly stop sending full_name. This prepares caseworker for that change

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1044)
