### PR TITLE
CRM457-1033: Remove feedback URL from all notifications

### DIFF
--- a/app/mailers/nsm/feedback_messages/feedback_base.rb
+++ b/app/mailers/nsm/feedback_messages/feedback_base.rb
@@ -60,10 +60,6 @@ module Nsm
       def claim_total
         @submission.data['submitted_total_inc_vat'] || @submission.data['submitted_total'] || 0
       end
-
-      def feedback_url
-        Rails.configuration.x.contact.feedback_url
-      end
     end
   end
 end

--- a/app/mailers/nsm/feedback_messages/further_information_request_feedback.rb
+++ b/app/mailers/nsm/feedback_messages/further_information_request_feedback.rb
@@ -17,7 +17,6 @@ module Nsm
           date_to_respond_by: 7.days.from_now.strftime('%d %B %Y'),
           caseworker_information_requested: @comment,
           date: DateTime.now.strftime('%d %B %Y'),
-          feedback_url: feedback_url
         }
       end
     end

--- a/app/mailers/nsm/feedback_messages/granted_feedback.rb
+++ b/app/mailers/nsm/feedback_messages/granted_feedback.rb
@@ -15,7 +15,6 @@ module Nsm
           defendant_reference: defendant_reference_string,
           claim_total: claim_total,
           date: DateTime.now.strftime('%d %B %Y'),
-          feedback_url: feedback_url
         }
       end
     end

--- a/app/mailers/nsm/feedback_messages/part_granted_feedback.rb
+++ b/app/mailers/nsm/feedback_messages/part_granted_feedback.rb
@@ -17,7 +17,6 @@ module Nsm
           part_grant_total: adjusted_total,
           caseworker_decision_explanation: @comment,
           date: DateTime.now.strftime('%d %B %Y'),
-          feedback_url: feedback_url
         }
       end
 

--- a/app/mailers/nsm/feedback_messages/provider_request_feedback.rb
+++ b/app/mailers/nsm/feedback_messages/provider_request_feedback.rb
@@ -15,7 +15,6 @@ module Nsm
           defendant_reference: defendant_reference_string,
           claim_total: claim_total,
           date: DateTime.now.strftime('%d %B %Y'),
-          feedback_url: feedback_url
         }
       end
     end

--- a/app/mailers/nsm/feedback_messages/rejected_feedback.rb
+++ b/app/mailers/nsm/feedback_messages/rejected_feedback.rb
@@ -16,7 +16,6 @@ module Nsm
           claim_total: claim_total,
           caseworker_decision_explanation: @comment,
           date: DateTime.now.strftime('%d %B %Y'),
-          feedback_url: feedback_url
         }
       end
     end

--- a/app/mailers/prior_authority/feedback_messages/feedback_base.rb
+++ b/app/mailers/prior_authority/feedback_messages/feedback_base.rb
@@ -45,10 +45,6 @@ module PriorAuthority
         decision.comments
       end
 
-      def feedback_url
-        Rails.configuration.x.contact.feedback_url
-      end
-
       private
 
       def application_summary

--- a/app/mailers/prior_authority/feedback_messages/further_information_request_feedback.rb
+++ b/app/mailers/prior_authority/feedback_messages/further_information_request_feedback.rb
@@ -16,7 +16,6 @@ module PriorAuthority
           date_to_respond_by: 14.days.from_now.strftime('%d %B %Y'),
           caseworker_information_requested: comments,
           date: DateTime.now.strftime('%d %B %Y'),
-          feedback_url: feedback_url
         }
       end
 

--- a/app/mailers/prior_authority/feedback_messages/granted_feedback.rb
+++ b/app/mailers/prior_authority/feedback_messages/granted_feedback.rb
@@ -14,7 +14,6 @@ module PriorAuthority
           defendant_name: defendant_name,
           application_total: application_total,
           date: DateTime.now.strftime('%d %B %Y'),
-          feedback_url: feedback_url
         }
       end
     end

--- a/app/mailers/prior_authority/feedback_messages/part_granted_feedback.rb
+++ b/app/mailers/prior_authority/feedback_messages/part_granted_feedback.rb
@@ -16,7 +16,6 @@ module PriorAuthority
           part_grant_total: adjusted_total,
           caseworker_decision_explanation: comments,
           date: DateTime.now.strftime('%d %B %Y'),
-          feedback_url: feedback_url
         }
       end
 

--- a/app/mailers/prior_authority/feedback_messages/rejected_feedback.rb
+++ b/app/mailers/prior_authority/feedback_messages/rejected_feedback.rb
@@ -15,7 +15,6 @@ module PriorAuthority
           application_total: application_total,
           caseworker_decision_explanation: comments,
           date: DateTime.now.strftime('%d %B %Y'),
-          feedback_url: feedback_url
         }
       end
     end

--- a/spec/mailers/nsm/feedback_messages/further_information_request_feeback_spec.rb
+++ b/spec/mailers/nsm/feedback_messages/further_information_request_feeback_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe Nsm::FeedbackMessages::FurtherInformationRequestFeedback do
   let(:date_to_respond_by) { 7.days.from_now.strftime('%d %B %Y') }
   let(:caseworker_information_requested) { 'Test Request' }
   let(:date) { DateTime.now.strftime('%d %B %Y') }
-  let(:feedback_url) { 'tbc' }
 
   describe '#template' do
     it 'has correct template id' do
@@ -35,7 +34,6 @@ RSpec.describe Nsm::FeedbackMessages::FurtherInformationRequestFeedback do
         date_to_respond_by:,
         caseworker_information_requested:,
         date:,
-        feedback_url:
       )
     end
   end

--- a/spec/mailers/nsm/feedback_messages/granted_feedback_spec.rb
+++ b/spec/mailers/nsm/feedback_messages/granted_feedback_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Nsm::FeedbackMessages::GrantedFeedback do
   let(:defendant_reference) { 'MAAT ID: AB12123' }
   let(:claim_total) { 0 }
   let(:date) { DateTime.now.strftime('%d %B %Y') }
-  let(:feedback_url) { 'tbc' }
 
   describe '#template' do
     it 'has correct template id' do
@@ -31,7 +30,6 @@ RSpec.describe Nsm::FeedbackMessages::GrantedFeedback do
         defendant_reference:,
         claim_total:,
         date:,
-        feedback_url:
       )
     end
   end

--- a/spec/mailers/nsm/feedback_messages/part_granted_feedback_spec.rb
+++ b/spec/mailers/nsm/feedback_messages/part_granted_feedback_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe Nsm::FeedbackMessages::PartGrantedFeedback do
   let(:part_grant_total) { 0 }
   let(:caseworker_decision_explanation) { 'Test Explanation' }
   let(:date) { DateTime.now.strftime('%d %B %Y') }
-  let(:feedback_url) { 'tbc' }
 
   describe '#template' do
     it 'has correct template id' do
@@ -35,7 +34,6 @@ RSpec.describe Nsm::FeedbackMessages::PartGrantedFeedback do
         part_grant_total:,
         caseworker_decision_explanation:,
         date:,
-        feedback_url:
       )
     end
   end

--- a/spec/mailers/nsm/feedback_messages/provider_request_feedback_spec.rb
+++ b/spec/mailers/nsm/feedback_messages/provider_request_feedback_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe Nsm::FeedbackMessages::ProviderRequestFeedback do
   let(:defendant_reference) { 'MAAT ID: AB12123' }
   let(:claim_total) { 0 }
   let(:date) { DateTime.now.strftime('%d %B %Y') }
-  let(:feedback_url) { 'tbc' }
 
   describe '#template' do
     it 'has correct template id' do
@@ -31,7 +30,6 @@ RSpec.describe Nsm::FeedbackMessages::ProviderRequestFeedback do
         defendant_reference:,
         claim_total:,
         date:,
-        feedback_url:
       )
     end
   end

--- a/spec/mailers/nsm/feedback_messages/rejected_feedback_spec.rb
+++ b/spec/mailers/nsm/feedback_messages/rejected_feedback_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe Nsm::FeedbackMessages::RejectedFeedback do
   let(:claim_total) { 0 }
   let(:caseworker_decision_explanation) { 'Test Explanation' }
   let(:date) { DateTime.now.strftime('%d %B %Y') }
-  let(:feedback_url) { 'tbc' }
 
   describe '#template' do
     it 'has correct template id' do
@@ -33,7 +32,6 @@ RSpec.describe Nsm::FeedbackMessages::RejectedFeedback do
         claim_total:,
         caseworker_decision_explanation:,
         date:,
-        feedback_url:
       )
     end
   end

--- a/spec/mailers/nsm/submission_feedback_mailer_spec.rb
+++ b/spec/mailers/nsm/submission_feedback_mailer_spec.rb
@@ -2,7 +2,6 @@
 
 require 'rails_helper'
 
-# rubocop:disable RSpec/MultipleMemoizedHelpers
 RSpec.describe Nsm::SubmissionFeedbackMailer, type: :mailer do
   let(:recipient) { 'provider@example.com' }
   let(:laa_case_reference) { 'LAA-FHaMVK' }
@@ -11,14 +10,13 @@ RSpec.describe Nsm::SubmissionFeedbackMailer, type: :mailer do
   let(:defendant_reference) { 'MAAT ID: AB12123' }
   let(:claim_total) { 0 }
   let(:date) { DateTime.now.strftime('%d %B %Y') }
-  let(:feedback_url) { 'tbc' }
 
   describe 'granted' do
     context 'with maat id' do
       let(:claim) { build(:claim, state: 'granted') }
       let(:feedback_template) { '80c0dcd2-597b-4c82-8c94-f6e26af71a40' }
       let(:personalisation) do
-        [laa_case_reference:, ufn:, main_defendant_name:, defendant_reference:, claim_total:, date:, feedback_url:]
+        [laa_case_reference:, ufn:, main_defendant_name:, defendant_reference:, claim_total:, date:]
       end
 
       include_examples 'creates a feedback mailer'
@@ -35,7 +33,7 @@ RSpec.describe Nsm::SubmissionFeedbackMailer, type: :mailer do
 
       let(:feedback_template) { '80c0dcd2-597b-4c82-8c94-f6e26af71a40' }
       let(:personalisation) do
-        [laa_case_reference:, ufn:, main_defendant_name:, defendant_reference:, claim_total:, date:, feedback_url:]
+        [laa_case_reference:, ufn:, main_defendant_name:, defendant_reference:, claim_total:, date:]
       end
 
       include_examples 'creates a feedback mailer'
@@ -50,7 +48,7 @@ RSpec.describe Nsm::SubmissionFeedbackMailer, type: :mailer do
     let(:personalisation) do
       [laa_case_reference:, ufn:, main_defendant_name:,
        defendant_reference:, claim_total:, part_grant_total:, caseworker_decision_explanation:,
-       date:, feedback_url:]
+       date:]
     end
 
     include_examples 'creates a feedback mailer'
@@ -62,7 +60,7 @@ RSpec.describe Nsm::SubmissionFeedbackMailer, type: :mailer do
     let(:caseworker_decision_explanation) { '' }
     let(:personalisation) do
       [laa_case_reference:, ufn:, main_defendant_name:, defendant_reference:, claim_total:,
-       caseworker_decision_explanation:, date:, feedback_url:]
+       caseworker_decision_explanation:, date:]
     end
 
     include_examples 'creates a feedback mailer'
@@ -76,7 +74,7 @@ RSpec.describe Nsm::SubmissionFeedbackMailer, type: :mailer do
     let(:personalisation) do
       [laa_case_reference:, ufn:, main_defendant_name:,
        defendant_reference:, claim_total:, date_to_respond_by:,
-       caseworker_information_requested:, date:, feedback_url:]
+       caseworker_information_requested:, date:]
     end
 
     include_examples 'creates a feedback mailer'
@@ -86,7 +84,7 @@ RSpec.describe Nsm::SubmissionFeedbackMailer, type: :mailer do
     let(:claim) { build(:claim, state: 'provider_requested') }
     let(:feedback_template) { 'bfd28bd8-b9d8-4b18-8ce0-3fb763123573' }
     let(:personalisation) do
-      [laa_case_reference:, ufn:, main_defendant_name:, defendant_reference:, claim_total:, date:, feedback_url:]
+      [laa_case_reference:, ufn:, main_defendant_name:, defendant_reference:, claim_total:, date:]
     end
 
     include_examples 'creates a feedback mailer'
@@ -100,10 +98,9 @@ RSpec.describe Nsm::SubmissionFeedbackMailer, type: :mailer do
     let(:personalisation) do
       [laa_case_reference:, ufn:, main_defendant_name:, defendant_reference:,
        claim_total:, date_to_respond_by:, caseworker_information_requested:,
-       date:, feedback_url:]
+       date:]
     end
 
     include_examples 'creates a feedback mailer'
   end
 end
-# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/mailers/prior_authority/feedback_messages/further_information_request_feeback_spec.rb
+++ b/spec/mailers/prior_authority/feedback_messages/further_information_request_feeback_spec.rb
@@ -56,7 +56,6 @@ RSpec.describe PriorAuthority::FeedbackMessages::FurtherInformationRequestFeedba
         application_total: '£324.50',
         date_to_respond_by: 14.days.from_now.to_fs(:stamp),
         date: DateTime.now.to_fs(:stamp),
-        feedback_url: 'tbc',
       )
     end
 

--- a/spec/mailers/prior_authority/feedback_messages/granted_feedback_spec.rb
+++ b/spec/mailers/prior_authority/feedback_messages/granted_feedback_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe PriorAuthority::FeedbackMessages::GrantedFeedback do
         defendant_name: 'Abe Abrahams',
         application_total: '£324.50',
         date: DateTime.now.to_fs(:stamp),
-        feedback_url: 'tbc',
       )
     end
   end

--- a/spec/mailers/prior_authority/feedback_messages/part_granted_feedback_spec.rb
+++ b/spec/mailers/prior_authority/feedback_messages/part_granted_feedback_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe PriorAuthority::FeedbackMessages::PartGrantedFeedback do
         part_grant_total: '£150.00',
         caseworker_decision_explanation: 'Caseworker part granted coz...',
         date: DateTime.now.to_fs(:stamp),
-        feedback_url: 'tbc',
       )
     end
   end

--- a/spec/mailers/prior_authority/feedback_messages/rejected_feedback_spec.rb
+++ b/spec/mailers/prior_authority/feedback_messages/rejected_feedback_spec.rb
@@ -51,7 +51,6 @@ RSpec.describe PriorAuthority::FeedbackMessages::RejectedFeedback do
         application_total: '£324.50',
         caseworker_decision_explanation: 'Caseworker rejected coz...',
         date: DateTime.now.to_fs(:stamp),
-        feedback_url: 'tbc',
       )
     end
   end

--- a/spec/mailers/prior_authority/submission_feedback_mailer_spec.rb
+++ b/spec/mailers/prior_authority/submission_feedback_mailer_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe PriorAuthority::SubmissionFeedbackMailer, type: :mailer do
   let(:defendant_name) { 'Abe Abrahams' }
   let(:application_total) { '£324.50' }
   let(:date) { DateTime.now.to_fs(:stamp) }
-  let(:feedback_url) { 'tbc' }
 
   let(:application) do
     create(
@@ -46,7 +45,7 @@ RSpec.describe PriorAuthority::SubmissionFeedbackMailer, type: :mailer do
 
     let(:personalisation) do
       [laa_case_reference:, ufn:, defendant_name:,
-       application_total:, date:, feedback_url:]
+       application_total:, date:]
     end
 
     include_examples 'creates a prior authority feedback mailer'
@@ -95,7 +94,7 @@ RSpec.describe PriorAuthority::SubmissionFeedbackMailer, type: :mailer do
     let(:personalisation) do
       [laa_case_reference:, ufn:, defendant_name:,
        application_total:, part_grant_total:,
-       caseworker_decision_explanation:, date:, feedback_url:]
+       caseworker_decision_explanation:, date:]
     end
 
     include_examples 'creates a prior authority feedback mailer'
@@ -110,7 +109,7 @@ RSpec.describe PriorAuthority::SubmissionFeedbackMailer, type: :mailer do
     let(:personalisation) do
       [laa_case_reference:, ufn:, defendant_name:,
       application_total:, caseworker_decision_explanation:,
-      date:, feedback_url:]
+      date:]
     end
 
     include_examples 'creates a prior authority feedback mailer'
@@ -153,7 +152,7 @@ RSpec.describe PriorAuthority::SubmissionFeedbackMailer, type: :mailer do
     let(:personalisation) do
       [laa_case_reference:, ufn:, defendant_name:,
        application_total:, date_to_respond_by:,
-       caseworker_information_requested:, date:, feedback_url:]
+       caseworker_information_requested:, date:]
     end
 
     include_examples 'creates a prior authority feedback mailer'


### PR DESCRIPTION
## Description of change
Remove feedback URL from all notifications

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1033)

Inline with UCD discussion it was decided to remove feedback
links from notification emails sent by the service.

The templates have been edited on notify and no longer use it.

### Before changes (RFI mail example):
<img width="582" alt="Screenshot 2024-03-22 at 12 29 18" src="https://github.com/ministryofjustice/laa-assess-crime-forms/assets/7016425/a53e6f6d-5f0f-41d3-8ce7-3e036cf89506">

### After changes (RFI mail example):
<img width="566" alt="Screenshot 2024-03-22 at 12 28 07" src="https://github.com/ministryofjustice/laa-assess-crime-forms/assets/7016425/626be375-8860-4c49-bd0b-7c621a171abb">



