### PR TITLE
Put further information request in more useful format

### DIFF
--- a/app/forms/prior_authority/send_back_form.rb
+++ b/app/forms/prior_authority/send_back_form.rb
@@ -53,11 +53,27 @@ module PriorAuthority
     end
 
     def update_local_records
-      submission.data['resubmission_deadline'] = Rails.application.config.x.rfi.resubmission_window.from_now
+      submission.data['resubmission_deadline'] = resubmission_deadline
+
+      append_further_information_object if updates_needed.include?(FURTHER_INFORMATION)
 
       submission.update!(state: PriorAuthorityApplication::SENT_BACK)
       submission.assignments.destroy_all
       save_event
+    end
+
+    def resubmission_deadline
+      Rails.application.config.x.rfi.resubmission_window.from_now
+    end
+
+    def append_further_information_object
+      submission.data['further_information'] ||= []
+
+      submission.data['further_information'] << {
+        caseworker_id: current_user.id,
+        information_requested: further_information_explanation,
+        requested_at: DateTime.current
+      }
     end
 
     def save_event

--- a/spec/forms/prior_authority/send_back_form_spec.rb
+++ b/spec/forms/prior_authority/send_back_form_spec.rb
@@ -96,6 +96,7 @@ RSpec.describe PriorAuthority::SendBackForm do
         it 'stores information' do
           expect(submission.data['updates_needed']).to include('further_information')
           expect(submission.data['further_information_explanation']).to eq further_information_explanation
+          expect(submission.data['further_information'][0]['caseworker_id']).to eq user.id
         end
 
         it 'sets a resubmission deadline' do

--- a/spec/forms/prior_authority/send_back_form_spec.rb
+++ b/spec/forms/prior_authority/send_back_form_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe PriorAuthority::SendBackForm do
       end
     end
 
-    context 'when params are valid' do
+    context 'when params are valid for further information' do
       let(:params) do
         {
           updates_needed: ['further_information'],
@@ -97,6 +97,51 @@ RSpec.describe PriorAuthority::SendBackForm do
           expect(submission.data['updates_needed']).to include('further_information')
           expect(submission.data['further_information_explanation']).to eq further_information_explanation
           expect(submission.data['further_information'][0]['caseworker_id']).to eq user.id
+        end
+
+        it 'sets a resubmission deadline' do
+          expect(DateTime.parse(submission.data['resubmission_deadline'])).to eq 14.days.from_now
+        end
+
+        it 'updates the state' do
+          expect(submission.state).to eq 'sent_back'
+        end
+
+        it 'adds an event' do
+          expect(submission.events.first).to be_a(PriorAuthority::Event::SendBack)
+        end
+
+        it 'notifies the app store' do
+          expect(NotifyAppStore).to have_received(:process).with(submission:)
+        end
+      end
+    end
+
+    context 'when params are valid for incorrect information' do
+      let(:params) do
+        {
+          updates_needed: ['incorrect_information'],
+          incorrect_information_explanation: incorrect_information_explanation,
+          submission: submission,
+          current_user: user
+        }
+      end
+
+      it 'returns true' do
+        expect(subject.save).to be true
+      end
+
+      it 'removes the assignment' do
+        expect { subject.save }.to change { submission.assignments.count }.from(1).to(0)
+      end
+
+      context 'when save runs' do
+        before { subject.save }
+
+        it 'stores information' do
+          expect(submission.data['updates_needed']).to include('incorrect_information')
+          expect(submission.data['incorrect_information_explanation']).to eq incorrect_information_explanation
+          expect(submission.data['further_information']).to be_nil
         end
 
         it 'sets a resubmission deadline' do


### PR DESCRIPTION
As discussed on slack, we're going to start populating a `further_information` array of hashes.