### PR TITLE
Remove edit link when not editable

### DIFF
--- a/app/views/prior_authority/applications/_primary_quote_card.html.erb
+++ b/app/views/prior_authority/applications/_primary_quote_card.html.erb
@@ -3,7 +3,9 @@
   <%= govuk_table(head: [t('.cost_type'), t('.amount'), t('.requested'), t('.total')],
                   rows: model.table_rows,) %>
 
-  <p>
-    <%= link_to t('.adjust'), prior_authority_application_adjustments_path(model.application_details.id) %>
-  </p>
+  <% if editable %>
+    <p>
+      <%= link_to t('.adjust'), prior_authority_application_adjustments_path(model.application_details.id) %>
+    </p>
+  <% end %>
 <% end %>

--- a/app/views/prior_authority/applications/show.html.erb
+++ b/app/views/prior_authority/applications/show.html.erb
@@ -39,7 +39,7 @@
     <%= render 'overview_card', model: @details.overview_card %>
 
     <h2 class="govuk-heading-m"><%= t('.about_the_request') %></h2>
-    <%= render 'primary_quote_card', model: @details.primary_quote_card %>
+    <%= render 'primary_quote_card', model: @details.primary_quote_card, editable: @summary.can_edit?(current_user) %>
     <%= render 'reason_why_card', model: @details.reason_why_card %>
     <% @details.alternative_quote_cards.each_with_index do |alternative_quote_card, index| %>
       <%= render alternative_quote_card.class.name.split('::').last.underscore, model: alternative_quote_card, n: index + 1 %>


### PR DESCRIPTION
## Description of change
Came out of QA: when an application is not editable, the primary quote card shouldn't have a link offering to make adjustments.
 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-994)
