### PR TITLE
Stop referring to specific ruby classes in event payload

### DIFF
--- a/app/jobs/pull_latest_version_data.rb
+++ b/app/jobs/pull_latest_version_data.rb
@@ -53,7 +53,7 @@ class PullLatestVersionData < ApplicationJob
     submission.save!
 
     json_data['events']&.each do |event|
-      submission.events.rehydrate!(event)
+      submission.events.rehydrate!(event, submission.application_type)
     end
     Event::NewVersion.build(submission:)
   end

--- a/spec/jobs/pull_latest_version_data_spec.rb
+++ b/spec/jobs/pull_latest_version_data_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe PullLatestVersionData do
           'created_at' => '2023-10-02T14:41:45.136Z',
           'updated_at' => '2023-10-02T14:41:45.136Z',
           'public' => true,
-          'event_type' => 'Event::Edit'
+          'event_type' => 'edit'
         }]
       end
 
@@ -82,7 +82,7 @@ RSpec.describe PullLatestVersionData do
         )
       end
 
-      context 'an no primary user is set' do
+      context 'and no primary user is set' do
         let(:events_data) do
           [{
             'submission_version' => 1,
@@ -94,7 +94,7 @@ RSpec.describe PullLatestVersionData do
             'created_at' => '2023-10-02T14:41:45.136Z',
             'updated_at' => '2023-10-02T14:41:45.136Z',
             'public' => true,
-            'event_type' => 'Event::NewVersion'
+            'event_type' => 'new_version'
           }]
         end
 
@@ -150,6 +150,22 @@ RSpec.describe PullLatestVersionData do
               auth_subject_id: primary_user_id
             )
           end
+        end
+      end
+
+      context 'when event is namespaced' do
+        let(:events_data) do
+          [{
+            'submission_version' => 1,
+            'primary_user_id' => primary_user_id,
+            'public' => true,
+            'event_type' => 'send_back'
+          }]
+        end
+
+        it 'rehydrates the event using the appropriate namespace' do
+          subject.perform(claim)
+          expect(Event.last).to be_a(Nsm::Event::SendBack)
         end
       end
     end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Event do
         'public' => nil,
         'secondary_user_id' => nil,
         'updated_at' => an_instance_of(String),
-        :event_type => 'Event::NewVersion',
+        :event_type => 'new_version',
         :public => false,
       )
     end
@@ -35,7 +35,7 @@ RSpec.describe Event do
           'public' => nil,
           'secondary_user_id' => nil,
           'updated_at' => an_instance_of(String),
-          :event_type => 'Event::Decision',
+          :event_type => 'decision',
           :public => true,
         )
       end


### PR DESCRIPTION
## Description of change
So that if we refactor classes in future we don't end up with data that refers to classes that no longer exist.