### PR TITLE
CRM457-992: QA feedback tweaks

### DIFF
--- a/app/forms/base_adjustment_form.rb
+++ b/app/forms/base_adjustment_form.rb
@@ -7,8 +7,6 @@ class BaseAdjustmentForm
   attribute :explanation, :string
   attribute :current_user
   attribute :item # used to detect changes in data
-
-  validates :explanation, presence: true, if: :explanation_required?
   validate :data_changed
 
   private

--- a/app/forms/nsm/base_adjustment_form.rb
+++ b/app/forms/nsm/base_adjustment_form.rb
@@ -3,6 +3,8 @@ module Nsm
     attribute :claim
     validates :submission, presence: true
 
+    validates :explanation, presence: true, if: :explanation_required?
+
     # Used by the superclass
     def submission
       claim

--- a/app/forms/prior_authority/base_cost_adjustment_form.rb
+++ b/app/forms/prior_authority/base_cost_adjustment_form.rb
@@ -20,6 +20,8 @@ module PriorAuthority
       validates :cost_per_hour, presence: true, numericality: { greater_than: 0 }, is_a_number: true
     end
 
+    validates :explanation, presence: true, if: :explanation_required?
+
     def save
       return false unless valid?
 

--- a/app/forms/prior_authority/travel_cost_form.rb
+++ b/app/forms/prior_authority/travel_cost_form.rb
@@ -9,6 +9,8 @@ module PriorAuthority
     validates :travel_time, presence: true, time_period: true
     validates :travel_cost_per_hour, presence: true, numericality: { greater_than: 0 }, is_a_number: true
 
+    validates :explanation, presence: true, if: :explanation_required?
+
     def save
       return false unless valid?
 

--- a/app/views/prior_authority/service_costs/edit.html.erb
+++ b/app/views/prior_authority/service_costs/edit.html.erb
@@ -6,7 +6,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds" id="service-cost-adjustment-container", data-turbo="false">
     <h1 class="govuk-heading-xl"><%= t('.page_title') %></h1>
-    <h2 class="govuk-heading-l"><%= t('.service_type_cost', service_type: t(submission.data['service_type'], scope: 'prior_authority.service_types')) %></h2>
+    <h2 class="govuk-heading-l"><%= t(submission.data['service_type'], scope: 'prior_authority.service_types') %></h2>
     <p class="govuk-body"><%= t('.adjustment_blurb', service_type: t(submission.data['service_type'], scope: 'prior_authority.service_types')) %></p>
 
     <%= form_with model: form, url: prior_authority_application_service_cost_path(submission.id, item.id), method: :patch do |f| %>

--- a/config/locales/en/prior_authority/service_costs.yml
+++ b/config/locales/en/prior_authority/service_costs.yml
@@ -20,4 +20,3 @@ en:
           label: Explain your decision
         hourly_cost: Hourly cost
         page_title: Adjust service costs
-        service_type_cost: "%{service_type} cost"

--- a/spec/system/prior_authority/adjust_service_costs_spec.rb
+++ b/spec/system/prior_authority/adjust_service_costs_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'Adjust service costs' do
     end
 
     it 'allows me to adjust the Time spent' do
-      expect(page).to have_content('Pathologist report cost')
+      expect(page).to have_content('Pathologist report')
 
       fill_in 'Hours', with: 10
       fill_in 'Minutes', with: 30
@@ -152,7 +152,7 @@ RSpec.describe 'Adjust service costs' do
     end
 
     it 'allows me to adjust the Number of items (minutes)' do
-      expect(page).to have_content('Translation and transcription cost')
+      expect(page).to have_content('Translation and transcription')
 
       fill_in 'Number of minutes', with: 60
       fill_in 'Explain your decision', with: '1 hour maximum allowed'


### PR DESCRIPTION
## Description of change
Remove "costs" suffix on h2 of service cost adjustment page

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-992)

QA feedback tweak 
### Before changes:
<img width="615" alt="Screenshot 2024-03-27 at 15 46 03" src="https://github.com/ministryofjustice/laa-assess-crime-forms/assets/7016425/d6a09aed-72d0-467a-8844-6949c23ce964">


### After changes:
<img width="642" alt="Screenshot 2024-03-27 at 15 41 08" src="https://github.com/ministryofjustice/laa-assess-crime-forms/assets/7016425/ad3f5c69-28e6-48d8-a077-9153c074e812">

