### PR TITLE
CRM457-1325: Fix key information card for prison law

### DIFF
--- a/app/view_models/prior_authority/v1/application_details.rb
+++ b/app/view_models/prior_authority/v1/application_details.rb
@@ -1,8 +1,6 @@
 module PriorAuthority
   module V1
     class ApplicationDetails < ApplicationSummary
-      attribute :ufn, :string
-      attribute :prison_law, :boolean
       attribute :prior_authority_granted, :boolean
       attribute :reason_why, :string
       attribute :supporting_documents

--- a/app/view_models/prior_authority/v1/application_details/key_information_card.rb
+++ b/app/view_models/prior_authority/v1/application_details/key_information_card.rb
@@ -2,9 +2,13 @@ module PriorAuthority
   module V1
     class ApplicationDetails
       class KeyInformationCard < BaseCard
-        CARD_ROWS = %i[main_offence primary_quote_postcode].freeze
+        CARD_ROWS = %i[main_offence ufn primary_quote_postcode].freeze
 
         delegate :main_offence, to: :application_details
+
+        def ufn
+          application_details.ufn if application_details.prison_law
+        end
 
         def primary_quote_postcode
           application_details.primary_quote.postcode

--- a/app/view_models/prior_authority/v1/application_summary.rb
+++ b/app/view_models/prior_authority/v1/application_summary.rb
@@ -1,6 +1,8 @@
 module PriorAuthority
   module V1
     class ApplicationSummary < BaseViewModel
+      attribute :prison_law, :boolean
+      attribute :ufn, :string
       attribute :laa_reference, :string
       attribute :firm_office
       attribute :quotes
@@ -26,7 +28,7 @@ module PriorAuthority
       def main_offence
         if main_offence_id == 'custom'
           custom_main_offence_name
-        else
+        elsif main_offence_id
           I18n.t("prior_authority.offences.#{main_offence_id}")
         end
       end

--- a/spec/view_models/prior_authority/v1/application_details/key_information_card_spec.rb
+++ b/spec/view_models/prior_authority/v1/application_details/key_information_card_spec.rb
@@ -4,10 +4,9 @@ RSpec.describe PriorAuthority::V1::ApplicationDetails::KeyInformationCard do
   subject(:key_information) { described_class.new(application_summary) }
 
   let(:klass) { PriorAuthority::V1::KeyInformation }
+  let(:application_summary) { klass.new(args) }
 
   describe '#primary_quote_postcode' do
-    let(:application_summary) { klass.new(args) }
-
     let(:args) do
       {
         quotes: [
@@ -21,6 +20,40 @@ RSpec.describe PriorAuthority::V1::ApplicationDetails::KeyInformationCard do
 
     it 'returns the postcode from the quote marked as primary true' do
       expect(key_information.primary_quote_postcode).to eq('E15 3JQ')
+    end
+  end
+
+  describe '#ufn' do
+    let(:args) do
+      {
+        prison_law: false,
+        ufn: '121212/001'
+      }
+    end
+
+    it 'returns nil when not prison law' do
+      expect(key_information.ufn).to be_nil
+    end
+  end
+
+  context 'when it is a prison law case' do
+    let(:args) do
+      {
+        prison_law: true,
+        ufn: '121212/001'
+      }
+    end
+
+    describe '#main_offence' do
+      it 'returns nil' do
+        expect(key_information.main_offence).to be_nil
+      end
+    end
+
+    describe '#ufn' do
+      it 'returns the ufn' do
+        expect(key_information.ufn).to eq '121212/001'
+      end
     end
   end
 end


### PR DESCRIPTION
## Description of change
- Show UFN on card but only for prison law
- When there is no main offence ID (i.e. prison law cases), do not try to work out the main offence name
 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1325)

