### PR TITLE
Use local app store service URL for production

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -65,7 +65,7 @@ autoscaling:
 
 variables:
   environment: production
-  appStoreUrl: https://laa-crime-application-store-prod.apps.live.cloud-platform.service.justice.gov.uk
+  appStoreUrl: http://laa-crime-application-store-app.laa-crime-application-store-production.svc.cluster.local
   enableSyncTriggerEndpoint: 'false'
   allowIndexing: 'true'
 


### PR DESCRIPTION
## Description of change

 [Update network policies so that Caseworker application talks to datastore via Cloud Platform rather than via an external url](https://dsdmoj.atlassian.net/browse/CRM457-1288)

The caseworker app image doesn't have curl so I can't test it using that - if anyone has any other ideas of how to run the request on the pod let me know, otherwise just trust me ;)

