### PR TITLE
Add envars needed for local integration

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -31,3 +31,20 @@ GOVUK_NOTIFY_API_KEY=not-a-real-key
 
 RUN_SIDEKIQ_IN_TEST_MODE=true
 ENABLE_SYNC_TRIGGER_ENDPOINT=true
+
+# App store credentials for testing against local app store
+#
+# - commenting out APP_STORE_TENANT_ID will prevent attempts to authenticate to configured app store.
+#   Note that the configured app store will require AUTHAUTHENTICATION_REQUIRED=false too in this case.
+#
+# - uncomment all and add secret values from k8s to autheticate
+#   Note that the configured app store must NOT have AUTHAUTHENTICATION_REQUIRED=false in this case.
+#
+APP_STORE_CLIENT_ID=not-a-real-key
+APP_STORE_TENANT_ID=not-a-real-key
+CASEWORKER_CLIENT_ID=not-a-real-key
+CASEWORKER_CLIENT_SECRET=not-a-real-key
+
+# ingress and protocol for webhook subscription to app store - must match local apps's rails server
+HOSTS=localhost:3002
+PROTOCOL=http

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
 web: RUN_SIDEKIQ_IN_TEST_MODE=false bin/rails server -p 3002
 js: yarn build --watch
 css: yarn build:css --watch
-sidekiq: DISABLE_SIDEKIQ_ALIVE=true bundle exec sidekiq
+sidekiq: RUN_SIDEKIQ_IN_TEST_MODE=false DISABLE_SIDEKIQ_ALIVE=true bundle exec sidekiq


### PR DESCRIPTION
## Description of change
Add envars needed for local integration

This is one way of replicating a production like
integration of assess with app store inline with pub/sub
changes.
