### PR TITLE
Use Local App Store URL - UAT

### DIFF
--- a/helm_deploy/values-uat.yaml
+++ b/helm_deploy/values-uat.yaml
@@ -65,7 +65,7 @@ autoscaling:
 
 variables:
   environment: uat
-  appStoreUrl: https://laa-crime-application-store-uat.apps.live.cloud-platform.service.justice.gov.uk
+  appStoreUrl: http://laa-crime-application-store-app.laa-crime-application-store-uat.svc.cluster.local
   enableSyncTriggerEndpoint: 'false'
   allowIndexing: 'false'
 


### PR DESCRIPTION
## Description of change

 [Update network policies so that Caseworker application talks to datastore via Cloud Platform rather than via an external url](https://dsdmoj.atlassian.net/browse/CRM457-1289)

## Notes for reviewer

This is just for the UAT env to use the local domain so ingress can be disabled in UAT also for an environment matching production more