### PR TITLE
CRM457-1318: Auto grant email

### DIFF
--- a/app/forms/nsm/make_decision_form.rb
+++ b/app/forms/nsm/make_decision_form.rb
@@ -31,7 +31,7 @@ module Nsm
                                 comment: comment,
                                 previous_state: previous_state,
                                 current_user: current_user)
-        NotifyAppStore.process(submission: claim)
+        NotifyAppStore.perform_later(submission: claim)
       end
 
       true

--- a/app/forms/nsm/send_back_form.rb
+++ b/app/forms/nsm/send_back_form.rb
@@ -26,7 +26,7 @@ module Nsm
         claim.update!(state:)
         Nsm::Event::SendBack.build(submission: claim, comment: comment, previous_state: previous_state,
                                    current_user: current_user)
-        NotifyAppStore.process(submission: claim)
+        NotifyAppStore.perform_later(submission: claim)
       end
 
       true

--- a/app/forms/prior_authority/decision_form.rb
+++ b/app/forms/prior_authority/decision_form.rb
@@ -39,7 +39,7 @@ module PriorAuthority
                                 comment: explanation,
                                 previous_state: previous_state,
                                 current_user: current_user)
-        NotifyAppStore.process(submission:)
+        NotifyAppStore.perform_later(submission:)
       end
 
       true

--- a/app/forms/prior_authority/send_back_form.rb
+++ b/app/forms/prior_authority/send_back_form.rb
@@ -32,7 +32,7 @@ module PriorAuthority
       PriorAuthorityApplication.transaction do
         stash(add_draft_send_back_event: false)
         update_local_records
-        NotifyAppStore.process(submission:)
+        NotifyAppStore.perform_later(submission:)
       end
 
       true

--- a/app/jobs/expire_sendbacks.rb
+++ b/app/jobs/expire_sendbacks.rb
@@ -12,6 +12,6 @@ class ExpireSendbacks < ApplicationJob
   def expire(submission)
     submission.update!(state: PriorAuthorityApplication::EXPIRED)
     Event::Expiry.build(submission:)
-    NotifyAppStore.process(submission: submission, trigger_email: false)
+    NotifyAppStore.perform_later(submission: submission, trigger_email: false)
   end
 end

--- a/app/mailers/prior_authority/submission_feedback_mailer.rb
+++ b/app/mailers/prior_authority/submission_feedback_mailer.rb
@@ -6,6 +6,7 @@ module PriorAuthority
 
     FEEDBACK_MESSAGE_KLASSES = {
       PriorAuthorityApplication::GRANTED => FeedbackMessages::GrantedFeedback,
+      PriorAuthorityApplication::AUTO_GRANT => FeedbackMessages::GrantedFeedback,
       PriorAuthorityApplication::PART_GRANT => FeedbackMessages::PartGrantedFeedback,
       PriorAuthorityApplication::REJECTED => FeedbackMessages::RejectedFeedback,
       PriorAuthorityApplication::SENT_BACK => FeedbackMessages::FurtherInformationRequestFeedback,

--- a/app/services/notify_app_store.rb
+++ b/app/services/notify_app_store.rb
@@ -1,26 +1,7 @@
 class NotifyAppStore < ApplicationJob
   queue_as :default
 
-  def self.process(submission:, trigger_email: true)
-    if ENV.key?('REDIS_HOST')
-      set(wait: Rails.application.config.x.application.app_store_wait.seconds)
-        .perform_later(submission, trigger_email:)
-    else
-      begin
-        new.notify(MessageBuilder.new(submission:))
-        return unless trigger_email
-
-        klass = "#{submission.namespace}::SubmissionFeedbackMailer".constantize
-        klass.notify(submission).deliver_later!
-      rescue StandardError => e
-        # we only get errors here when processing inline, which we don't want
-        # to be visible to the end user, so swallow errors
-        Sentry.capture_exception(e)
-      end
-    end
-  end
-
-  def perform(submission, trigger_email: true)
+  def perform(submission:, trigger_email: true)
     notify(MessageBuilder.new(submission:))
 
     return unless trigger_email
@@ -30,13 +11,6 @@ class NotifyAppStore < ApplicationJob
   end
 
   def notify(message_builder)
-    raise 'SNS notification is not yet enabled' if ENV.key?('SNS_URL')
-
-    # implement and call SNS notification
-
-    # TODO: we only do post requests here as the system is not currently
-    # able to support re-sending/submitting an appplication so we can ignore
-    # put requests
     client = AppStoreClient.new
     client.update_submission(message_builder.message)
   end

--- a/app/services/update_submission.rb
+++ b/app/services/update_submission.rb
@@ -69,6 +69,6 @@ class UpdateSubmission
     submission.update!(state: PriorAuthorityApplication::AUTO_GRANT)
 
     Event::AutoDecision.build(submission:, previous_state:)
-    NotifyAppStore.process(submission:)
+    NotifyAppStore.perform_later(submission:)
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -73,9 +73,6 @@ module LaaAssessNonStandardMagistrateFee
     config.x.rfi.resubmission_window = 14.days
 
     config.x.contact.feedback_url = 'tbc'
-    #time to wait for requests to be made to app store for db consistency
-    config.x.application.app_store_wait = ENV.fetch('APP_STORE_WAIT_SECS',0).to_i
-
     config.after_initialize do
       Rails.application.reload_routes!
       AppStoreSubscriber.call

--- a/helm_deploy/templates/deployment-worker.yaml
+++ b/helm_deploy/templates/deployment-worker.yaml
@@ -162,8 +162,6 @@ spec:
                 secretKeyRef:
                   name: google-analytics
                   key: tracking_key
-            - name: APP_STORE_WAIT_SECS
-              value: '30'
             - name: OS_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/helm_deploy/templates/deployment.yaml
+++ b/helm_deploy/templates/deployment.yaml
@@ -162,8 +162,6 @@ spec:
                 secretKeyRef:
                   name: s3-policy-arns
                   key: bucket_name
-            - name: APP_STORE_WAIT_SECS
-              value: '30'
             - name: SIDEKIQ_WEB_UI_USERNAME
               valueFrom:
                 secretKeyRef:

--- a/spec/forms/nsm/make_decision_form_spec.rb
+++ b/spec/forms/nsm/make_decision_form_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Nsm::MakeDecisionForm do
 
     before do
       allow(Event::Decision).to receive(:build)
-      allow(NotifyAppStore).to receive(:process)
+      allow(NotifyAppStore).to receive(:perform_later)
     end
 
     it { expect(subject.save).to be_truthy }
@@ -91,7 +91,7 @@ RSpec.describe Nsm::MakeDecisionForm do
 
     it 'trigger an update to the app store' do
       subject.save
-      expect(NotifyAppStore).to have_received(:process).with(submission: claim)
+      expect(NotifyAppStore).to have_received(:perform_later).with(submission: claim)
     end
 
     context 'when not valid' do

--- a/spec/forms/nsm/send_back_form_spec.rb
+++ b/spec/forms/nsm/send_back_form_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Nsm::SendBackForm do
 
     before do
       allow(Nsm::Event::SendBack).to receive(:build)
-      allow(NotifyAppStore).to receive(:process)
+      allow(NotifyAppStore).to receive(:perform_later)
     end
 
     it { expect(subject.save).to be_truthy }
@@ -84,7 +84,7 @@ RSpec.describe Nsm::SendBackForm do
 
     it 'trigger an update to the app store' do
       subject.save
-      expect(NotifyAppStore).to have_received(:process).with(submission: claim)
+      expect(NotifyAppStore).to have_received(:perform_later).with(submission: claim)
     end
 
     context 'when not valid' do

--- a/spec/forms/prior_authority/send_back_form_spec.rb
+++ b/spec/forms/prior_authority/send_back_form_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe PriorAuthority::SendBackForm do
     let(:user) { create(:caseworker) }
 
     before do
-      allow(NotifyAppStore).to receive(:process)
+      allow(NotifyAppStore).to receive(:perform_later)
       travel_to fixed_arbitrary_date
       create(:assignment, submission:, user:)
     end
@@ -112,7 +112,7 @@ RSpec.describe PriorAuthority::SendBackForm do
         end
 
         it 'notifies the app store' do
-          expect(NotifyAppStore).to have_received(:process).with(submission:)
+          expect(NotifyAppStore).to have_received(:perform_later).with(submission:)
         end
       end
     end
@@ -157,7 +157,7 @@ RSpec.describe PriorAuthority::SendBackForm do
         end
 
         it 'notifies the app store' do
-          expect(NotifyAppStore).to have_received(:process).with(submission:)
+          expect(NotifyAppStore).to have_received(:perform_later).with(submission:)
         end
       end
     end

--- a/spec/jobs/expire_sendbacks_spec.rb
+++ b/spec/jobs/expire_sendbacks_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe ExpireSendbacks do
 
     before do
       application
-      allow(NotifyAppStore).to receive(:process)
+      allow(NotifyAppStore).to receive(:perform_later)
       described_class.new.perform
     end
 
@@ -23,7 +23,7 @@ RSpec.describe ExpireSendbacks do
       end
 
       it 'updates the app store without an email' do
-        expect(NotifyAppStore).to have_received(:process).with(submission: application, trigger_email: false)
+        expect(NotifyAppStore).to have_received(:perform_later).with(submission: application, trigger_email: false)
       end
     end
 

--- a/spec/mailers/prior_authority/submission_feedback_mailer_spec.rb
+++ b/spec/mailers/prior_authority/submission_feedback_mailer_spec.rb
@@ -51,6 +51,19 @@ RSpec.describe PriorAuthority::SubmissionFeedbackMailer, type: :mailer do
     include_examples 'creates a prior authority feedback mailer'
   end
 
+  context 'with auto_grant state' do
+    let(:state) { 'auto_grant' }
+    let(:caseworker_comment) { nil }
+    let(:feedback_template) { 'd4f3da60-4da5-423e-bc93-d9235ff01a7b' }
+
+    let(:personalisation) do
+      [laa_case_reference:, ufn:, defendant_name:,
+       application_total:, date:]
+    end
+
+    include_examples 'creates a prior authority feedback mailer'
+  end
+
   context 'with part granted state' do
     let(:state) { 'part_grant' }
 

--- a/spec/services/notify_app_store_spec.rb
+++ b/spec/services/notify_app_store_spec.rb
@@ -11,68 +11,6 @@ RSpec.describe NotifyAppStore do
       .and_return(message_builder)
   end
 
-  describe '#process' do
-    context 'when REDIS_HOST is not present' do
-      before do
-        allow(ENV).to receive(:key?).and_call_original
-        allow(ENV).to receive(:key?).with('REDIS_HOST').and_return(false)
-        allow(submission).to receive(:namespace).and_return(Nsm)
-        allow(Nsm::SubmissionFeedbackMailer).to receive_message_chain(:notify, :deliver_later!)
-
-        expect(AppStoreClient).to receive(:new)
-          .and_return(http_notifier)
-      end
-
-      let(:http_notifier) { instance_double(AppStoreClient, update_submission: true) }
-
-      it 'does not raise any errors' do
-        expect { described_class.process(submission:) }.not_to raise_error
-      end
-
-      it 'sends a HTTP message' do
-        expect(http_notifier).to receive(:update_submission).with(message_builder.message)
-
-        described_class.process(submission:)
-      end
-
-      it 'queues an email' do
-        expect(Nsm::SubmissionFeedbackMailer).to receive_message_chain(:notify, :deliver_later!)
-        described_class.process(submission:)
-      end
-
-      context 'when error during notify process' do
-        before do
-          allow(http_notifier).to receive(:update_submission).and_raise('annoying_error')
-        end
-
-        it 'sends the error to sentry and ignores it' do
-          expect(Sentry).to receive(:capture_exception)
-
-          expect { described_class.process(submission:) }.not_to raise_error
-        end
-      end
-
-      context 'when emails should not be triggered' do
-        it 'does not send an email' do
-          expect(Nsm::SubmissionFeedbackMailer).not_to receive(:notify)
-          described_class.process(submission: submission, trigger_email: false)
-        end
-      end
-    end
-
-    context 'when REDIS_HOST is present' do
-      before do
-        allow(ENV).to receive(:key?).with('REDIS_HOST').and_return(true)
-      end
-
-      it 'schedules the job' do
-        expect(described_class).to receive_message_chain(:set, :perform_later).with(submission, trigger_email: true)
-
-        described_class.process(submission:)
-      end
-    end
-  end
-
   describe '#perform' do
     let(:http_notifier) { instance_double(AppStoreClient, update_submission: true) }
 
@@ -86,61 +24,49 @@ RSpec.describe NotifyAppStore do
       expect(described_class::MessageBuilder).to receive(:new)
         .with(submission:)
 
-      subject.perform(submission)
+      subject.perform(submission:)
     end
 
     it 'queues an email' do
       expect(Nsm::SubmissionFeedbackMailer).to receive_message_chain(:notify, :deliver_later!)
-      subject.perform(submission)
+      subject.perform(submission:)
     end
 
     context 'when emails should not be triggered' do
       it 'does not send an email' do
         expect(Nsm::SubmissionFeedbackMailer).not_to receive(:notify)
-        subject.perform(submission, trigger_email: false)
+        subject.perform(submission: submission, trigger_email: false)
       end
     end
   end
 
   describe '#notify' do
-    context 'when SNS_URL is not present' do
-      let(:http_notifier) { instance_double(AppStoreClient, update_submission: true) }
+    let(:http_notifier) { instance_double(AppStoreClient, update_submission: true) }
 
-      before do
-        allow(AppStoreClient).to receive(:new)
-          .and_return(http_notifier)
-      end
-
-      it 'creates a new AppStoreClient instance' do
-        expect(AppStoreClient).to receive(:new)
-
-        subject.notify(message_builder)
-      end
-
-      it 'sends a HTTP message' do
-        expect(http_notifier).to receive(:update_submission).with(message_builder.message)
-
-        subject.notify(message_builder)
-      end
-
-      describe 'when error during notify process' do
-        before do
-          allow(http_notifier).to receive(:update_submission).and_raise('annoying_error')
-        end
-
-        it 'allows the error to be raised - should reset the sidekiq job' do
-          expect { subject.notify(message_builder) }.to raise_error('annoying_error')
-        end
-      end
+    before do
+      allow(AppStoreClient).to receive(:new)
+        .and_return(http_notifier)
     end
 
-    context 'when SNS_URL is present' do
+    it 'creates a new AppStoreClient instance' do
+      expect(AppStoreClient).to receive(:new)
+
+      subject.notify(message_builder)
+    end
+
+    it 'sends a HTTP message' do
+      expect(http_notifier).to receive(:update_submission).with(message_builder.message)
+
+      subject.notify(message_builder)
+    end
+
+    describe 'when error during notify process' do
       before do
-        allow(ENV).to receive(:key?).with('SNS_URL').and_return(true)
+        allow(http_notifier).to receive(:update_submission).and_raise('annoying_error')
       end
 
-      it 'raises an error' do
-        expect { subject.notify(message_builder) }.to raise_error('SNS notification is not yet enabled')
+      it 'allows the error to be raised - should reset the sidekiq job' do
+        expect { subject.notify(message_builder) }.to raise_error('annoying_error')
       end
     end
   end

--- a/spec/services/update_submission_spec.rb
+++ b/spec/services/update_submission_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe UpdateSubmission do
       before do
         allow(Autograntable).to receive(:new).and_return(autograntable)
         allow(Event::AutoDecision).to receive(:build)
-        allow(NotifyAppStore).to receive(:process)
+        allow(NotifyAppStore).to receive(:perform_later)
       end
 
       it 'updates the state to auto_grant' do
@@ -239,7 +239,7 @@ RSpec.describe UpdateSubmission do
 
       it 'notifys the app store' do
         described_class.call(record)
-        expect(NotifyAppStore).to have_received(:process).with(submission: application.becomes(Submission))
+        expect(NotifyAppStore).to have_received(:perform_later).with(submission: application.becomes(Submission))
       end
     end
 
@@ -251,7 +251,7 @@ RSpec.describe UpdateSubmission do
         allow(autograntable).to receive(:grantable?).and_raise(LocationService::NotFoundError)
         allow(Autograntable).to receive(:new).and_return(autograntable)
         allow(Event::AutoDecision).to receive(:build)
-        allow(NotifyAppStore).to receive(:process)
+        allow(NotifyAppStore).to receive(:perform_later)
         allow(Sentry).to receive(:capture_exception)
       end
 
@@ -270,7 +270,7 @@ RSpec.describe UpdateSubmission do
         allow(autograntable).to receive(:grantable?).and_raise(LocationService::ResponseError)
         allow(Autograntable).to receive(:new).and_return(autograntable)
         allow(Event::AutoDecision).to receive(:build)
-        allow(NotifyAppStore).to receive(:process)
+        allow(NotifyAppStore).to receive(:perform_later)
         allow(Sentry).to receive(:capture_exception)
       end
 
@@ -289,7 +289,7 @@ RSpec.describe UpdateSubmission do
         allow(autograntable).to receive(:grantable?).and_raise('unknown_error')
         allow(Autograntable).to receive(:new).and_return(autograntable)
         allow(Event::AutoDecision).to receive(:build)
-        allow(NotifyAppStore).to receive(:process)
+        allow(NotifyAppStore).to receive(:perform_later)
       end
 
       it 'raise the erroor' do

--- a/spec/system/nsm/assessment_spec.rb
+++ b/spec/system/nsm/assessment_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-Rails.describe 'Claim Feedback', :stub_oauth_token, :stub_update_claim do
+Rails.describe 'Assessment', :stub_oauth_token, :stub_update_claim do
   let(:user) { create(:caseworker) }
   let(:claim) { create(:claim) }
 
@@ -11,19 +11,19 @@ Rails.describe 'Claim Feedback', :stub_oauth_token, :stub_update_claim do
   end
 
   context 'granted' do
-    it 'sends a granted email' do
+    it 'sends a granted notification' do
       visit nsm_claim_claim_details_path(claim)
       click_link_or_button 'Make a decision'
       choose 'Grant it'
 
       expect do
         click_link_or_button 'Submit decision'
-      end.to have_enqueued_job.on_queue('mailers')
+      end.to have_enqueued_job(NotifyAppStore)
     end
   end
 
   context 'part-granted' do
-    it 'sends a part granted email' do
+    it 'sends a part granted notification' do
       visit nsm_claim_claim_details_path(claim)
       click_link_or_button 'Make a decision'
       choose 'Part grant it'
@@ -31,12 +31,12 @@ Rails.describe 'Claim Feedback', :stub_oauth_token, :stub_update_claim do
 
       expect do
         click_link_or_button 'Submit decision'
-      end.to have_enqueued_job.on_queue('mailers')
+      end.to have_enqueued_job(NotifyAppStore)
     end
   end
 
   context 'rejected' do
-    it 'sends a rejected email' do
+    it 'sends a rejected notification' do
       visit nsm_claim_claim_details_path(claim)
       click_link_or_button 'Make a decision'
       choose 'Reject it'
@@ -44,12 +44,12 @@ Rails.describe 'Claim Feedback', :stub_oauth_token, :stub_update_claim do
 
       expect do
         click_link_or_button 'Submit decision'
-      end.to have_enqueued_job.on_queue('mailers')
+      end.to have_enqueued_job(NotifyAppStore)
     end
   end
 
   context 'provider requested' do
-    it 'sends a granted email' do
+    it 'sends a notification' do
       visit nsm_claim_claim_details_path(claim)
       click_link_or_button 'Send back to provider'
       choose 'Provider request'
@@ -57,12 +57,12 @@ Rails.describe 'Claim Feedback', :stub_oauth_token, :stub_update_claim do
 
       expect do
         click_link_or_button 'Send back to provider'
-      end.to have_enqueued_job.on_queue('mailers')
+      end.to have_enqueued_job(NotifyAppStore)
     end
   end
 
   context 'further information required' do
-    it 'sends a granted email' do
+    it 'sends a notification' do
       visit nsm_claim_claim_details_path(claim)
       click_link_or_button 'Send back to provider'
       choose 'Further information request'
@@ -70,7 +70,7 @@ Rails.describe 'Claim Feedback', :stub_oauth_token, :stub_update_claim do
 
       expect do
         click_link_or_button 'Send back to provider'
-      end.to have_enqueued_job.on_queue('mailers')
+      end.to have_enqueued_job(NotifyAppStore)
     end
   end
 end

--- a/spec/system/prior_authority/make_decision_spec.rb
+++ b/spec/system/prior_authority/make_decision_spec.rb
@@ -3,15 +3,8 @@ require 'rails_helper'
 RSpec.describe 'Decide an application', :stub_oauth_token do
   let(:caseworker) { create(:caseworker) }
   let(:application) { create(:prior_authority_application, state: 'submitted') }
-  let(:app_store_stub) do
-    stub_request(:put, %r{http.*/v1/application/.*})
-      .to_return(
-        status: 201
-      )
-  end
 
   before do
-    app_store_stub
     sign_in caseworker
     create(:assignment, submission: application, user: caseworker)
     visit '/'
@@ -26,16 +19,14 @@ RSpec.describe 'Decide an application', :stub_oauth_token do
       fill_in 'Provide detailed reasons for rejecting this application', with: 'The wrong form was used'
     end
 
-    it 'triggers an email' do
-      expect { click_on 'Submit decision' }.to have_enqueued_job.on_queue('mailers')
+    it 'triggers a notification' do
+      expect { click_on 'Submit decision' }.to have_enqueued_job(NotifyAppStore)
     end
 
     context 'once the decision has been processed' do
       before do
         click_on 'Submit decision'
       end
-
-      it { expect(app_store_stub).to have_been_requested }
 
       it 'shows my decision' do
         expect(page).to have_content 'Decision sent'


### PR DESCRIPTION
## Description of change
Add 'granted' email for auto-grants, and standardise how NotifyAppStore works to remove SNS stuff and now-unnecessary 30 second wait

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1318)
