### PR TITLE
CRM457-1012: RFI tweaks from QA

### DIFF
--- a/app/services/notify_app_store.rb
+++ b/app/services/notify_app_store.rb
@@ -1,5 +1,6 @@
 class NotifyAppStore < ApplicationJob
   queue_as :default
+  retry_on StandardError, wait: :polynomially_longer, attempts: 10
 
   def perform(submission:, trigger_email: true)
     notify(MessageBuilder.new(submission:))

--- a/app/services/update_submission.rb
+++ b/app/services/update_submission.rb
@@ -23,8 +23,13 @@ class UpdateSubmission
     PriorAuthorityApplication.transaction do
       update_submission
       autogrant if cached_autograntable
-      Event::NewVersion.build(submission:) if version_changed
+      Event::NewVersion.build(submission:) if new_version_appropriate? && version_changed
     end
+  end
+
+  def new_version_appropriate?
+    # If this is a prior authority submission, only add a new version event on the first new version
+    @record['version'] == 1 || @record['application_type'] != Submission::APPLICATION_TYPES[:prior_authority]
   end
 
   def assign_attributes

--- a/app/view_models/prior_authority/v1/application_details.rb
+++ b/app/view_models/prior_authority/v1/application_details.rb
@@ -99,7 +99,7 @@ module PriorAuthority
 
         submission.data['further_information']
                   .select { _1['information_supplied'].present? }
-                  .sort_by { DateTime.parse(_1['requested_at']) }
+                  .sort_by { _1['requested_at'] }
                   .reverse
                   .map do |further_information|
           FurtherInformationCard.new(self, further_information)

--- a/app/view_models/prior_authority/v1/application_details.rb
+++ b/app/view_models/prior_authority/v1/application_details.rb
@@ -97,7 +97,11 @@ module PriorAuthority
       def further_information_cards
         return [] unless submission.data['further_information']
 
-        submission.data['further_information'].select { _1['information_supplied'].present? }.map do |further_information|
+        submission.data['further_information']
+                  .select { _1['information_supplied'].present? }
+                  .sort_by { DateTime.parse(_1['requested_at']) }
+                  .reverse
+                  .map do |further_information|
           FurtherInformationCard.new(self, further_information)
         end
       end

--- a/app/view_models/prior_authority/v1/application_details/further_information_card.rb
+++ b/app/view_models/prior_authority/v1/application_details/further_information_card.rb
@@ -18,13 +18,13 @@ module PriorAuthority
         end
 
         def information_request
-          @further_information['information_requested']
+          simple_format(@further_information['information_requested'])
         end
 
         def provider_response
           safe_join(
-            [@further_information['information_supplied']] +
-             documents.map { [document_link(_1), tag.br] }.flatten
+            [simple_format(@further_information['information_supplied'])] +
+             documents.map { [tag.br, document_link(_1)] }.flatten
           )
         end
 

--- a/app/view_models/prior_authority/v1/application_details/further_information_card.rb
+++ b/app/view_models/prior_authority/v1/application_details/further_information_card.rb
@@ -24,7 +24,7 @@ module PriorAuthority
         def provider_response
           safe_join(
             [simple_format(@further_information['information_supplied'])] +
-             documents.map { [tag.br, document_link(_1)] }.flatten
+             documents.flat_map { [tag.br, document_link(_1)] }
           )
         end
 

--- a/app/view_models/prior_authority/v1/event_summary.rb
+++ b/app/view_models/prior_authority/v1/event_summary.rb
@@ -12,7 +12,7 @@ module PriorAuthority
         safe_join([
                     event.created_at.to_fs(:stamp),
                     tag.br,
-                    event.created_at.to_fs(:time_of_day)
+                    event.created_at.in_time_zone('London').to_fs(:time_of_day)
                   ])
       end
 

--- a/app/views/prior_authority/applications/show.html.erb
+++ b/app/views/prior_authority/applications/show.html.erb
@@ -21,18 +21,12 @@
       <div class="govuk-inset-text">
         <p><strong><%= t(".sent_back", date: @summary.date_updated_str) %></strong></p>
         <% if @details.further_information_requested? %>
-          <p>
-            <%= t('.further_information') %>
-            <br>
-            <%= @details.further_information_explanation %>
-          </p>
+          <p><%= t('.further_information') %></p>
+          <%= simple_format @details.further_information_explanation %>
         <% end %>
         <% if @details.corrections_requested? %>
-          <p>
-            <%= t('.incorrect_information') %>
-            <br>
-            <%= @details.incorrect_information_explanation %>
-          </p>
+          <p><%= t('.incorrect_information') %></p>
+          <%= simple_format @details.incorrect_information_explanation %>
         <% end %>
       </div>
     <% elsif @summary.provider_updated? %>

--- a/app/views/prior_authority/events/index.html.erb
+++ b/app/views/prior_authority/events/index.html.erb
@@ -56,7 +56,7 @@
               <% end %>
             </tbody>
           </table>
-          <%= render 'shared/pagination', pagy: pagy, item: t("prior_authority.applications.table.table_info_item") %>
+          <%= render 'shared/pagination', pagy: pagy, item: t(".event") %>
       </div>
     </div>
 

--- a/app/views/prior_authority/send_backs/show.html.erb
+++ b/app/views/prior_authority/send_backs/show.html.erb
@@ -28,7 +28,7 @@
               <%= t('.further_information') %>
             </dt>
             <dd class="govuk-summary-list__value">
-              <%= @model.further_information_explanation %>
+              <%= simple_format @model.further_information_explanation %>
             </dd>
           </div>
         <% end %>
@@ -39,11 +39,10 @@
               <%= t('.incorrect_information') %>
             </dt>
             <dd class="govuk-summary-list__value">
-              <%= @model.incorrect_information_explanation %>
+              <%= simple_format @model.incorrect_information_explanation %>
             </dd>
           </div>
         <% end %>
-
 
       </dl>
       <div class="govuk-button-group govuk-button-group-vertically-centred">

--- a/config/locales/en/prior_authority/events.yml
+++ b/config/locales/en/prior_authority/events.yml
@@ -25,3 +25,4 @@ en:
         caseworker: Caseworker
         update: Update
         add_note: Add a note to the application history
+        event: event

--- a/spec/system/prior_authority/send_back_spec.rb
+++ b/spec/system/prior_authority/send_back_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Send an application back', :stub_oauth_token do
 
       it 'shows my application' do
         expect(page).to have_content 'Application sent'
-        expect(page).to have_content 'Further information You forgot to say please'
+        expect(page).to have_content "Further information\nYou forgot to say please"
       end
 
       it 'shows the decision in the history' do

--- a/spec/system/prior_authority/view_applications_spec.rb
+++ b/spec/system/prior_authority/view_applications_spec.rb
@@ -286,10 +286,15 @@ RSpec.describe 'View applications' do
     before do
       application.data['further_information'] = [
         { caseworker_id: caseworker.id,
-          information_requested: 'Set the scene a little more',
-          information_supplied: 'It was a dark and stormy night',
+          information_requested: "Set the scene \na little more",
+          information_supplied: "It was a dark \nand stormy night",
           requested_at: DateTime.new(2023, 5, 2, 4, 3, 2),
-          documents: [{ file_name: 'example.pdf', file_path: 'some-file-on-amazon' }] }
+          documents: [{ file_name: 'example.pdf', file_path: 'some-file-on-amazon' }] },
+        { caseworker_id: caseworker.id,
+          information_requested: 'Next request',
+          information_supplied: 'Next response',
+          requested_at: DateTime.new(2023, 5, 3, 4, 3, 2),
+          documents: [] }
       ]
       application.update!(state: 'provider_updated', updated_at: DateTime.new(2023, 6, 5, 4, 3, 2))
       create(:event, :provider_updated,
@@ -314,6 +319,10 @@ RSpec.describe 'View applications' do
     it 'shows the updated date' do
       expect(page).to have_content 'Further information request 2 May 2023'
       expect(page).to have_content 'Date amended: 5 June 2023'
+    end
+
+    it 'shows RFIs in reverse order' do
+      expect(page).to have_text(/Next request.+Set the scene/m)
     end
   end
 end


### PR DESCRIPTION
## Description of change
- Reorder further information cards
- preserve paragraph breaks
- make sure there's a `br` between provider-provided text and first document link

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1012)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
