### PR TITLE
Reduce app store calls

### DIFF
--- a/app/controllers/sync_controller.rb
+++ b/app/controllers/sync_controller.rb
@@ -9,8 +9,7 @@ class SyncController < ApplicationController
   end
 
   def sync_individual
-    record = AppStoreClient.new.get_submission(params[:submission_id])
-    UpdateSubmission.call(record)
+    UpdateSubmission.call(params[:data].permit!.to_h)
     head :ok
   end
 

--- a/app/services/app_store_client.rb
+++ b/app/services/app_store_client.rb
@@ -2,12 +2,16 @@ class AppStoreClient
   include HTTParty
   headers 'Content-Type' => 'application/json'
 
-  def get_submission(submission_id)
-    process(:get, "/v1/application/#{submission_id}")
-  end
-
   def get_all_submissions(last_update)
-    process(:get, "/v1/applications?since=#{last_update.to_i}")
+    url = "/v1/applications?since=#{last_update.to_i}"
+    response = self.class.get "#{host}#{url}", **options
+
+    case response.code
+    when 200
+      JSON.parse(response.body)
+    else
+      raise "Unexpected response from AppStore - status #{response.code} for '#{url}'"
+    end
   end
 
   def update_submission(payload)
@@ -37,17 +41,6 @@ class AppStoreClient
   end
 
   private
-
-  def process(method, url)
-    response = self.class.public_send(method, "#{host}#{url}", **options)
-
-    case response.code
-    when 200
-      JSON.parse(response.body)
-    else
-      raise "Unexpected response from AppStore - status #{response.code} for '#{url}'"
-    end
-  end
 
   def options(payload = nil)
     options = payload ? { body: payload.to_json } : {}

--- a/spec/requests/sync_spec.rb
+++ b/spec/requests/sync_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Syncs' do
 
   describe 'POST /app_store_webhook' do
     let(:client) { instance_double(AppStoreClient) }
-    let(:record) { :record }
+    let(:record) { { 'foo' => 'bar' } }
 
     context 'when no auth token is provided' do
       it 'rejects all requests' do
@@ -31,15 +31,12 @@ RSpec.describe 'Syncs' do
           allow(AppStoreTokenProvider).to receive(:instance).and_return(token_provider)
           allow(token_provider).to receive(:authentication_configured?).and_return false
 
-          allow(AppStoreClient).to receive(:new).and_return(client)
-          allow(client).to receive(:get_submission).and_return(record)
           allow(UpdateSubmission).to receive(:call)
         end
 
         it 'triggers a sync' do
-          post '/app_store_webhook', params: { submission_id: '123' }, headers: { 'Authorization' => 'Bearer ABC' }
+          post '/app_store_webhook', params: { submission_id: '123', data: record }, headers: { 'Authorization' => 'Bearer ABC' }
           expect(response).to have_http_status(:ok)
-          expect(client).to have_received(:get_submission).with('123')
           expect(UpdateSubmission).to have_received(:call).with(record)
         end
       end
@@ -78,15 +75,12 @@ RSpec.describe 'Syncs' do
           allow(JWT::JWK::Set).to receive(:new).with('keys').and_return(jwks)
           allow(JWT).to receive(:decode).with('ABC', nil, true, { algorithms: 'RS256', jwks: jwks }).and_return(decoded)
 
-          allow(AppStoreClient).to receive(:new).and_return(client)
-          allow(client).to receive(:get_submission).and_return(record)
           allow(UpdateSubmission).to receive(:call)
         end
 
         it 'triggers a sync' do
-          post '/app_store_webhook', params: { submission_id: '123' }, headers: { 'Authorization' => 'Bearer ABC' }
+          post '/app_store_webhook', params: { submission_id: '123', data: record }, headers: { 'Authorization' => 'Bearer ABC' }
           expect(response).to have_http_status(:ok)
-          expect(client).to have_received(:get_submission).with('123')
           expect(UpdateSubmission).to have_received(:call).with(record)
         end
       end

--- a/spec/services/app_store_client_spec.rb
+++ b/spec/services/app_store_client_spec.rb
@@ -13,60 +13,6 @@ RSpec.describe AppStoreClient, :stub_oauth_token do
       .and_return(response)
   end
 
-  describe '#get_submission' do
-    context 'when APP_STORE_URL is present' do
-      before do
-        allow(ENV).to receive(:fetch).with('APP_STORE_URL', 'http://localhost:8000')
-                                     .and_return('http://some.url')
-      end
-
-      it 'get the claims to the specified URL' do
-        expect(described_class).to receive(:get).with("http://some.url/v1/application/#{claim.id}",
-                                                      headers: { authorization: 'Bearer test-bearer-token' })
-
-        subject.get_submission(claim.id)
-      end
-
-      context 'when authentication is not configured' do
-        before do
-          allow(ENV).to receive(:fetch).with('APP_STORE_TENANT_ID', nil).and_return(nil)
-        end
-
-        it 'gets the claims without headers' do
-          expect(described_class).to receive(:get)
-            .with("http://some.url/v1/application/#{claim.id}", headers: { 'X-Client-Type': 'caseworker' })
-
-          subject.get_submission(claim.id)
-        end
-      end
-    end
-
-    context 'when APP_STORE_URL is not present' do
-      it 'get the claims to default localhost url' do
-        expect(described_class).to receive(:get).with("http://localhost:8000/v1/application/#{claim.id}",
-                                                      headers: { authorization: 'Bearer test-bearer-token' })
-
-        subject.get_submission(claim.id)
-      end
-    end
-
-    context 'when response code is 200 - ok' do
-      it 'returns the parsed json' do
-        expect(subject.get_submission(claim.id)).to eq('some' => 'data')
-      end
-    end
-
-    context 'when response code is unexpected (neither 201 or 209)' do
-      let(:code) { 501 }
-
-      it 'raises and error' do
-        expect { subject.get_submission(claim.id) }.to raise_error(
-          "Unexpected response from AppStore - status 501 for '/v1/application/#{claim.id}'"
-        )
-      end
-    end
-  end
-
   describe '#get_all_submissions' do
     context 'when APP_STORE_URL is present' do
       before do


### PR DESCRIPTION
## Description of change
Use `params[:data]` instead of re-pulling the data via a GET request
This means we can remove the `get_submission` app store call entirely, as we never use it.