### PR TITLE
Stop converting to arrays for pagination

### DIFF
--- a/app/controllers/nsm/assessed_claims_controller.rb
+++ b/app/controllers/nsm/assessed_claims_controller.rb
@@ -1,7 +1,7 @@
 module Nsm
   class AssessedClaimsController < ApplicationController
     def index
-      @pagy, claims = pagy_array(Claim.decision_made)
+      @pagy, claims = pagy(Claim.decision_made)
       @claims = claims.map { |claim| BaseViewModel.build(:assessed_claims, claim) }
     end
   end

--- a/app/controllers/nsm/claims_controller.rb
+++ b/app/controllers/nsm/claims_controller.rb
@@ -1,7 +1,7 @@
 module Nsm
   class ClaimsController < ApplicationController
     def index
-      @pagy, claims = pagy_array(Claim.pending_decision)
+      @pagy, claims = pagy(Claim.pending_decision)
       @claims = claims.map { |claim| BaseViewModel.build(:all_claims, claim) }
     end
 

--- a/app/controllers/nsm/your_claims_controller.rb
+++ b/app/controllers/nsm/your_claims_controller.rb
@@ -2,7 +2,7 @@ module Nsm
   class YourClaimsController < ApplicationController
     def index
       claims = Claim.pending_and_assigned_to(current_user)
-      pagy, filtered_claims = pagy_array(claims)
+      pagy, filtered_claims = pagy(claims)
       your_claims = filtered_claims.map { |claim| BaseViewModel.build(:your_claims, claim) }
 
       render locals: { your_claims:, pagy: }


### PR DESCRIPTION
Didn't notice first time round that all the NSM code is using pagy_array instead of pagy