### PR TITLE
Only send emails if a flag is set

### DIFF
--- a/app/services/notify_app_store.rb
+++ b/app/services/notify_app_store.rb
@@ -7,7 +7,7 @@ class NotifyAppStore < ApplicationJob
     return unless trigger_email
 
     klass = "#{submission.namespace}::SubmissionFeedbackMailer".constantize
-    klass.notify(submission).deliver_later!
+    klass.notify(submission).deliver_later! if ENV.fetch('SEND_EMAILS', 'false') == 'true'
   end
 
   def notify(message_builder)

--- a/helm_deploy/templates/deployment-worker.yaml
+++ b/helm_deploy/templates/deployment-worker.yaml
@@ -167,6 +167,8 @@ spec:
                 secretKeyRef:
                   name: ordnance-survey
                   key: api-key
+            - name: SEND_EMAILS
+              value: 'true'
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm_deploy/templates/deployment.yaml
+++ b/helm_deploy/templates/deployment.yaml
@@ -185,6 +185,8 @@ spec:
               value: '{{ .Values.variables.enableSyncTriggerEndpoint }}'
             - name: ALLOW_INDEXING
               value: '{{ .Values.variables.allowIndexing }}'
+            - name: SEND_EMAILS
+              value: 'true'
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/spec/services/notify_app_store_spec.rb
+++ b/spec/services/notify_app_store_spec.rb
@@ -27,9 +27,20 @@ RSpec.describe NotifyAppStore do
       subject.perform(submission:)
     end
 
-    it 'queues an email' do
-      expect(Nsm::SubmissionFeedbackMailer).to receive_message_chain(:notify, :deliver_later!)
+    it 'does not queue an email' do
+      expect(Nsm::SubmissionFeedbackMailer).not_to receive(:notify)
       subject.perform(submission:)
+    end
+
+    context 'when email flag is set' do
+      before do
+        allow(ENV).to receive(:fetch).with('SEND_EMAILS', 'false').and_return 'true'
+      end
+
+      it 'queues an email' do
+        expect(Nsm::SubmissionFeedbackMailer).to receive_message_chain(:notify, :deliver_later!)
+        subject.perform(submission:)
+      end
     end
 
     context 'when emails should not be triggered' do


### PR DESCRIPTION
E2E tests are now failing because they are trying to send an email and failing. We need to be able _not_ to try to send an email.