### PR TITLE
CRM457-1284: Add assessment fakery

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -90,8 +90,6 @@ RSpec/MessageChain:
 RSpec/SpecFilePathFormat:
   Enabled: false
 
-
-
 Naming/VariableNumber:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -90,6 +90,8 @@ RSpec/MessageChain:
 RSpec/SpecFilePathFormat:
   Enabled: false
 
+
+
 Naming/VariableNumber:
   Enabled: false
 
@@ -98,7 +100,7 @@ Naming/VariableNumber:
 
 # To be tweaked until we find the right balance
 Metrics/MethodLength:
-  Max: 13
+  Max: 15
 
 Metrics/ClassLength:
   Max: 140
@@ -163,4 +165,8 @@ Rails/ActionControllerFlashBeforeRender:
   Enabled: false
 
 RSpec/FilePath:
+  Enabled: false
+
+# Occasionally it's useful to create big lists
+FactoryBot/ExcessiveCreateList:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'aws-sdk-s3', '~> 1.149'
 gem 'bootsnap', require: false
 gem 'cssbundling-rails'
 gem 'devise', '>= 4.9.4'
+gem 'faker'
 gem 'govuk-components'
 gem 'govuk_design_system_formbuilder'
 gem 'govuk_notify_rails', '~> 2.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,6 +185,8 @@ GEM
     factory_bot_rails (6.4.3)
       factory_bot (~> 6.4)
       railties (>= 5.0.0)
+    faker (3.3.1)
+      i18n (>= 1.8.11, < 2)
     faraday (2.9.0)
       faraday-net_http (>= 2.0, < 3.2)
     faraday-follow_redirects (0.3.0)
@@ -582,6 +584,7 @@ DEPENDENCIES
   dotenv-rails
   erb_lint
   factory_bot_rails
+  faker
   govuk-components
   govuk_design_system_formbuilder
   govuk_notify_rails (~> 2.2.0)

--- a/app/jobs/nsm/fake_assess.rb
+++ b/app/jobs/nsm/fake_assess.rb
@@ -32,12 +32,30 @@ module Nsm
     end
 
     def part_grant(claim)
+      adjust(claim)
+
       Nsm::MakeDecisionForm.new(
         claim: claim,
         current_user: User.first,
         partial_comment: Faker::Lorem.paragraph,
         state: 'part_grant'
       ).save
+    end
+
+    def adjust(claim)
+      items = BaseViewModel.build(:work_item, claim, 'work_items')
+      item = items.sample
+
+      form = WorkItemForm.new(
+        claim: claim,
+        item: item,
+        uplift: 0,
+        time_spent: Faker::Number.between(from: 1, to: 300),
+        explanation: Faker::Lorem.paragraph,
+        current_user: User.first,
+        id: item.id
+      )
+      form.save
     end
 
     def reject(claim)

--- a/app/jobs/nsm/fake_assess.rb
+++ b/app/jobs/nsm/fake_assess.rb
@@ -1,0 +1,70 @@
+module Nsm
+  class FakeAssess < ApplicationJob
+    def perform(claim_ids)
+      Claim.where(id: claim_ids)
+           .where.not(state: Nsm::MakeDecisionForm::STATES)
+           .find_each do |claim|
+        assess(claim)
+      end
+    end
+
+    def assess(claim)
+      case SecureRandom.rand(5)
+      when 0
+        grant(claim)
+      when 1
+        part_grant(claim)
+      when 2
+        reject(claim)
+      when 3
+        request_further_info(claim)
+      when 4
+        mark_provider_requested(claim)
+      else
+        raise 'Unexpected randomness outcome - did someone mess up a refactor?'
+      end
+    end
+
+    private
+
+    def grant(claim)
+      Nsm::MakeDecisionForm.new(claim: claim, current_user: User.first, state: 'granted').save
+    end
+
+    def part_grant(claim)
+      Nsm::MakeDecisionForm.new(
+        claim: claim,
+        current_user: User.first,
+        partial_comment: Faker::Lorem.paragraph,
+        state: 'part_grant'
+      ).save
+    end
+
+    def reject(claim)
+      Nsm::MakeDecisionForm.new(
+        claim: claim,
+        current_user: User.first,
+        reject_comment: Faker::Lorem.paragraph,
+        state: 'rejected'
+      ).save
+    end
+
+    def request_further_info(claim)
+      Nsm::SendBackForm.new(
+        claim: claim,
+        current_user: User.first,
+        state: 'further_info',
+        comment: Faker::Lorem.paragraph
+      ).save
+    end
+
+    def mark_provider_requested(claim)
+      Nsm::SendBackForm.new(
+        claim: claim,
+        current_user: User.first,
+        state: 'provider_requested',
+        comment: Faker::Lorem.paragraph
+      ).save
+    end
+  end
+end

--- a/app/jobs/prior_authority/fake_assess.rb
+++ b/app/jobs/prior_authority/fake_assess.rb
@@ -1,0 +1,87 @@
+module PriorAuthority
+  class FakeAssess < ApplicationJob
+    def perform(application_ids)
+      PriorAuthorityApplication.where(id: application_ids, state: PriorAuthorityApplication::ASSESSABLE_STATES)
+                               .find_each do |application|
+        assess(application)
+      end
+    end
+
+    def assess(application)
+      case SecureRandom.rand(5)
+      when 0
+        grant(application)
+      when 1
+        part_grant(application)
+      when 2
+        reject(application)
+      when 3
+        request_further_info(application)
+      when 4
+        request_correction(application)
+      else
+        raise 'Unexpected randomness outcome - did someone mess up a refactor?'
+      end
+    end
+
+    private
+
+    def grant(application)
+      PriorAuthority::DecisionForm.new(submission: application, current_user: User.first, pending_decision: 'granted').save
+    end
+
+    def part_grant(application)
+      adjust(application)
+
+      PriorAuthority::DecisionForm.new(
+        submission: application,
+        current_user: User.first,
+        pending_decision: 'part_grant',
+        pending_part_grant_explanation: Faker::Lorem.paragraph
+      ).save
+    end
+
+    def adjust(submission)
+      primary_quote = V1::Quote.build(:quote, submission, 'quotes').find(&:primary)
+      item = BaseViewModel.build(:service_cost, submission, 'quotes').find { _1.id == primary_quote.id }
+      current_user = User.first
+      form = ServiceCostForm.new(submission:, item:, current_user:, **item.form_attributes)
+      form.assign_attributes(
+        items: Faker::Number.between(from: 1, to: 6),
+        cost_per_item: Faker::Number.between(from: 1.0, to: 99.0).round(2),
+        period: Faker::Number.between(from: 1, to: 300),
+        cost_per_hour: Faker::Number.between(from: 1.0, to: 99.0).round(2),
+        explanation: Faker::Lorem.paragraph,
+      )
+
+      form.save
+    end
+
+    def reject(application)
+      PriorAuthority::DecisionForm.new(
+        submission: application,
+        current_user: User.first,
+        pending_decision: 'rejected',
+        pending_rejected_explanation: Faker::Lorem.paragraph
+      ).save
+    end
+
+    def request_further_info(application)
+      PriorAuthority::SendBackForm.new(
+        submission: application,
+        current_user: User.first,
+        updates_needed: ['further_information'],
+        further_information_explanation: Faker::Lorem.paragraph
+      ).save
+    end
+
+    def request_correction(application)
+      PriorAuthority::SendBackForm.new(
+        submission: application,
+        current_user: User.first,
+        updates_needed: ['incorrect_information'],
+        incorrect_information_explanation: Faker::Lorem.paragraph
+      ).save
+    end
+  end
+end

--- a/app/view_models/nsm/v1/details_of_claim.rb
+++ b/app/view_models/nsm/v1/details_of_claim.rb
@@ -13,7 +13,6 @@ module Nsm
         I18n.t(".nsm.claim_details.#{key}.title")
       end
 
-      # rubocop:disable Metrics/MethodLength
       def data
         [
           {
@@ -30,7 +29,6 @@ module Nsm
           }
         ]
       end
-      # rubocop:enable Metrics/MethodLength
 
       def rows
         { title:, data: }

--- a/app/view_models/nsm/v1/equality_details.rb
+++ b/app/view_models/nsm/v1/equality_details.rb
@@ -24,7 +24,6 @@ module Nsm
         ]
       end
 
-      # rubocop:disable Metrics/MethodLength
       def equality_answers
         return [] unless answer_equality.value == 'yes'
 
@@ -43,7 +42,6 @@ module Nsm
           }
         ]
       end
-      # rubocop:enable Metrics/MethodLength
 
       def rows
         { title:, data: }

--- a/lib/tasks/dummy_assessments.rake
+++ b/lib/tasks/dummy_assessments.rake
@@ -1,0 +1,15 @@
+namespace :dummy_assessments do
+  desc 'assess all pending assessments randomly'
+
+  task create: :environment do
+    PriorAuthorityApplication.where(state: PriorAuthorityApplication::ASSESSABLE_STATES)
+                             .find_in_batches(batch_size: 100) do |batch|
+      PriorAuthority::FakeAssess.perform_later(batch.map(&:id))
+    end
+
+    Claim.where.not(state: Nsm::MakeDecisionForm::STATES)
+         .find_in_batches(batch_size: 100) do |batch|
+      Nsm::FakeAssess.perform_later(batch.map(&:id))
+    end
+  end
+end

--- a/spec/jobs/nsm/fake_assess_spec.rb
+++ b/spec/jobs/nsm/fake_assess_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+RSpec.describe Nsm::FakeAssess do
+  subject { described_class.new }
+
+  let(:claim) { create(:claim, state: :submitted) }
+
+  context 'when harnessing randomness' do
+    before do
+      create(:caseworker)
+      allow(NotifyAppStore).to receive(:perform_later)
+      allow(SecureRandom).to receive(:rand).and_return random_choice
+      subject.perform([claim.id])
+    end
+
+    context 'when granting claims' do
+      let(:random_choice) { 0 }
+
+      context 'when claim is not assessable' do
+        let(:claim) { create(:claim, state: :rejected) }
+
+        it 'does not change the claim' do
+          expect(claim.reload.state).to eq 'rejected'
+        end
+      end
+
+      it 'marks as granted' do
+        expect(claim.reload.state).to eq 'granted'
+      end
+
+      it 'notifies the app store' do
+        expect(NotifyAppStore).to have_received(:perform_later).with(submission: claim)
+      end
+    end
+
+    context 'when part-granting claims' do
+      let(:random_choice) { 1 }
+
+      it 'marks as part-granted' do
+        expect(claim.reload.state).to eq 'part_grant'
+      end
+
+      it 'notifies the app store' do
+        expect(NotifyAppStore).to have_received(:perform_later).with(submission: claim)
+      end
+    end
+
+    context 'when rejecting claims' do
+      let(:random_choice) { 2 }
+
+      it 'marks as rejected' do
+        expect(claim.reload.state).to eq 'rejected'
+      end
+
+      it 'notifies the app store' do
+        expect(NotifyAppStore).to have_received(:perform_later).with(submission: claim)
+      end
+    end
+
+    context 'when sending back claims for further info' do
+      let(:random_choice) { 3 }
+
+      it 'marks as sent back' do
+        expect(claim.reload.state).to eq 'further_info'
+      end
+
+      it 'notifies the app store' do
+        expect(NotifyAppStore).to have_received(:perform_later).with(submission: claim)
+      end
+    end
+
+    context 'when sending back claims as provider requested' do
+      let(:random_choice) { 4 }
+
+      it 'marks as sent back' do
+        expect(claim.reload.state).to eq 'provider_requested'
+      end
+
+      it 'notifies the app store' do
+        expect(NotifyAppStore).to have_received(:perform_later).with(submission: claim)
+      end
+    end
+  end
+
+  context 'when randomness goes wrong' do
+    before { allow(SecureRandom).to receive(:rand).and_return 5 }
+
+    it 'raises an error' do
+      expect { subject.perform([claim.id]) }.to raise_error StandardError
+    end
+  end
+end

--- a/spec/jobs/prior_authority/fake_assess_spec.rb
+++ b/spec/jobs/prior_authority/fake_assess_spec.rb
@@ -1,0 +1,100 @@
+require 'rails_helper'
+
+RSpec.describe PriorAuthority::FakeAssess do
+  subject { described_class.new }
+
+  let(:application) { create(:prior_authority_application, state: :submitted) }
+
+  context 'when harnessing the power of randomness' do
+    before do
+      create(:caseworker)
+      allow(NotifyAppStore).to receive(:perform_later)
+      allow(SecureRandom).to receive(:rand).and_return random_choice
+      subject.perform([application.id])
+    end
+
+    context 'when granting applications' do
+      let(:random_choice) { 0 }
+
+      context 'when application is not assessable' do
+        let(:application) { create(:prior_authority_application, state: :rejected) }
+
+        it 'does not change the application' do
+          expect(application.reload).to be_rejected
+        end
+      end
+
+      it 'marks as granted' do
+        expect(application.reload).to be_granted
+      end
+
+      it 'notifies the app store' do
+        expect(NotifyAppStore).to have_received(:perform_later).with(submission: application)
+      end
+    end
+
+    context 'when part-granting applications' do
+      let(:random_choice) { 1 }
+
+      it 'marks as part-granted' do
+        expect(application.reload).to be_part_grant
+      end
+
+      it 'notifies the app store' do
+        expect(NotifyAppStore).to have_received(:perform_later).with(submission: application)
+      end
+    end
+
+    context 'when rejecting applications' do
+      let(:random_choice) { 2 }
+
+      it 'marks as rejected' do
+        expect(application.reload).to be_rejected
+      end
+
+      it 'notifies the app store' do
+        expect(NotifyAppStore).to have_received(:perform_later).with(submission: application)
+      end
+    end
+
+    context 'when sending back applications for further info' do
+      let(:random_choice) { 3 }
+
+      it 'marks as sent back' do
+        expect(application.reload).to be_sent_back
+      end
+
+      it 'adds a further information object' do
+        expect(application.reload.data['further_information'][0]).to be_present
+      end
+
+      it 'notifies the app store' do
+        expect(NotifyAppStore).to have_received(:perform_later).with(submission: application)
+      end
+    end
+
+    context 'when sending back applications for corrections' do
+      let(:random_choice) { 4 }
+
+      it 'marks as sent back' do
+        expect(application.reload).to be_sent_back
+      end
+
+      it 'specifies corrections needed' do
+        expect(application.reload.events.last['details']['updates_needed']).to include('incorrect_information')
+      end
+
+      it 'notifies the app store' do
+        expect(NotifyAppStore).to have_received(:perform_later).with(submission: application)
+      end
+    end
+  end
+
+  context 'when randomness goes wrong' do
+    before { allow(SecureRandom).to receive(:rand).and_return 5 }
+
+    it 'raises an error' do
+      expect { subject.perform([application.id]) }.to raise_error StandardError
+    end
+  end
+end

--- a/spec/lib/tasks/dummy_assessments_spec.rb
+++ b/spec/lib/tasks/dummy_assessments_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+describe 'dummy_assessments:', type: :task do
+  describe 'create' do
+    subject { Rake::Task['dummy_assessments:create'] }
+
+    before do
+      Rails.application.load_tasks if Rake::Task.tasks.empty?
+    end
+
+    after do
+      Rake::Task['dummy_assessments:create'].reenable
+    end
+
+    context 'when there is a submitted PA application' do
+      before do
+        create(:prior_authority_application, state: :submitted)
+      end
+
+      it 'enqueues a job' do
+        expect { subject.invoke }.to have_enqueued_job(PriorAuthority::FakeAssess)
+      end
+    end
+
+    context 'when there is a granted PA application' do
+      before do
+        create(:prior_authority_application, state: :granted)
+      end
+
+      it 'does not enqueue a job' do
+        expect { subject.invoke }.not_to have_enqueued_job(PriorAuthority::FakeAssess)
+      end
+    end
+
+    context 'when there are 150 submitted PA applications' do
+      before do
+        create_list(:prior_authority_application, 150, state: :submitted)
+      end
+
+      it 'enqueues 2 jobs' do
+        expect { subject.invoke }.to have_enqueued_job(PriorAuthority::FakeAssess).exactly(2).times
+      end
+    end
+
+    context 'when there is a submitted NSM claim' do
+      before do
+        create(:claim, state: :submitted)
+      end
+
+      it 'enqueues a job' do
+        expect { subject.invoke }.to have_enqueued_job(Nsm::FakeAssess)
+      end
+    end
+
+    context 'when there is a granted NSM claim' do
+      before do
+        create(:claim, state: :granted)
+      end
+
+      it 'does not enqueue a job' do
+        expect { subject.invoke }.not_to have_enqueued_job(Nsm::FakeAssess)
+      end
+    end
+
+    context 'when there are 150 submitted NSM claims' do
+      before do
+        create_list(:claim, 150, state: :submitted)
+      end
+
+      it 'enqueues 2 jobs' do
+        expect { subject.invoke }.to have_enqueued_job(Nsm::FakeAssess).exactly(2).times
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ SimpleCov.start 'rails' do
   add_filter 'spec/'
   add_filter 'gems/'
   add_filter 'config/'
+  add_filter 'lib/tasks/'
 
   add_filter 'app/presenters/claim_details/table.rb'
   add_filter 'app/jobs/application_job.rb'


### PR DESCRIPTION
## Description of change
Group assessable submissions into batches so that we don't have to worry about long-running jobs being interrupted
Randomise between all different outcomes

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1284)
