### PR TITLE
CRM457-1460: Hide send back button if claim is sent back

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -24,8 +24,12 @@ class Claim < Submission
     Nsm::MakeDecisionForm::STATES.exclude?(state)
   end
 
+  def sent_back?
+    Nsm::SendBackForm::STATES.include?(state)
+  end
+
   def display_state?
-    Nsm::SendBackForm::STATES.include?(state) || !editable?
+    sent_back? || !editable?
   end
 
   def formatted_claimed_total

--- a/app/views/shared/_claim_button_group.erb
+++ b/app/views/shared/_claim_button_group.erb
@@ -1,7 +1,9 @@
 <% if claim.editable? %>
   <div class="govuk-button-group">
     <%= govuk_button_link_to( t('.make_decision'), edit_nsm_claim_make_decision_path(claim), primary: true, data: { turbo: "false" }) %>
-    <%= govuk_button_link_to(t('.send_back'), edit_nsm_claim_send_back_path(claim), warning: true) %>
+    <% unless claim.sent_back? %>
+      <%= govuk_button_link_to(t('.send_back'), edit_nsm_claim_send_back_path(claim), warning: true) %>
+    <% end %>
     <%= govuk_button_link_to(t('.save_and_come_back'), nsm_your_claims_path, secondary: true) %>
   </div>
 <% end %>

--- a/spec/system/nsm/assessment_spec.rb
+++ b/spec/system/nsm/assessment_spec.rb
@@ -49,6 +49,15 @@ Rails.describe 'Assessment', :stub_oauth_token, :stub_update_claim do
   end
 
   context 'provider requested' do
+    context 'when claim is already sent back' do
+      before { claim.update(state: 'provider_requested') }
+
+      it 'does not give the option to send back again' do
+        visit nsm_claim_claim_details_path(claim)
+        expect(page).to have_no_content 'Send back to provider'
+      end
+    end
+
     it 'sends a notification' do
       visit nsm_claim_claim_details_path(claim)
       click_link_or_button 'Send back to provider'


### PR DESCRIPTION
## Description of change
Hide send back button if claim is sent back

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1460)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
