### PR TITLE
CRM457-1423: Move error messages and tie to a field if possible

### DIFF
--- a/app/forms/base_adjustment_form.rb
+++ b/app/forms/base_adjustment_form.rb
@@ -55,7 +55,11 @@ class BaseAdjustmentForm
   def data_changed
     return if data_has_changed?
 
-    errors.add(:base, :no_change)
+    errors.add(no_change_field, :no_change)
+  end
+
+  def no_change_field
+    :base
   end
 
   def explanation_required?

--- a/app/forms/nsm/disbursements_form.rb
+++ b/app/forms/nsm/disbursements_form.rb
@@ -36,6 +36,10 @@ module Nsm
       end
     end
 
+    def no_change_field
+      :total_cost_without_vat
+    end
+
     def new_total_cost_without_vat
       total_cost_without_vat == 'yes' ? 0 : item.original_total_cost_without_vat
     end

--- a/app/forms/nsm/letters_calls_form.rb
+++ b/app/forms/nsm/letters_calls_form.rb
@@ -55,6 +55,12 @@ module Nsm
       uplift == 'yes' ? 0 : item.original_uplift
     end
 
+    def no_change_field
+      return super if item.uplift?
+
+      :count
+    end
+
     def data_has_changed?
       count.to_s.strip != item.count.to_s ||
         (item.uplift? && item.uplift.zero? != (uplift == UPLIFT_RESET))

--- a/app/forms/nsm/work_item_form.rb
+++ b/app/forms/nsm/work_item_form.rb
@@ -37,6 +37,12 @@ module Nsm
 
     private
 
+    def no_change_field
+      return super if item.uplift?
+
+      :time_spent
+    end
+
     def selected_record
       @selected_record ||= claim.data['work_items'].detect do |row|
         row.fetch('id') == item.id

--- a/app/views/about/feedback/index.html.erb
+++ b/app/views/about/feedback/index.html.erb
@@ -2,13 +2,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Help us improve this service</h1>
-      <%= form_with model: @feedback, url: about_feedback_index_path do |f| %>
-        <%= f.govuk_error_summary %>
-        <%= f.govuk_email_field :user_email, label: { text: t('feedback.email_label') }, hint: { text: t('feedback.email_hint') } %>
-        <%= f.govuk_text_area :user_feedback ,label: { text: t('feedback.comment_label') }, hint: { text: t('feedback.comment_hint') },rows: 5 %>
-        <%= f.govuk_collection_radio_buttons :user_rating, Feedback::RATINGS, :first, :last, legend: { text: t('feedback.ratings_label'), size: 's' } %>
-        <%= f.govuk_submit( t('feedback.continue') ) %>
-      <% end %>
+    <%= form_with model: @feedback, url: about_feedback_index_path do |f| %>
+      <%= f.govuk_error_summary %>
+      <h1 class="govuk-heading-xl">Help us improve this service</h1>
+      <%= f.govuk_email_field :user_email, label: { text: t('feedback.email_label') }, hint: { text: t('feedback.email_hint') } %>
+      <%= f.govuk_text_area :user_feedback ,label: { text: t('feedback.comment_label') }, hint: { text: t('feedback.comment_hint') },rows: 5 %>
+      <%= f.govuk_collection_radio_buttons :user_rating, Feedback::RATINGS, :first, :last, legend: { text: t('feedback.ratings_label'), size: 's' } %>
+      <%= f.govuk_submit( t('feedback.continue') ) %>
+    <% end %>
   </div>
 </div>

--- a/app/views/nsm/change_risks/edit.html.erb
+++ b/app/views/nsm/change_risks/edit.html.erb
@@ -2,10 +2,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(risk) %>
     <h1 class="govuk-heading-xl"><%= t('.heading') %></h1>
     <p class="govuk-body"> <%= t('.current_risk', level: claim.risk) %></p>
     <%= form_with model: risk, url: edit_nsm_claim_change_risk_path(claim.id), method: :put do |f| %>
-      <%= govuk_error_summary(risk) %>
       <%= f.govuk_collection_radio_buttons :risk_level, risk.available_risks, :id, :level, legend: { text: t('.legend') } %>
       <%= f.govuk_text_area :explanation, label: { size: 'm' }, rows: 5 %>
       <%= f.govuk_submit t('.save_changes') do %>

--- a/app/views/nsm/disbursements/edit.html.erb
+++ b/app/views/nsm/disbursements/edit.html.erb
@@ -6,6 +6,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters">
+    <%= govuk_error_summary(form) %>
     <h1 class="govuk-heading-xl">
         <%= t('.heading') %>
     </h1>
@@ -27,7 +28,6 @@
 
     <div id='disbursement-adjustment-form'>
       <%= form_with model: form, url: nsm_claim_disbursement_path(claim.id, item.id), method: :put do |f| %>
-          <%= govuk_error_summary(form) %>
           <%= f.govuk_radio_buttons_fieldset(:total_cost_without_vat, legend: { size: 's' }) do %>
             <%= f.govuk_radio_button :total_cost_without_vat, 'yes' do %>
               <%= f.govuk_text_area :explanation, label: { size: 's' }, rows: 5 %>

--- a/app/views/nsm/letters_and_calls/edit.html.erb
+++ b/app/views/nsm/letters_and_calls/edit.html.erb
@@ -6,6 +6,7 @@
 
 <div class="govuk-grid-row" id="letters-and-calls-adjustment-container">
   <div class="govuk-grid-column-three-quarters">
+    <%= govuk_error_summary(form) %>
     <h1 class="govuk-heading-xl">
         <%= t('.heading', type: item.type_name) %>
     </h1>
@@ -22,7 +23,6 @@
 
     <h2 class="govuk-heading-l"><%= t('.laa_adjustments') %></h2>
     <%= form_with model: form, url: nsm_claim_letters_and_call_path(claim.id, item.type.value), method: :put do |f| %>
-      <%= govuk_error_summary(form) %>
       <% if item.uplift? %>
         <%= f.govuk_radio_buttons_fieldset(:uplift, legend: { size: 's' }) do %>
           <%= f.govuk_radio_button :uplift, 'yes' %>

--- a/app/views/nsm/letters_and_calls/uplifts/edit.html.erb
+++ b/app/views/nsm/letters_and_calls/uplifts/edit.html.erb
@@ -6,13 +6,13 @@
 
 <div class="govuk-grid-row" id="letters-and-calls-adjustment-container">
   <div class="govuk-grid-column-three-quarters">
+    <%= govuk_error_summary(form) %>
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-4"><%= t('.heading') %></h1>
   </div>
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-hint govuk-!-margin-bottom-4"><%= t('.warning') %></div>
 
     <%= form_with model: form, url: nsm_claim_letters_and_calls_uplift_path(claim.id), method: :put do |f| %>
-      <%= govuk_error_summary(form) %>
       <%= f.govuk_text_area :explanation, label: { size: 'm' }, rows: 5 %>
       <%= f.govuk_submit t('.remove_uplift') do %>
         <%= link_to t('shared.cancel'), nsm_claim_adjustments_path(claim, anchor: 'letters-and-calls-tab'), class: 'govuk-link', data: { turbo: 'false' } %>

--- a/app/views/nsm/make_decisions/edit.html.erb
+++ b/app/views/nsm/make_decisions/edit.html.erb
@@ -2,13 +2,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(decision) %>
     <h1 class="govuk-heading-xl"><%= t('.heading') %></h1>
   </div>
 </div>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: decision, url: nsm_claim_make_decision_path(claim_id: claim.id), method: :put, id: dom_id(decision) do |f| %>
-      <%= govuk_error_summary(decision) %>
       <%= f.govuk_radio_buttons_fieldset :state, legend: { size: 's' } do %>
         <%= f.govuk_radio_button :state, Nsm::MakeDecisionForm::GRANTED %>
         <%= f.govuk_radio_button :state, Nsm::MakeDecisionForm::PART_GRANT do %>

--- a/app/views/nsm/send_backs/edit.html.erb
+++ b/app/views/nsm/send_backs/edit.html.erb
@@ -2,13 +2,13 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(send_back) %>
     <h1 class="govuk-heading-xl"><%= t('.heading', defendant_name:) %></h1>
   </div>
 </div>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: send_back, url: nsm_claim_send_back_path(claim_id: claim.id), method: :put do |f| %>
-      <%= govuk_error_summary(send_back) %>
       <%= f.govuk_radio_buttons_fieldset :state, legend: { size: 's' } do %>
         <%= f.govuk_radio_button :state, Nsm::SendBackForm::FURTHER_INFO %>
         <%= f.govuk_radio_button :state, Nsm::SendBackForm::PROVIDER_REQUESTED %>

--- a/app/views/nsm/unassignments/edit.html.erb
+++ b/app/views/nsm/unassignments/edit.html.erb
@@ -2,6 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(unassignment) %>
     <h1 class="govuk-heading-xl"><%= t(".heading.#{unassignment.unassignment_user}", caseworker: unassignment.user.display_name) %></h1>
     <p class="govuk-body-m"><%= t('.hint') %></p>
   </div>
@@ -9,7 +10,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: unassignment, url: nsm_claim_unassignment_path(claim_id: claim.id), method: :put do |f| %>
-      <%= govuk_error_summary(unassignment) %>
       <%= f.govuk_text_area :comment, width: 'one-third', autocomplete: 'off', label: { size: 'm' } %>
 
       <%= f.govuk_submit(t('.submit')) do %>

--- a/app/views/nsm/work_items/edit.html.erb
+++ b/app/views/nsm/work_items/edit.html.erb
@@ -6,6 +6,7 @@
 
 <div class="govuk-grid-row" id="work-items-adjustment-container">
   <div class="govuk-grid-column-three-quarters">
+    <%= govuk_error_summary(form) %>
     <h1 class="govuk-heading-xl">
         <%= t('.heading') %>
     </h1>
@@ -23,7 +24,6 @@
 
     <h2 class="govuk-heading-l"><%= t('.laa_adjustments') %></h2>
     <%= form_with model: form, url: nsm_claim_work_item_path(claim.id, item.id), method: :put do |f| %>
-      <%= govuk_error_summary(form) %>
       <% if item.uplift? %>
         <%= f.govuk_radio_buttons_fieldset(:uplift, legend: { size: 's' }) do %>
           <%= f.govuk_radio_button :uplift, 'yes' %>

--- a/app/views/nsm/work_items/uplifts/edit.html.erb
+++ b/app/views/nsm/work_items/uplifts/edit.html.erb
@@ -6,13 +6,13 @@
 
 <div class="govuk-grid-row" id="work-items-adjustment-container">
   <div class="govuk-grid-column-three-quarters">
+    <%= govuk_error_summary(form) %>
     <h1 class="govuk-heading-xl govuk-!-margin-bottom-4"><%= t('.heading') %></h1>
   </div>
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-hint govuk-!-margin-bottom-4"><%= t('.warning') %></div>
 
     <%= form_with model: form, url: nsm_claim_work_items_uplift_path(claim.id), method: :put do |f| %>
-      <%= govuk_error_summary(form) %>
       <%= f.govuk_text_area :explanation, label: { size: 'm' }, rows: 5 %>
       <%= f.govuk_submit t('.remove_uplift') do %>
         <%= link_to t('shared.cancel'), nsm_claim_adjustments_path(claim, anchor: 'work-items-tab'), class: 'govuk-link', data: { turbo: 'false' } %>

--- a/app/views/prior_authority/additional_costs/edit.html.erb
+++ b/app/views/prior_authority/additional_costs/edit.html.erb
@@ -5,11 +5,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds" id="additional-cost-adjustment-container">
+    <%= govuk_error_summary(form) %>
     <h1 class="govuk-heading-xl"><%= t('.page_title', n: index + 1) %></h1>
     <p class="govuk-body"><%= t('.adjustment_blurb', service_type: t(submission.data['service_type'], scope: 'prior_authority.service_types')) %></h1>
 
     <%= form_with model: form, url: prior_authority_application_additional_cost_path(submission.id, item.id), method: :patch do |f| %>
-      <%= govuk_error_summary(form) %>
       <%= f.hidden_field(:unit_type, value: item.unit_type) %>
 
       <%= render 'cost_fields', form: f %>

--- a/app/views/prior_authority/decisions/new.html.erb
+++ b/app/views/prior_authority/decisions/new.html.erb
@@ -10,11 +10,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-
+    <%= govuk_error_summary(@form_object) %>
     <span class="govuk-caption-xl"><%= @form_object.summary.laa_reference %></span>
     <h1 class="govuk-heading-xl"><%= t('.page_title') %></h1>
     <%= form_with model: @form_object, url: prior_authority_application_decision_path(@form_object.summary.id) do |f| %>
-      <%= govuk_error_summary(@form_object) %>
       <%= f.govuk_radio_buttons_fieldset :pending_decision,
                                         legend: { size: 's', text: t('.pending_decision') },
                                         hint: { text: t('.pending_decision_hint') } do %>

--- a/app/views/prior_authority/manual_assignments/new.html.erb
+++ b/app/views/prior_authority/manual_assignments/new.html.erb
@@ -6,9 +6,9 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds" id="travel-cost-adjustment-container">
+    <%= govuk_error_summary(@form) %>
     <h1 class="govuk-heading-xl"><%= t('.page_title') %></h1>
     <%= form_with model: @form, url: prior_authority_application_manual_assignments_path(params[:application_id]) do |f| %>
-      <%= govuk_error_summary(@form) %>
       <%= f.govuk_text_area :comment,
                             label: { size: 's', text: t('.label') },
                             hint: { size: 's', text: t('.hint') } %>

--- a/app/views/prior_authority/send_backs/new.html.erb
+++ b/app/views/prior_authority/send_backs/new.html.erb
@@ -10,11 +10,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= govuk_error_summary(@form_object) %>
 
     <span class="govuk-caption-xl"><%= @form_object.summary.laa_reference %></span>
     <h1 class="govuk-heading-xl"><%= t('.page_title') %></h1>
     <%= form_with model: @form_object, url: prior_authority_application_send_back_path(@form_object.summary.id) do |f| %>
-      <%= govuk_error_summary(@form_object) %>
       <%= f.govuk_check_boxes_fieldset :updates_needed,
                                       legend: { size: 's', text: t('.which_updates') },
                                       hint: { text: t('.which_updates_hint') } do %>

--- a/app/views/prior_authority/service_costs/edit.html.erb
+++ b/app/views/prior_authority/service_costs/edit.html.erb
@@ -4,14 +4,13 @@
 
 <% title t('.page_title') %>
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds" id="service-cost-adjustment-container", data-turbo="false">
+  <div class="govuk-grid-column-two-thirds" id="service-cost-adjustment-container" data-turbo="false">
+    <%= govuk_error_summary(form) %>
     <h1 class="govuk-heading-xl"><%= t('.page_title') %></h1>
     <h2 class="govuk-heading-l"><%= t(submission.data['service_type'], scope: 'prior_authority.service_types') %></h2>
     <p class="govuk-body"><%= t('.adjustment_blurb', service_type: t(submission.data['service_type'], scope: 'prior_authority.service_types')) %></p>
 
     <%= form_with model: form, url: prior_authority_application_service_cost_path(submission.id, item.id), method: :patch do |f| %>
-      <%= govuk_error_summary(form) %>
-
       <%= f.hidden_field(:cost_type, value: item.cost_type) %>
       <%= f.hidden_field(:item_type, value: item.item_type) %>
 

--- a/app/views/prior_authority/travel_costs/edit.html.erb
+++ b/app/views/prior_authority/travel_costs/edit.html.erb
@@ -6,11 +6,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds" id="travel-cost-adjustment-container">
+    <%= govuk_error_summary(form) %>
     <h1 class="govuk-heading-xl"><%= t('.page_title') %></h1>
     <p class="govuk-body"><%= t('.adjustment_blurb', service_type: t(submission.data['service_type'], scope: 'prior_authority.service_types')) %></p>
 
     <%= form_with model: form, url: prior_authority_application_travel_cost_path(submission.id, item.id), method: :patch do |f| %>
-      <%= govuk_error_summary(form) %>
       <%= f.govuk_period_field :travel_time, legend: { text: t('.travel_time'), size: 's', class: 'govuk-!-font-weight-bold' }, width: 'one-third' %>
 
       <%= f.govuk_text_field  :travel_cost_per_hour,

--- a/app/views/prior_authority/unassignments/new.html.erb
+++ b/app/views/prior_authority/unassignments/new.html.erb
@@ -6,10 +6,10 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds" id="travel-cost-adjustment-container">
+    <%= govuk_error_summary(@form) %>
     <h1 class="govuk-heading-xl"><%= t('.page_title', caseworker: @form.caseworker_name) %></h1>
     <p><%= t('.paragraph') %></p>
     <%= form_with model: @form, url: prior_authority_application_unassignments_path(params[:application_id]) do |f| %>
-      <%= govuk_error_summary(@form) %>
       <%= f.govuk_text_area :comment,
                             label: { size: 's', text: t('.label') },
                             hint: { size: 's', text: t('.hint') } %>

--- a/config/locales/en/nsm/disbursements.yml
+++ b/config/locales/en/nsm/disbursements.yml
@@ -76,8 +76,8 @@ en:
         nsm/disbursements_form:
           attributes:
             base:
-              no_change: There are no changes to save. Select cancel if you do not want to make any changes.
             total_cost_without_vat:
               inclusion: Select an option
+              no_change: There are no changes to save. Select cancel if you do not want to make any changes.
             explanation:
               blank: Add an explanation for your decision

--- a/config/locales/en/nsm/letters_and_calls.yml
+++ b/config/locales/en/nsm/letters_and_calls.yml
@@ -119,6 +119,7 @@ en:
               no_change: The new number of letters cannot be the same as the number submitted by the provider
             count:
               blank: Enter the number of letters you want to change the total to
+              no_change: The new number of letters cannot be the same as the number submitted by the provider
               greater_than_or_equal_to: The number of letters must be 0 or more
               not_a_number: The number of letters must be a number
               not_an_integer: The number of letters must be a whole number
@@ -128,6 +129,7 @@ en:
               no_change: The new number of calls cannot be the same as the number submitted by the provider
             count:
               blank: Enter the number of calls you want to change the total to
+              no_change: The new number of calls cannot be the same as the number submitted by the provider
               greater_than_or_equal_to: The number of calls must be 0 or more
               not_a_number: The number of calls must be a number
               not_an_integer: The number of calls must be a whole number

--- a/config/locales/en/nsm/work_items.yml
+++ b/config/locales/en/nsm/work_items.yml
@@ -110,5 +110,6 @@ en:
               positive_minutes: Number of minutes must be 0 or more
               positive_hours: Number of hours must be 0 or more
               invalid: Something went wrong
+              no_change: The new time cannot be the same as the cost submitted by the provider
             explanation:
               blank: Add an explanaion for your decision

--- a/spec/forms/nsm/letters_calls_form_spec.rb
+++ b/spec/forms/nsm/letters_calls_form_spec.rb
@@ -81,6 +81,15 @@ RSpec.describe Nsm::LettersCallsForm do
         expect(subject.errors.of_kind?(:base, :no_change)).to be(true)
       end
 
+      context 'when there is no uplift to edit' do
+        let(:original_uplift) { nil }
+
+        it 'adds the error message to the one editable field' do
+          expect(subject).not_to be_valid
+          expect(subject.errors.of_kind?(:count, :no_change)).to be(true)
+        end
+      end
+
       context 'and explanation does not have an error' do
         let(:explanation) { '' }
 

--- a/spec/forms/nsm/work_item_form_spec.rb
+++ b/spec/forms/nsm/work_item_form_spec.rb
@@ -63,6 +63,15 @@ RSpec.describe Nsm::WorkItemForm do
         expect(subject.errors.of_kind?(:base, :no_change)).to be(true)
       end
 
+      context 'when there was no uplift originally' do
+        let(:original_uplift) { nil }
+
+        it 'marks the error on the only editable field' do
+          expect(subject).not_to be_valid
+          expect(subject.errors.of_kind?(:time_spent, :no_change)).to be(true)
+        end
+      end
+
       context 'and explanation does not have an error' do
         let(:explanation) { '' }
 

--- a/spec/system/nsm/disbursements_spec.rb
+++ b/spec/system/nsm/disbursements_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe 'Disbursements' do
     choose 'No'
     click_on 'Save changes'
     expect(page).to have_css('.govuk-error-summary__body',
-                             text: I18n.t("#{disbursement_form_error_message}.base.no_change"))
+                             text: I18n.t("#{disbursement_form_error_message}.total_cost_without_vat.no_change"))
   end
 
   context 'when claim has been assessed' do


### PR DESCRIPTION
## Description of change
- Move error summary to top of page across all forms
- Where we display a 'no change' error and there is only one field that is changeable, attach the error message to that field.

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1423)