### PR TITLE
CRM457-1463: Correct typo accessed -> assessed 

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -60,7 +60,7 @@ module ApplicationHelper
     end
   end
 
-  def accessed_colour(state)
+  def assessed_colour(state)
     {
       'granted' => 'green',
       'part-grant' => 'blue',

--- a/app/views/nsm/claims/_claim_summary.html.erb
+++ b/app/views/nsm/claims/_claim_summary.html.erb
@@ -2,7 +2,7 @@
     <div class="govuk-grid-column-two-thirds">
       <% if claim.display_state? %>
         <p>
-          <%= govuk_tag(text: t(".status_list.#{claim.state}"), colour: accessed_colour(claim.state)) %>
+          <%= govuk_tag(text: t(".status_list.#{claim.state}"), colour: assessed_colour(claim.state)) %>
         </p>
       <% end %>
       <p class="govuk-caption-xl">

--- a/config/locales/en/nsm/claims.yml
+++ b/config/locales/en/nsm/claims.yml
@@ -37,7 +37,7 @@ en:
           change: Change risk
         assigned_to: "Assigned to:"
         date_received: "Date received:"
-        date_assessed: Date accessed
+        date_assessed: Date assessed
         remove_from_list: Remove from list
         remove_from_yourlist: Remove from your list
     adjustments:

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -199,12 +199,12 @@ RSpec.describe ApplicationHelper, type: :helper do
     end
   end
 
-  describe '#accessed_colour' do
+  describe '#assessed_colour' do
     it 'returns the case based on the state' do
-      expect(helper.accessed_colour('granted')).to eq('green')
-      expect(helper.accessed_colour('part-grant')).to eq('blue')
-      expect(helper.accessed_colour('rejected')).to eq('red')
-      expect(helper.accessed_colour('other')).to eq('yellow')
+      expect(helper.assessed_colour('granted')).to eq('green')
+      expect(helper.assessed_colour('part-grant')).to eq('blue')
+      expect(helper.assessed_colour('rejected')).to eq('red')
+      expect(helper.assessed_colour('other')).to eq('yellow')
     end
   end
 

--- a/spec/view_models/nsm/v1/claim_summary_spec.rb
+++ b/spec/view_models/nsm/v1/claim_summary_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Nsm::V1::ClaimSummary do
     end
   end
 
-  describe '#accessed_on' do
+  describe '#assessed_on' do
     context 'when a decision has been made' do
       it 'returns the date from the last Decision event' do
         decision = create(:event, :decision)


### PR DESCRIPTION
## Description of change
Correct typo accessed -> assessed

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1463)
