### PR TITLE
CRM457-1467: Use rationals instead of decimals to deal with recurring decimal imprecision

### DIFF
--- a/app/view_models/nsm/v1/work_item.rb
+++ b/app/view_models/nsm/v1/work_item.rb
@@ -112,6 +112,9 @@ module Nsm
 
       def calculate_cost(original: false)
         scoped_uplift, scoped_time_spent = original ? [original_uplift, original_time_spent] : [uplift, time_spent]
+        # We need to use a Rational because some numbers divided by 60 cannot be accurately represented as a decimal,
+        # and when summing up multiple work items with sub-penny precision, those small inaccuracies can lead to
+        # a larger inaccuracy when the total is eventually rounded to 2 decimal places.
         Rational(pricing * scoped_time_spent * (100 + scoped_uplift.to_i), 100 * 60)
       end
 

--- a/app/view_models/nsm/v1/work_item.rb
+++ b/app/view_models/nsm/v1/work_item.rb
@@ -112,7 +112,7 @@ module Nsm
 
       def calculate_cost(original: false)
         scoped_uplift, scoped_time_spent = original ? [original_uplift, original_time_spent] : [uplift, time_spent]
-        pricing * scoped_time_spent * (100 + scoped_uplift.to_i) / 100 / 60
+        Rational(pricing * scoped_time_spent * (100 + scoped_uplift.to_i), 100 * 60)
       end
 
       def format(value, as: :pounds)

--- a/spec/view_models/nsm/v1/core_cost_summary_spec.rb
+++ b/spec/view_models/nsm/v1/core_cost_summary_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe Nsm::V1::CoreCostSummary do
         ]
       end
 
-      it 'summs them all together in profit costs' do
+      it 'sums them all together in profit costs' do
         expect(subject.table_fields[0]).to eq(
           {
             allowed_gross_cost: { numeric: true, text: '£170.00' },
@@ -203,6 +203,24 @@ RSpec.describe Nsm::V1::CoreCostSummary do
             net_cost: { numeric: true, text: '£60.00' },
             vat: { numeric: true, text: '£0.00' }
           }
+        )
+      end
+    end
+
+    context 'when dealing with figures involving recurring decimals' do
+      let(:work_items) do
+        Array.new(30) do
+          {
+            work_type: { value: 'advocacy', en: 'Advocacy' },
+            pricing: 45.35, time_spent: 175,
+          }
+        end
+      end
+
+      it 'sums them into profit costs' do
+        expect(subject.table_fields[0]).to include(
+          gross_cost: { numeric: true, text: '£3,968.13' },
+          name: { numeric: false, text: 'Profit costs', width: nil }
         )
       end
     end


### PR DESCRIPTION
## Description of change

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1467)
