### PR TITLE
Bump braces 3.0.2 to 3.0.3

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,10 +1,11 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.25.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
-ignore:
-  SNYK-JS-BRACES-6838727:
-    - '*':
-        reason: no fix; no impact
-        expires: 2099-01-01T00:00:00.000Z
-        created: 2024-05-14T06:44:55.382Z
+ignore: {}
+  # FIXED by bumping to braces@3.0.3
+  # SNYK-JS-BRACES-6838727:
+  #   - '*':
+  #       reason: no fix; no impact
+  #       expires: 2099-01-01T00:00:00.000Z
+  #       created: 2024-05-14T06:44:55.382Z
 patch: {}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "8.0.4",
     "@ministryofjustice/frontend": "^2.1.3",
-    "braces": "^3.0.3",
     "decimal.js": "^10.4.3",
     "esbuild": "^0.21.3",
     "govuk-frontend": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "8.0.4",
     "@ministryofjustice/frontend": "^2.1.3",
+    "braces": "3.0.3",
     "decimal.js": "^10.4.3",
     "esbuild": "^0.21.3",
     "govuk-frontend": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -6,12 +6,15 @@
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "8.0.4",
     "@ministryofjustice/frontend": "^2.1.3",
-    "braces": "3.0.3",
+    "braces": "^3.0.3",
     "decimal.js": "^10.4.3",
     "esbuild": "^0.21.3",
     "govuk-frontend": "^5.4.0",
     "jquery": "^3.6.0",
     "sass": "^1.77.2"
+  },
+  "resolutions": {
+    "sass/**/braces": "^3.0.3"
   },
   "scripts": {
     "unit-test": "jest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1390,6 +1390,13 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
+braces@3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
+  integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
+  dependencies:
+    fill-range "^7.1.1"
+
 braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
@@ -1641,6 +1648,13 @@ fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+  dependencies:
+    to-regex-range "^5.0.1"
+
+fill-range@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
+  integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
   dependencies:
     to-regex-range "^5.0.1"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1390,19 +1390,19 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"
   integrity sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==
 
-braces@3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
-  integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
-  dependencies:
-    fill-range "^7.1.1"
-
-braces@^3.0.2, braces@~3.0.2:
+braces@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+braces@^3.0.3, braces@~3.0.2:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
+  integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
+  dependencies:
+    fill-range "^7.1.1"
 
 browserslist@^4.22.2:
   version "4.22.2"


### PR DESCRIPTION
## Description of change
Bump braces 3.0.2 to 3.0.3 and unignore CVE warning

This fixes the CVE we currently ignore, designated
as SNYK-JS-BRACES-6838727.

## Notes for reviewer

If Snyk scan passes when the specific CVE is unignored then it is good to go. The snyk ignore has been left in as an example for future reference.
