### PR TITLE
CRM457-1551: Amend "Get next" logic

### DIFF
--- a/app/services/prior_authority/choose_application_for_assignment.rb
+++ b/app/services/prior_authority/choose_application_for_assignment.rb
@@ -7,10 +7,16 @@ module PriorAuthority
           CASE WHEN data->>'service_type' = 'pathologist_report' THEN 0 ELSE 1 END as pathologist_report
         SQL
 
+        date_order_clause = Arel.sql("DATE_TRUNC('day', app_store_updated_at) ASC")
+
         PriorAuthorityApplication.assignable(user)
                                  .select('submissions.*', criminal_court, pathologist_report)
-                                 .order(criminal_court: :asc, pathologist_report: :asc, app_store_updated_at: :asc)
-                                 .first
+                                 .order(
+                                   date_order_clause,
+                                   criminal_court: :asc,
+                                   pathologist_report: :asc,
+                                   app_store_updated_at: :asc
+                                 ).first
       end
     end
   end

--- a/spec/services/prior_authority/choose_application_for_assignment_spec.rb
+++ b/spec/services/prior_authority/choose_application_for_assignment_spec.rb
@@ -3,7 +3,15 @@ require 'rails_helper'
 RSpec.describe PriorAuthority::ChooseApplicationForAssignment do
   let(:user) { create(:caseworker) }
 
-  context 'when there is an older and a newer application' do
+  # Priority order should be as follows
+  # P1 - Oldest Date + Central Criminal Court (court type)
+  # P2 - Oldest Date + Pathologist (service type)
+  # P3 - Oldest Date
+  #
+
+  let(:a_date) { 1.day.ago }
+
+  context 'when there is an older and a newer application (P3)' do
     let(:newer_application) { create(:prior_authority_application, app_store_updated_at: 1.day.ago) }
     let(:older_application) { create(:prior_authority_application, app_store_updated_at: 2.days.ago) }
 
@@ -16,17 +24,17 @@ RSpec.describe PriorAuthority::ChooseApplicationForAssignment do
     end
   end
 
-  context 'when the newer application is a central criminal court case' do
+  context 'with two applications on same day where one is a central criminal court case (P1 + P3)' do
     let(:central_court_application) do
       create(:prior_authority_application,
-             created_at: 1.day.ago,
-                    data: build(:prior_authority_data, court_type: 'central_criminal_court'))
+             app_store_updated_at: a_date,
+             data: build(:prior_authority_data, court_type: 'central_criminal_court'))
     end
 
     let(:non_central_court_application) do
       create(:prior_authority_application,
-             created_at: 2.days.ago,
-                    data: build(:prior_authority_data, court_type: 'other'))
+             app_store_updated_at: a_date,
+             data: build(:prior_authority_data, court_type: 'other'))
     end
 
     before do
@@ -38,17 +46,84 @@ RSpec.describe PriorAuthority::ChooseApplicationForAssignment do
     end
   end
 
-  context 'when the newer application is a pathology case' do
+  context 'with two applications on different day where one is a central criminal court case (P1 + older P3)' do
+    let(:central_court_application) do
+      create(:prior_authority_application,
+             app_store_updated_at: 1.day.ago,
+             data: build(:prior_authority_data, court_type: 'central_criminal_court'))
+    end
+
+    let(:non_central_court_application) do
+      create(:prior_authority_application,
+             app_store_updated_at: 2.days.ago,
+             data: build(:prior_authority_data, court_type: 'other'))
+    end
+
+    before do
+      central_court_application && non_central_court_application
+    end
+
+    it 'prefers the older non criminal court case' do
+      expect(described_class.call(user)).to eq non_central_court_application
+    end
+  end
+
+  context 'with two central criminal court cases on the same day where one is older in time (P1 + bit older P1)' do
+    let(:central_court_application) do
+      create(:prior_authority_application,
+             app_store_updated_at: a_date,
+             data: build(:prior_authority_data, court_type: 'central_criminal_court'))
+    end
+
+    let(:older_central_court_application) do
+      create(:prior_authority_application,
+             app_store_updated_at: a_date - 1.minute,
+             data: build(:prior_authority_data, court_type: 'central_criminal_court'))
+    end
+
+    before do
+      # create older last to avoid false positives resulting from default DB ordering
+      central_court_application && older_central_court_application
+    end
+
+    it 'prefers the older criminal court case' do
+      expect(described_class.call(user)).to eq older_central_court_application
+    end
+  end
+
+  context 'with central criminal court case and "normal" case on same but normal is only a minute older (P1 + bit older P3)' do
+    let(:central_court_application) do
+      create(:prior_authority_application,
+             app_store_updated_at: a_date,
+             data: build(:prior_authority_data, court_type: 'central_criminal_court'))
+    end
+
+    let(:non_central_court_application) do
+      create(:prior_authority_application,
+             app_store_updated_at: a_date - 1.minute,
+             data: build(:prior_authority_data, court_type: 'other'))
+    end
+
+    before do
+      central_court_application && non_central_court_application
+    end
+
+    it 'prefers the little newer criminal court case' do
+      expect(described_class.call(user)).to eq central_court_application
+    end
+  end
+
+  context 'with two applications on same day where one is a pathologist report service case (P2 + P3)' do
     let(:pathology_application) do
       create(:prior_authority_application,
-             created_at: 1.day.ago,
-                    data: build(:prior_authority_data, service_type: 'pathologist_report'))
+             app_store_updated_at: a_date,
+             data: build(:prior_authority_data, service_type: 'pathologist_report'))
     end
 
     let(:non_pathology_application) do
       create(:prior_authority_application,
-             created_at: 2.days.ago,
-                    data: build(:prior_authority_data, service_type: 'other'))
+             app_store_updated_at: a_date,
+             data: build(:prior_authority_data, service_type: 'other'))
     end
 
     before do
@@ -60,17 +135,39 @@ RSpec.describe PriorAuthority::ChooseApplicationForAssignment do
     end
   end
 
-  context 'when there is a pathology case and a central court case' do
+  context 'with two applications on different day where one is a pathologist report service case (P2 + older P3)' do
     let(:pathology_application) do
       create(:prior_authority_application,
-             created_at: 1.day.ago,
-                    data: build(:prior_authority_data, service_type: 'pathologist_report'))
+             app_store_updated_at: 1.day.ago,
+             data: build(:prior_authority_data, service_type: 'pathologist_report'))
+    end
+
+    let(:non_pathology_application) do
+      create(:prior_authority_application,
+             app_store_updated_at: 2.days.ago,
+             data: build(:prior_authority_data, service_type: 'other'))
+    end
+
+    before do
+      pathology_application && non_pathology_application
+    end
+
+    it 'prefers the older case' do
+      expect(described_class.call(user)).to eq non_pathology_application
+    end
+  end
+
+  context 'with a pathology case and a central court case on the same day (P1 + P2)' do
+    let(:pathology_application) do
+      create(:prior_authority_application,
+             app_store_updated_at: a_date,
+             data: build(:prior_authority_data, service_type: 'pathologist_report'))
     end
 
     let(:central_court_application) do
       create(:prior_authority_application,
-             created_at: 2.days.ago,
-                    data: build(:prior_authority_data, court_type: 'central_criminal_court'))
+             app_store_updated_at: a_date,
+            data: build(:prior_authority_data, court_type: 'central_criminal_court'))
     end
 
     before do
@@ -79,6 +176,34 @@ RSpec.describe PriorAuthority::ChooseApplicationForAssignment do
 
     it 'prefers the central criminal court case' do
       expect(described_class.call(user)).to eq central_court_application
+    end
+  end
+
+  context 'with a pathology case, a central court case and older "normal" case (P1 + P2 + older P3)' do
+    let(:pathology_application) do
+      create(:prior_authority_application,
+             app_store_updated_at: a_date,
+             data: build(:prior_authority_data, service_type: 'pathologist_report'))
+    end
+
+    let(:central_court_application) do
+      create(:prior_authority_application,
+             app_store_updated_at: a_date,
+            data: build(:prior_authority_data, court_type: 'central_criminal_court'))
+    end
+
+    let(:non_special_application) do
+      create(:prior_authority_application,
+             app_store_updated_at: 2.days.ago,
+             data: build(:prior_authority_data, court_type: 'other', service_type: 'other'))
+    end
+
+    before do
+      pathology_application && central_court_application && non_special_application
+    end
+
+    it 'prefers the older case' do
+      expect(described_class.call(user)).to eq non_special_application
     end
   end
 end


### PR DESCRIPTION
## Description of change
Amend "Get next" logic

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1551)

Inline with BA request the priority order should be as follows:

P1 - Oldest Date + Central Criminal Court (court type)
P2 - Oldest Date + Pathologist (service type)
P3 - Oldest Date

Note that "Oldest date" is the day, but same Priority levels on
the same day will need to also consider time. Time only matters after day
and court type/service type considered.

Examples:
- with two P1's on same day but one is older in time (A) than a newer (B) then A comes first?
- with a P1 (or P2) plus a P3 on the same day where P3 is older in time the P1 comes first?
