### PR TITLE
CRM457-1549: Add "Back calculation" autogrant limits

### DIFF
--- a/db/migrate/20240308140314_create_autogrant_limits.csv
+++ b/db/migrate/20240308140314_create_autogrant_limits.csv
@@ -2,6 +2,7 @@ service,start_date,unit_type,max_units,max_rate_london,max_rate_non_london,trave
 A&E consultant,2012/12/2,per_hour,8,108.00,100.80,40.00,40.00,4
 Accident reconstruction,2012/12/2,per_hour,15,54.40,72.00,27.20,36.00,4
 Animal behaviourist,2012/12/2,per_hour,13,85,85,40,40,4
+Back calculation,2012/12/2,per_item,1,151.20,144.00,0,0,0
 Benefit expert,2012/12/2,per_hour,12,72.00,72.00,36.00,36.00,4
 Cardiologist,2012/12/2,per_hour,8,72.00,115.20,36.00,40.00,4
 Cell phone site analysis,2012/12/2,per_hour,30,72.00,72.00,36.00,36.00,4
@@ -59,6 +60,7 @@ Psychological report (Prison Law),2012/12/2,per_hour,16,72.00,93.60,36.00,40.00,
 A&E consultant,2022/9/30,per_hour,8,124.20,115.92,40.00,40.00,4
 Accident reconstruction,2022/9/30,per_hour,15,62.56,82.80,31.30,40.00,4
 Animal behaviourist,2022/9/30,per_hour,13,85,85,40.00,40.00,4
+Back calculation,2022/9/30,per_item,1,173.88,165.50,0,0,0
 Benefit expert,2022/9/30,per_hour,12,83.00,83.00,40.00,40.00,4
 Cardiologist,2022/9/30,per_hour,8,83.00,132.00,40.00,40.00,4
 Cell phone site analysis,2022/9/30,per_hour,30,83.00,83.00,40.00,40.00,4

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,19 +1,2 @@
-return unless ENV.fetch('ENV', 'local').in?(%w[development local])
-
-case_worker = User.find_or_initialize_by(email: 'case.worker@test.com')
-case_worker.update(
-  first_name: 'case',
-  last_name: 'worker',
-  role: 'caseworker',
-  auth_oid: SecureRandom.uuid,
-  auth_subject_id: SecureRandom.uuid,
-)
-
-case_worker = User.find_or_initialize_by(email: 'super.visor@test.com')
-case_worker.update(
-  first_name: 'super',
-  last_name: 'visor',
-  role: 'supervisor',
-  auth_oid: SecureRandom.uuid,
-  auth_subject_id: SecureRandom.uuid,
-)
+load Rails.root.join("db/seeds/caseworkers.rb")
+load Rails.root.join("db/seeds/autogrant_limits.rb")

--- a/db/seeds/autogrant_limits.rb
+++ b/db/seeds/autogrant_limits.rb
@@ -1,0 +1,16 @@
+require 'csv'
+
+def limits
+  file_name = Rails.root.join('db/migrate/20240308140314_create_autogrant_limits.csv')
+  limits = CSV.read(file_name, headers: true).map { _1.to_h }
+  limits.each do |limit|
+    limit['service'] = lookup_service(limit['service'])
+  end
+end
+
+def lookup_service(service_name)
+  @service_ids ||= I18n.t("prior_authority.service_types").to_h.invert
+  @service_ids.fetch(service_name)
+end
+
+AutograntLimit.upsert_all(limits, unique_by: [:service, :start_date])

--- a/db/seeds/caseworkers.rb
+++ b/db/seeds/caseworkers.rb
@@ -1,0 +1,19 @@
+return unless ENV.fetch('ENV', 'local').in?(%w[development local])
+
+case_worker = User.find_or_initialize_by(email: 'case.worker@test.com')
+case_worker.update(
+  first_name: 'case',
+  last_name: 'worker',
+  role: 'caseworker',
+  auth_oid: SecureRandom.uuid,
+  auth_subject_id: SecureRandom.uuid,
+)
+
+case_worker = User.find_or_initialize_by(email: 'super.visor@test.com')
+case_worker.update(
+  first_name: 'super',
+  last_name: 'visor',
+  role: 'supervisor',
+  auth_oid: SecureRandom.uuid,
+  auth_subject_id: SecureRandom.uuid,
+)


### PR DESCRIPTION
## Description of change
Add "Back calculation" autogrant limits

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1549)
[Related bug fix ticket](https://dsdmoj.atlassian.net/browse/CRM457-1582)

It has been agreed with the BA that it can be autogranted.
Only one item (per_item unit_type only) can ever be claimed
at a rate less than or equal to the specified london/non-london
rates. all other scenarios for this service type will not be autogranted.

~~This is a less than ideal solution for implementing
autogrant for this service type.~~

~~It's implementation is pending discussion because
the service type is an outlier in a number of respects~~

~~- It is is implemented in provider as a variable hourly or item
  base service type, requiring 2 autogrant limit records per service 
  and start date (which is unique to this service)~~

~~- Only one (hour or item) can ever be claimed at a specific rate but the
  autogrant limit mechanism currently works on a "less than or equal"
  basis.~~

## Notes for reviewer
There should be 118 autogrant limits on this branch if seeding succeeded. spoiler it did.

This switches from using migrations for data creation/updating to using seeds. This is more idiomatic IMO and handles this [bug](https://dsdmoj.atlassian.net/browse/CRM457-1582) that occurs due to our branch builder setup

