### PR TITLE
Store incorrect info to allow for historic event to be captured

### DIFF
--- a/app/views/prior_authority/applications/show.html.erb
+++ b/app/views/prior_authority/applications/show.html.erb
@@ -38,6 +38,7 @@
               <%= link_to t('.further_information_provided'), '#further-information-1', class: "govuk-link--no-visited-state" %>
             </li>
           <% end %>
+
           <% @details.updated_fields.each do |field| %>
             <li>
               <%= link_to t(".updated_field", field: t(".updated_fields.#{field[:label]}", n: field[:n])), field[:anchor], class: "govuk-link--no-visited-state" %>

--- a/config/locales/en/prior_authority/applications.yml
+++ b/config/locales/en/prior_authority/applications.yml
@@ -33,7 +33,8 @@ en:
         provider_updated: Provider updated %{date}
         further_information: 'Further information:'
         incorrect_information: 'Incorrect information:'
-        further_information_provided: 'Further information'
+        further_information_provided: 'Further information request'
+        amendment_request: Amendment request
         updated_field: '%{field} - updated'
         updated_fields:
           ufn: Application details

--- a/spec/forms/prior_authority/send_back_form_spec.rb
+++ b/spec/forms/prior_authority/send_back_form_spec.rb
@@ -97,6 +97,7 @@ RSpec.describe PriorAuthority::SendBackForm do
           expect(submission.data['updates_needed']).to include('further_information')
           expect(submission.data['further_information_explanation']).to eq further_information_explanation
           expect(submission.data['further_information'][0]['caseworker_id']).to eq user.id
+          expect(submission.data['incorrect_information']).to be_nil
         end
 
         it 'sets a resubmission deadline' do
@@ -141,6 +142,7 @@ RSpec.describe PriorAuthority::SendBackForm do
         it 'stores information' do
           expect(submission.data['updates_needed']).to include('incorrect_information')
           expect(submission.data['incorrect_information_explanation']).to eq incorrect_information_explanation
+          expect(submission.data['incorrect_information'][0]['caseworker_id']).to eq user.id
           expect(submission.data['further_information']).to be_nil
         end
 


### PR DESCRIPTION
## Description of change
So we want to show historic incorrect info requests and stuff.. but we don;t currently get this back from provider...

This is the first change to send the data in an array instead of just the message - it will work very similarly to further info requests

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1556)
