### PR TITLE
CRM457-1565: Add subheadings in email for further info and incorrect info

### DIFF
--- a/app/mailers/prior_authority/feedback_messages/further_information_request_feedback.rb
+++ b/app/mailers/prior_authority/feedback_messages/further_information_request_feedback.rb
@@ -22,7 +22,19 @@ module PriorAuthority
       protected
 
       def comments
-        [incorrect_information_explanation, further_information_explanation].compact_blank.join("\n\n")
+        comments = []
+
+        if incorrect_information_explanation.present?
+          comments << "## #{I18n.t('prior_authority.send_backs.show.incorrect_information')}"
+          comments << incorrect_information_explanation
+        end
+
+        if further_information_explanation.present?
+          comments << "## #{I18n.t('prior_authority.send_backs.show.further_information')}"
+          comments << further_information_explanation
+        end
+
+        comments.compact_blank.join("\n\n")
       end
 
       def incorrect_information_explanation

--- a/app/mailers/prior_authority/feedback_messages/further_information_request_feedback.rb
+++ b/app/mailers/prior_authority/feedback_messages/further_information_request_feedback.rb
@@ -24,14 +24,14 @@ module PriorAuthority
       def comments
         comments = []
 
-        if incorrect_information_explanation.present?
-          comments << "## #{I18n.t('prior_authority.send_backs.show.incorrect_information')}"
-          comments << incorrect_information_explanation
-        end
-
         if further_information_explanation.present?
           comments << "## #{I18n.t('prior_authority.send_backs.show.further_information')}"
           comments << further_information_explanation
+        end
+
+        if incorrect_information_explanation.present?
+          comments << "## #{I18n.t('prior_authority.send_backs.show.incorrect_information')}"
+          comments << incorrect_information_explanation
         end
 
         comments.compact_blank.join("\n\n")

--- a/spec/mailers/prior_authority/feedback_messages/further_information_request_feeback_spec.rb
+++ b/spec/mailers/prior_authority/feedback_messages/further_information_request_feeback_spec.rb
@@ -65,10 +65,11 @@ RSpec.describe PriorAuthority::FeedbackMessages::FurtherInformationRequestFeedba
 
       it 'has expected content' do
         expect(feedback.contents).to include(
-          caseworker_information_requested: "## Amendment request\n\n" \
-                                            "Please correct this information...\n\n" \
-                                            "## Further information request\n\n" \
-                                            'Please provide this further info...',
+          caseworker_information_requested:
+            "## Further information request\n\n" \
+            "Please provide this further info...\n\n" \
+            "## Amendment request\n\n" \
+            'Please correct this information...' \
         )
       end
     end
@@ -80,7 +81,7 @@ RSpec.describe PriorAuthority::FeedbackMessages::FurtherInformationRequestFeedba
       it 'has expected content' do
         expect(feedback.contents).to include(
           caseworker_information_requested: "## Amendment request\n\n" \
-                                            'Please correct this information...',
+                                            'Please correct this information...'
         )
 
         expect(feedback.contents).not_to include('Amendment request')
@@ -94,7 +95,7 @@ RSpec.describe PriorAuthority::FeedbackMessages::FurtherInformationRequestFeedba
       it 'has expected content' do
         expect(feedback.contents).to include(
           caseworker_information_requested: "## Further information request\n\n" \
-                                            'Please provide this further info...',
+                                            'Please provide this further info...'
         )
 
         expect(feedback.contents).not_to include('Further information request')

--- a/spec/mailers/prior_authority/feedback_messages/further_information_request_feeback_spec.rb
+++ b/spec/mailers/prior_authority/feedback_messages/further_information_request_feeback_spec.rb
@@ -65,7 +65,9 @@ RSpec.describe PriorAuthority::FeedbackMessages::FurtherInformationRequestFeedba
 
       it 'has expected content' do
         expect(feedback.contents).to include(
-          caseworker_information_requested: "Please correct this information...\n\n" \
+          caseworker_information_requested: "## Amendment request\n\n" \
+                                            "Please correct this information...\n\n" \
+                                            "## Further information request\n\n" \
                                             'Please provide this further info...',
         )
       end
@@ -77,8 +79,11 @@ RSpec.describe PriorAuthority::FeedbackMessages::FurtherInformationRequestFeedba
 
       it 'has expected content' do
         expect(feedback.contents).to include(
-          caseworker_information_requested: 'Please correct this information...',
+          caseworker_information_requested: "## Amendment request\n\n" \
+                                            'Please correct this information...',
         )
+
+        expect(feedback.contents).not_to include('Amendment request')
       end
     end
 
@@ -88,8 +93,11 @@ RSpec.describe PriorAuthority::FeedbackMessages::FurtherInformationRequestFeedba
 
       it 'has expected content' do
         expect(feedback.contents).to include(
-          caseworker_information_requested: 'Please provide this further info...',
+          caseworker_information_requested: "## Further information request\n\n" \
+                                            'Please provide this further info...',
         )
+
+        expect(feedback.contents).not_to include('Further information request')
       end
     end
   end

--- a/spec/mailers/prior_authority/submission_feedback_mailer_spec.rb
+++ b/spec/mailers/prior_authority/submission_feedback_mailer_spec.rb
@@ -133,10 +133,10 @@ RSpec.describe PriorAuthority::SubmissionFeedbackMailer, type: :mailer do
     let(:date_to_respond_by) { 14.days.from_now.to_fs(:stamp) }
 
     let(:caseworker_information_requested) do
-      "## Amendment request\n\n" \
-        "Please correct this information...\n\n" \
-        "## Further information request\n\n" \
-        'Please provide this further info...'
+      "## Further information request\n\n" \
+        "Please provide this further info...\n\n" \
+        "## Amendment request\n\n" \
+        'Please correct this information...' \
     end
 
     let(:application) do

--- a/spec/mailers/prior_authority/submission_feedback_mailer_spec.rb
+++ b/spec/mailers/prior_authority/submission_feedback_mailer_spec.rb
@@ -133,7 +133,9 @@ RSpec.describe PriorAuthority::SubmissionFeedbackMailer, type: :mailer do
     let(:date_to_respond_by) { 14.days.from_now.to_fs(:stamp) }
 
     let(:caseworker_information_requested) do
-      "Please correct this information...\n\n" \
+      "## Amendment request\n\n" \
+        "Please correct this information...\n\n" \
+        "## Further information request\n\n" \
         'Please provide this further info...'
     end
 


### PR DESCRIPTION
## Description of change
CRM457-1565: Add subheadings in email for further info and incorrect info

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1565)

So providers/recipients can clearly tell what is requested
of them. Inline with content design QA reviews.

## Notes for reviewer

### After changes:

![Screenshot 2024-06-03 at 15 44 39](https://github.com/ministryofjustice/laa-assess-crime-forms/assets/7016425/4c0f1b0c-1e4f-4540-a166-8e9eb4a77465)


## How to manually test the feature
submit a PA with your email as a contact, in caseworker assign and "Send back to provider", select further info and amendment request.
