### PR TITLE
CRM457-1549: ensure seeds are run on hosted envs

### DIFF
--- a/db/migrate/20240605125438_seed_autogrant_limits.rb
+++ b/db/migrate/20240605125438_seed_autogrant_limits.rb
@@ -1,0 +1,5 @@
+class SeedAutograntLimits < ActiveRecord::Migration[7.1]
+  def up
+    load Rails.root.join("db/seeds/autogrant_limits.rb")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_13_123836) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_05_125438) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 cd /usr/src/app
 
-bundle exec bin/rails db:prepare db:seed && bundle exec pumactl -F config/puma.rb start
+bundle exec bin/rails db:prepare && bundle exec pumactl -F config/puma.rb start

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 cd /usr/src/app
 
-bundle exec bin/rails db:prepare && bundle exec pumactl -F config/puma.rb start
+bundle exec bin/rails db:prepare db:seed && bundle exec pumactl -F config/puma.rb start


### PR DESCRIPTION
## Description of change
Run seeds on deploy 

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1549)

For DEV branches db:prepare will run seeds when it first creates the database, but not thereafter. hosted envs will never run db:seeds as part of db:prepare so we add it explcitly. For local development we add amigration just to ensure developers have latest seeds locally. Seeds are idempotent so this should not matter.

- Run seeds on app start for hosted environments
- Add migration to [re]seed autogrant limits locally

## Notes for reviewer
Instead of the migration we could instead rely on developers to run db:seeds themselves locally but i quite like have the migration for historical reasons.
