### PR TITLE
CRM457-1597: Allow zero times

### DIFF
--- a/app/forms/prior_authority/base_cost_adjustment_form.rb
+++ b/app/forms/prior_authority/base_cost_adjustment_form.rb
@@ -16,7 +16,7 @@ module PriorAuthority
     end
 
     with_options if: :per_hour? do
-      validates :period, presence: true, time_period: true
+      validates :period, presence: true, time_period: { allow_zero: true }
       validates :cost_per_hour, presence: true, numericality: { greater_than: 0 }, is_a_number: true
     end
 

--- a/app/forms/prior_authority/base_cost_adjustment_form.rb
+++ b/app/forms/prior_authority/base_cost_adjustment_form.rb
@@ -11,7 +11,7 @@ module PriorAuthority
     attribute :cost_per_hour, :gbp
 
     with_options if: :per_item? do
-      validates :items, item_type_dependant: { pluralize: true }
+      validates :items, item_type_dependant: { pluralize: true, allow_zero: true }
       validates :cost_per_item, item_type_dependant: true
     end
 

--- a/app/forms/prior_authority/travel_cost_form.rb
+++ b/app/forms/prior_authority/travel_cost_form.rb
@@ -6,7 +6,7 @@ module PriorAuthority
     attribute :travel_time, :time_period
     attribute :travel_cost_per_hour, :gbp
 
-    validates :travel_time, presence: true, time_period: true
+    validates :travel_time, presence: true, time_period: { allow_zero: true }
     validates :travel_cost_per_hour, presence: true, numericality: { greater_than: 0 }, is_a_number: true
 
     validates :explanation, presence: true, if: :explanation_required?

--- a/app/validators/item_type_dependant_validator.rb
+++ b/app/validators/item_type_dependant_validator.rb
@@ -1,14 +1,15 @@
 class ItemTypeDependantValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     item_type = item_type_for(record)
-    item_type = item_type.pluralize if options[:pluralize]
 
     record.errors.add(attribute, :blank, item_type:) if value.blank?
     record.errors.add(attribute, :not_a_number, item_type:) if value.is_a?(String)
-    record.errors.add(attribute, :greater_than, item_type:) if value.to_i <= 0
+    record.errors.add(attribute, :greater_than, item_type:) if value.to_i.negative?
+    record.errors.add(attribute, :greater_than, item_type:) if value.to_i.zero? && !options[:allow_zero]
   end
 
   def item_type_for(record)
-    record.respond_to?(:item_type) ? record.item_type || 'item' : 'item'
+    basic = record.respond_to?(:item_type) ? record.item_type || 'item' : 'item'
+    options[:pluralize] ? basic.pluralize : basic
   end
 end

--- a/app/view_models/prior_authority/v1/application_details/primary_quote_card.rb
+++ b/app/view_models/prior_authority/v1/application_details/primary_quote_card.rb
@@ -15,7 +15,9 @@ module PriorAuthority
         def table_rows
           rows = [[service_label, base_units, base_cost_per_unit, formatted_base_cost]]
 
-          rows << [travel_label, travel_units, travel_cost_per_unit, formatted_travel_cost] if quote.travel_costs.positive?
+          if quote.travel_costs(original: true).positive?
+            rows << [travel_label, travel_units, travel_cost_per_unit, formatted_travel_cost]
+          end
 
           rows + quote.additional_costs.map do |additional_cost|
             additional_cost_row(additional_cost)

--- a/app/views/prior_authority/adjustments/index.html.erb
+++ b/app/views/prior_authority/adjustments/index.html.erb
@@ -13,7 +13,7 @@
     <%= render 'key_information_card', model: @key_information.key_information_card %>
     <%= render 'service_costs', application_summary:, application:, editable: %>
 
-    <% if application_summary.primary_quote.travel_costs.positive? %>
+    <% if application_summary.primary_quote.travel_costs(original: true).positive? %>
       <%= render 'travel_costs', application_summary:, application:, editable: %>
     <% end %>
 

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -23,7 +23,7 @@ en:
     not_a_number: The cost per %{item_type} must be a number, like 25
   shared_items_errors: &shared_items_errors
     blank: Enter the number of %{item_type}
-    greater_than: The number of %{item_type} must be more than 0
+    greater_than: The number of %{item_type} must be 0 or more
     not_a_number: The number of %{item_type} must be a number, like 25
 
   errors:

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -5,9 +5,9 @@ en:
     blank_hours: Enter number of hours
     blank_minutes: Enter number of minutes
     invalid: Time must be valid
-    invalid_hours: Hours must be greater than 0
+    invalid_hours: Hours must be 0 or more
     invalid_minutes: Minutes must be between 0 and 59
-    invalid_period: Time must be more than 0
+    invalid_period: Time must be 0 or more
     non_integer_hours: The number of hours must be a whole number
     non_integer_minutes: The number of minutes must be a whole number
     non_numerical_hours: The number of hours must be a number

--- a/spec/system/prior_authority/adjust_additional_costs_spec.rb
+++ b/spec/system/prior_authority/adjust_additional_costs_spec.rb
@@ -144,12 +144,12 @@ RSpec.describe 'Adjust additional costs' do
         .to have_content('Enter the number of items')
         .and have_content('Enter the cost per item')
 
-      fill_in 'Number of items', with: 0
+      fill_in 'Number of items', with: '-1'
       fill_in 'What is the cost per item?', with: 0
 
       click_on 'Save changes'
       expect(page)
-        .to have_content('The number of items must be more than 0')
+        .to have_content('The number of items must be 0 or more')
         .and have_content('The cost per item must be more than 0')
 
       fill_in 'Number of items', with: 'a'

--- a/spec/system/prior_authority/adjust_service_costs_spec.rb
+++ b/spec/system/prior_authority/adjust_service_costs_spec.rb
@@ -203,12 +203,12 @@ RSpec.describe 'Adjust service costs' do
         .to have_content('Enter the number of minutes')
         .and have_content('Enter the cost per minute')
 
-      fill_in 'Number of minutes', with: 0
+      fill_in 'Number of minutes', with: '-1'
       fill_in 'What is the cost per minute?', with: 0
 
       click_on 'Save changes'
       expect(page)
-        .to have_content('The number of minutes must be more than 0')
+        .to have_content('The number of minutes must be 0 or more')
         .and have_content('The cost per minute must be more than 0')
 
       fill_in 'Number of minutes', with: 'a'

--- a/spec/validators/item_type_dependant_validator_spec.rb
+++ b/spec/validators/item_type_dependant_validator_spec.rb
@@ -3,7 +3,11 @@ require 'rails_helper'
 RSpec.describe ItemTypeDependantValidator do
   subject(:instance) { klass.new(items:, cost_per_item:) }
 
+  let(:items_options) { { pluralize: true } }
   let(:klass) do
+    # needs to be a local variable to allow use in class definition block
+    options = items_options
+
     Class.new do
       include ActiveModel::Model
       include ActiveModel::Attributes
@@ -15,7 +19,7 @@ RSpec.describe ItemTypeDependantValidator do
       attribute :items
       attribute :cost_per_item, :gbp
 
-      validates :items, item_type_dependant: { pluralize: true }
+      validates :items, item_type_dependant: options
       validates :cost_per_item, item_type_dependant: true
     end
   end
@@ -56,7 +60,7 @@ RSpec.describe ItemTypeDependantValidator do
     end
   end
 
-  context 'when attribute is less zero or less' do
+  context 'when attribute is zero or' do
     let(:items) { 0 }
     let(:cost_per_item) { 0 }
 
@@ -64,6 +68,16 @@ RSpec.describe ItemTypeDependantValidator do
       expect(instance).not_to be_valid
       expect(instance.errors.of_kind?(:items, :greater_than)).to be(true)
       expect(instance.errors.of_kind?(:cost_per_item, :greater_than)).to be(true)
+    end
+
+    context 'when allow_zero is true' do
+      let(:items_options) { { pluralize: true, allow_zero: true } }
+
+      it 'adds no greater_than error to items' do
+        expect(instance).not_to be_valid
+        expect(instance.errors.of_kind?(:items, :greater_than)).to be(false)
+        expect(instance.errors.of_kind?(:cost_per_item, :greater_than)).to be(true)
+      end
     end
   end
 


### PR DESCRIPTION
## Description of change
- Travel time and additional cost time can be set to zero by caseworkers
- If travel time was positive but is now zero, still show the travel cost data on overview and adjustment screens
- Fix error messaging so that we only show 'must be more than zero' if zero is not allowed.

 [Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1597)
