### PR TITLE
Remove coverage skip in CostItemTypeDependantValidator

### DIFF
--- a/app/forms/prior_authority/base_cost_adjustment_form.rb
+++ b/app/forms/prior_authority/base_cost_adjustment_form.rb
@@ -11,7 +11,7 @@ module PriorAuthority
     attribute :cost_per_hour, :gbp
 
     with_options if: :per_item? do
-      validates :items, item_type_dependant: { pluralize: true, allow_zero: true }
+      validates :items, item_type_dependant: { allow_zero: true }
       validates :cost_per_item, cost_item_type_dependant: true
     end
 

--- a/app/validators/cost_item_type_dependant_validator.rb
+++ b/app/validators/cost_item_type_dependant_validator.rb
@@ -10,7 +10,6 @@ class CostItemTypeDependantValidator < ActiveModel::EachValidator
   end
 
   def cost_item_type_for(record)
-    basic = record.respond_to?(:cost_item_type) ? record.cost_item_type || 'item' : 'item'
-    options[:pluralize] ? basic.pluralize : basic
+    record.respond_to?(:cost_item_type) ? record.cost_item_type || 'item' : 'item'
   end
 end

--- a/app/validators/cost_item_type_dependant_validator.rb
+++ b/app/validators/cost_item_type_dependant_validator.rb
@@ -10,9 +10,7 @@ class CostItemTypeDependantValidator < ActiveModel::EachValidator
   end
 
   def cost_item_type_for(record)
-    # :nocov:
     basic = record.respond_to?(:cost_item_type) ? record.cost_item_type || 'item' : 'item'
     options[:pluralize] ? basic.pluralize : basic
-    # :nocov:
   end
 end

--- a/app/validators/item_type_dependant_validator.rb
+++ b/app/validators/item_type_dependant_validator.rb
@@ -10,6 +10,6 @@ class ItemTypeDependantValidator < ActiveModel::EachValidator
 
   def item_type_for(record)
     basic = record.respond_to?(:item_type) ? record.item_type || 'item' : 'item'
-    options[:pluralize] ? basic.pluralize : basic
+    basic.pluralize
   end
 end

--- a/spec/validators/cost_item_type_dependant_validator_spec.rb
+++ b/spec/validators/cost_item_type_dependant_validator_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 RSpec.describe CostItemTypeDependantValidator do
   subject(:instance) { klass.new(cost_per_item:) }
 
-  let(:options) { { pluralize: true } }
+  let(:items_options) { {} }
   let(:klass) do
     # needs to be a local variable to allow use in class definition block
-
+    items_options
     Class.new do
       include ActiveModel::Model
       include ActiveModel::Attributes
@@ -34,34 +34,6 @@ RSpec.describe CostItemTypeDependantValidator do
 
     it 'form object is valid' do
       expect(instance).not_to be_valid
-    end
-  end
-
-  context 'options are not pluralized' do
-    subject(:instance) { klass.new(cost_per_item:, cost_item_type:) }
-
-    let(:options) { { pluralize: false } }
-    let(:cost_item_type) { 'word' }
-    let(:cost_per_item) { nil }
-
-    let(:klass) do
-      Class.new do
-        include ActiveModel::Model
-        include ActiveModel::Attributes
-
-        def self.model_name
-          ActiveModel::Name.new(self, nil, 'temp')
-        end
-
-        attribute :cost_item_type, :string
-        attribute :cost_per_item, :gbp
-        validates :cost_per_item, cost_item_type_dependant: true
-      end
-    end
-
-    it 'does not pluralize cost_item_type' do
-      instance.validate
-      expect(instance.errors.details[:cost_per_item].flat_map(&:values)).to include('word')
     end
   end
 
@@ -97,7 +69,7 @@ RSpec.describe CostItemTypeDependantValidator do
     end
 
     context 'when allow_zero is true' do
-      let(:items_options) { { pluralize: true, allow_zero: true } }
+      let(:items_options) { { allow_zero: true } }
 
       it 'adds no greater_than error to cost_per_item' do
         expect(instance).not_to be_valid

--- a/spec/validators/item_type_dependant_validator_spec.rb
+++ b/spec/validators/item_type_dependant_validator_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe ItemTypeDependantValidator do
   subject(:instance) { klass.new(items:, cost_per_item:) }
 
-  let(:items_options) { { pluralize: true } }
+  let(:items_options) { {} }
   let(:klass) do
     # needs to be a local variable to allow use in class definition block
     options = items_options
@@ -71,7 +71,7 @@ RSpec.describe ItemTypeDependantValidator do
     end
 
     context 'when allow_zero is true' do
-      let(:items_options) { { pluralize: true, allow_zero: true } }
+      let(:items_options) { { allow_zero: true } }
 
       it 'adds no greater_than error to items' do
         expect(instance).not_to be_valid
@@ -98,7 +98,7 @@ RSpec.describe ItemTypeDependantValidator do
         attribute :items
         attribute :cost_per_item, :gbp
 
-        validates :items, item_type_dependant: { pluralize: true }
+        validates :items, item_type_dependant: true
         validates :cost_per_item, item_type_dependant: true
       end
     end
@@ -108,10 +108,10 @@ RSpec.describe ItemTypeDependantValidator do
       let(:cost_per_item) { nil }
       let(:item_type) { 'word' }
 
-      it 'include item type option from model, pluralizing if option set' do
+      it 'include item type option from model' do
         instance.validate
         expect(instance.errors.details[:items].flat_map(&:values)).to include('words')
-        expect(instance.errors.details[:cost_per_item].flat_map(&:values)).to include('word')
+        expect(instance.errors.details[:cost_per_item].flat_map(&:values)).to include('words')
       end
     end
   end


### PR DESCRIPTION
## Description of change

 [Caseworker: Remove Coverage Skip for CostItemTypeDependantValidator](https://dsdmoj.atlassian.net/browse/CRM457-1620)

We do not use the pluralize feature and for cost item type validation and the way it was written for item type validation won't work as cost_item_type_for inputs into a translation - therefore, I removed that part of the code completely. If we need to use pluralize in the future, we can update appropriately

