### PR TITLE
add worker match labels

### DIFF
--- a/helm_deploy/templates/deployment-worker.yaml
+++ b/helm_deploy/templates/deployment-worker.yaml
@@ -14,6 +14,7 @@ spec:
   selector:
     matchLabels:
       {{- include "helm_deploy.selectorLabels" . | nindent 6 }}
+      appName: {{ include "helm_deploy.fullname" . }}-worker
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -22,6 +23,7 @@ spec:
       {{- end }}
       labels:
         {{- include "helm_deploy.selectorLabels" . | nindent 8 }}
+        appName: {{ include "helm_deploy.fullname" . }}-worker
     spec:
       serviceAccountName: {{ .Values.service_account.name }}
       {{- with .Values.imagePullSecrets }}

--- a/helm_deploy/templates/deployment-worker.yaml
+++ b/helm_deploy/templates/deployment-worker.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "helm_deploy.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount.worker }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/helm_deploy/templates/deployment.yaml
+++ b/helm_deploy/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "helm_deploy.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  replicas: {{ .Values.replicaCount.app }}
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -2,7 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
+replicaCount:
+  app: 1
+  worker: 1
 
 image:
   repository: nginx

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -2,7 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 4
+replicaCount:
+  app: 4
+  worker: 2
 
 image:
   repository: nginx

--- a/helm_deploy/values-uat.yaml
+++ b/helm_deploy/values-uat.yaml
@@ -2,7 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 4
+replicaCount:
+  app: 4
+  worker: 2
 
 image:
   repository: nginx


### PR DESCRIPTION
## Description of change
add worker match labels and separate replica count between app and worker

- To use more explicit labels for worker
- To allow separate control of worker pod count
