### PR TITLE
CRM457-1650: Standardise modsec and add correct tagging

### DIFF
--- a/helm_deploy/templates/ingress.yaml
+++ b/helm_deploy/templates/ingress.yaml
@@ -20,6 +20,17 @@ metadata:
     {{- include "helm_deploy.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
+      SecRequestBodyNoFilesLimit 524288
+      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-forms-team"
+      SecDefaultAction "phase:4,pass,log,tag:github_team=laa-crime-forms-team"
+      SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"
+      SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6"
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    nginx.ingress.kubernetes.io/default-backend: nginx-errors
+    nginx.ingress.kubernetes.io/custom-http-errors: "403"
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/helm_deploy/templates/ingress.yaml
+++ b/helm_deploy/templates/ingress.yaml
@@ -29,8 +29,6 @@ metadata:
       SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"
       SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6"
     external-dns.alpha.kubernetes.io/aws-weight: "100"
-    nginx.ingress.kubernetes.io/default-backend: nginx-errors
-    nginx.ingress.kubernetes.io/custom-http-errors: "403"
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -27,14 +27,7 @@ ingress:
   namespace: laa-assess-crime-forms-dev
   className: modsec
   annotations:
-      nginx.ingress.kubernetes.io/enable-modsecurity: "true"
-      nginx.ingress.kubernetes.io/modsecurity-snippet: |
-        SecRuleEngine On
-        SecRequestBodyNoFilesLimit 524288
-        SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"
-        SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6"
-      external-dns.alpha.kubernetes.io/set-identifier: laa-assess-crime-forms-app-laa-assess-crime-forms-dev-green
-      external-dns.alpha.kubernetes.io/aws-weight: "100"
+    external-dns.alpha.kubernetes.io/set-identifier: laa-assess-crime-forms-app-laa-assess-crime-forms-dev-green
   hosts:
     - host: dev.assess-crime-forms.service.justice.gov.uk
       paths:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -27,14 +27,7 @@ ingress:
   namespace: laa-assess-crime-forms-prod
   className: modsec
   annotations:
-      nginx.ingress.kubernetes.io/enable-modsecurity: "true"
-      nginx.ingress.kubernetes.io/modsecurity-snippet: |
-        SecRuleEngine On
-        SecRequestBodyNoFilesLimit 524288
-        SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"
-        SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6"
-      external-dns.alpha.kubernetes.io/set-identifier: laa-assess-crime-forms-app-laa-assess-crime-forms-prod-green
-      external-dns.alpha.kubernetes.io/aws-weight: "100"
+    external-dns.alpha.kubernetes.io/set-identifier: laa-assess-crime-forms-app-laa-assess-crime-forms-prod-green
   hosts:
     - host: assess-crime-forms.service.justice.gov.uk
       paths:

--- a/helm_deploy/values-uat.yaml
+++ b/helm_deploy/values-uat.yaml
@@ -27,14 +27,7 @@ ingress:
   namespace: laa-assess-crime-forms-uat
   className: modsec
   annotations:
-      nginx.ingress.kubernetes.io/enable-modsecurity: "true"
-      nginx.ingress.kubernetes.io/modsecurity-snippet: |
-        SecRuleEngine On
-        SecRequestBodyNoFilesLimit 524288
-        SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"
-        SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6"
-      external-dns.alpha.kubernetes.io/set-identifier: laa-assess-crime-forms-app-laa-assess-crime-forms-uat-green
-      external-dns.alpha.kubernetes.io/aws-weight: "100"
+    external-dns.alpha.kubernetes.io/set-identifier: laa-assess-crime-forms-app-laa-assess-crime-forms-uat-green
   hosts:
     - host: uat.assess-crime-forms.service.justice.gov.uk
       paths:


### PR DESCRIPTION
## Description of change
Instead of 3 copies of the same config, just use 1
Add the annotations that allow us to view modsec logs

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1650)
