### PR TITLE
CRM457-1657: Remove some Modsec rules that give false positives

### DIFF
--- a/helm_deploy/templates/ingress.yaml
+++ b/helm_deploy/templates/ingress.yaml
@@ -26,6 +26,9 @@ metadata:
       SecRequestBodyNoFilesLimit 524288
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-forms-team"
       SecDefaultAction "phase:4,pass,log,tag:github_team=laa-crime-forms-team"
+      SecRuleRemoveById 921110
+      SecRuleRemoveById 933210
+      SecRuleRemoveById 942230
       SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"
       SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=6"
     external-dns.alpha.kubernetes.io/aws-weight: "100"


### PR DESCRIPTION
## Description of change
We have been experiencing some ModSec false positives, and we are aware of other teams experiencing them. This PR disables some of the more unreliable rules:

### 921110 "HTTP Request Smuggling Attack"
Civil Apply [found](https://dsdmoj.atlassian.net/wiki/spaces/ATPPB/pages/3686039762/ModSecurity) that this was triggering if "a user ends a sentence with get and a single word, followed by a new line"

### 933210 "PHP Injection Attack"
We [found](https://mojdt.slack.com/archives/C06UR7V28RZ/p1718890420747279) that this was triggering if a string in a JSON payload contained two consecutive pairs of parentheses, such as "...The preparation hourly rate has been reduced as per Schedule 1 of The Criminal Legal Aid (Remuneration)(Amendment) Regulations 2022..."

### 942230 "SQL Injection Attack"
Crime Apply [found](https://github.com/ministryofjustice/cla_public/pull/1238) that this was triggering on a string containing the sequence 'having £'
[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1657)
