### PR TITLE
CRM457-1671: Remove duplicate nav

### DIFF
--- a/app/views/nsm/assignments/new.html.erb
+++ b/app/views/nsm/assignments/new.html.erb
@@ -1,7 +1,3 @@
-<% content_for(:primary_navigation) do %>
-  <% render 'layouts/primary_navigation' %>
-<% end %>
-
 <% title t('.page_title') %>
 
 <div class="govuk-grid-row">


### PR DESCRIPTION
## Description of change
We're rendering the primary nav twice on the assignment form for NSM
