### PR TITLE
Crm457 1665/send eveents

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -55,6 +55,10 @@ class Event < ApplicationRecord
 
     private
 
+    def notify(event)
+      NotifyAppStore.perform_later(event)
+    end
+
     def create_dummy_users_if_non_production(params)
       create_dummy_user_if_non_production(params['primary_user_id'])
       create_dummy_user_if_non_production(params['secondary_user_id'])

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -55,10 +55,6 @@ class Event < ApplicationRecord
 
     private
 
-    def notify(event)
-      NotifyEventAppStore.perform_later(event:)
-    end
-
     def create_dummy_users_if_non_production(params)
       create_dummy_user_if_non_production(params['primary_user_id'])
       create_dummy_user_if_non_production(params['secondary_user_id'])
@@ -109,6 +105,10 @@ class Event < ApplicationRecord
         public: PUBLIC_EVENTS.include?(event_type),
         event_type: event_type.demodulize.underscore
       )
+  end
+
+  def notify
+    NotifyEventAppStore.perform_later(event: self)
   end
 
   private

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -56,7 +56,7 @@ class Event < ApplicationRecord
     private
 
     def notify(event)
-      NotifyAppStore.perform_later(event)
+      NotifyEventAppStore.perform_later(event:)
     end
 
     def create_dummy_users_if_non_production(params)

--- a/app/models/event/assignment.rb
+++ b/app/models/event/assignment.rb
@@ -8,7 +8,7 @@ class Event
         details: {
           comment:
         }
-      )
+      ).tap { notify(_1) }
     end
 
     def title

--- a/app/models/event/assignment.rb
+++ b/app/models/event/assignment.rb
@@ -8,7 +8,7 @@ class Event
         details: {
           comment:
         }
-      ).tap { notify(_1) }
+      ).tap(&:notify)
     end
 
     def title

--- a/app/models/event/draft_decision.rb
+++ b/app/models/event/draft_decision.rb
@@ -11,7 +11,7 @@ class Event
           to: next_state,
           comment: comment
         }
-      ).tap { notify(_1) }
+      )
     end
   end
 end

--- a/app/models/event/draft_decision.rb
+++ b/app/models/event/draft_decision.rb
@@ -11,7 +11,7 @@ class Event
           to: next_state,
           comment: comment
         }
-      )
+      ).tap { notify(_1) }
     end
   end
 end

--- a/app/models/event/new_version.rb
+++ b/app/models/event/new_version.rb
@@ -2,6 +2,7 @@ class Event
   class NewVersion < Event
     def self.build(submission:)
       create(submission: submission, submission_version: submission.current_version)
+        .tap { notify(_1) }
     end
   end
 end

--- a/app/models/event/new_version.rb
+++ b/app/models/event/new_version.rb
@@ -2,7 +2,7 @@ class Event
   class NewVersion < Event
     def self.build(submission:)
       create(submission: submission, submission_version: submission.current_version)
-        .tap { notify(_1) }
+        .tap(&:notify)
     end
   end
 end

--- a/app/models/event/unassignment.rb
+++ b/app/models/event/unassignment.rb
@@ -11,7 +11,7 @@ class Event
         details: {
           comment:
         }
-      )
+      ).tap { notify(_1) }
     end
 
     def title

--- a/app/models/event/unassignment.rb
+++ b/app/models/event/unassignment.rb
@@ -11,7 +11,7 @@ class Event
         details: {
           comment:
         }
-      ).tap { notify(_1) }
+      ).tap(&:notify)
     end
 
     def title

--- a/app/services/app_store_client.rb
+++ b/app/services/app_store_client.rb
@@ -40,6 +40,17 @@ class AppStoreClient
     end
   end
 
+  def create_event(submission_id, payload)
+    response = self.class.post("#{host}/v1/submissions/#{submission_id}/events", **options(payload))
+
+    case response.code
+    when 200..204
+      :success
+    else
+      raise "Unexpected response from AppStore - status #{response.code} on create subscription"
+    end
+  end
+
   private
 
   def options(payload = nil)

--- a/app/services/app_store_client.rb
+++ b/app/services/app_store_client.rb
@@ -40,14 +40,14 @@ class AppStoreClient
     end
   end
 
-  def create_event(submission_id, payload)
+  def create_events(submission_id, payload)
     response = self.class.post("#{host}/v1/submissions/#{submission_id}/events", **options(payload))
 
     case response.code
     when 200..204
       :success
     else
-      raise "Unexpected response from AppStore - status #{response.code} on create subscription"
+      raise "Unexpected response from AppStore - status #{response.code} on create events"
     end
   end
 

--- a/app/services/notify_event_app_store.rb
+++ b/app/services/notify_event_app_store.rb
@@ -1,0 +1,9 @@
+class NotifyEventAppStore < ApplicationJob
+  queue_as :default
+  retry_on StandardError, wait: :polynomially_longer, attempts: 10
+
+  def perform(event:)
+    client = AppStoreClient.new
+    client.create_event(event.submission_id, events: [event.as_json])
+  end
+end

--- a/app/services/notify_event_app_store.rb
+++ b/app/services/notify_event_app_store.rb
@@ -4,6 +4,6 @@ class NotifyEventAppStore < ApplicationJob
 
   def perform(event:)
     client = AppStoreClient.new
-    client.create_event(event.submission_id, events: [event.as_json])
+    client.create_events(event.submission_id, events: [event.as_json])
   end
 end

--- a/db/migrate/20240625163719_send_missing_events.rb
+++ b/db/migrate/20240625163719_send_missing_events.rb
@@ -1,0 +1,9 @@
+class SendMissingEvents < ActiveRecord::Migration[7.1]
+  def change
+    # send across any missing events that we want for reporting
+    Event.joins(:submission)
+         .where(event_type: %[Event::Assignment Event::Unassignment Event::NewVersion])
+         .where(submission: { state: %[submitted provider_updated] })
+         .each { NotifyEventAppStore.perform_later(event: _1) }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_05_125438) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_25_163719) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"

--- a/spec/models/event/assignment_spec.rb
+++ b/spec/models/event/assignment_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe Event::Assignment do
     )
   end
 
+  it 'notifies the app store' do
+    event = instance_double(Event)
+    expect(described_class).to receive(:create).and_return(event)
+    expect(NotifyEventAppStore).to receive(:perform_later).with(event:)
+
+    subject
+  end
+
   it 'has a valid title' do
     expect(subject.title).to eq('Claim allocated to caseworker')
   end

--- a/spec/models/event/assignment_spec.rb
+++ b/spec/models/event/assignment_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Event::Assignment do
   end
 
   it 'notifies the app store' do
-    event = instance_double(Event)
+    event = Event.send(:new)
     expect(described_class).to receive(:create).and_return(event)
     expect(NotifyEventAppStore).to receive(:perform_later).with(event:)
 

--- a/spec/models/event/new_version_spec.rb
+++ b/spec/models/event/new_version_spec.rb
@@ -13,6 +13,14 @@ RSpec.describe Event::NewVersion do
     )
   end
 
+  it 'notifies the app store' do
+    event = instance_double(Event)
+    expect(described_class).to receive(:create).and_return(event)
+    expect(NotifyEventAppStore).to receive(:perform_later).with(event:)
+
+    subject
+  end
+
   it 'has a valid title' do
     expect(subject.title).to eq('New claim received')
   end

--- a/spec/models/event/new_version_spec.rb
+++ b/spec/models/event/new_version_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Event::NewVersion do
   end
 
   it 'notifies the app store' do
-    event = instance_double(Event)
+    event = Event.send(:new)
     expect(described_class).to receive(:create).and_return(event)
     expect(NotifyEventAppStore).to receive(:perform_later).with(event:)
 

--- a/spec/models/event/unassignment_spec.rb
+++ b/spec/models/event/unassignment_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe Event::Unassignment do
       )
     end
 
+    it 'notifies the app store' do
+      event = instance_double(Event)
+      expect(described_class).to receive(:create).and_return(event)
+      expect(NotifyEventAppStore).to receive(:perform_later).with(event:)
+
+      subject
+    end
+
     it 'has a valid title' do
       expect(subject.title).to eq('Caseworker removed self from claim')
     end
@@ -37,6 +45,14 @@ RSpec.describe Event::Unassignment do
         event_type: 'Event::Unassignment',
         details: { 'comment' => 'test comment' }
       )
+    end
+
+    it 'notifies the app store' do
+      event = instance_double(Event)
+      expect(described_class).to receive(:create).and_return(event)
+      expect(NotifyEventAppStore).to receive(:perform_later).with(event:)
+
+      subject
     end
 
     it 'has a valid title' do

--- a/spec/models/event/unassignment_spec.rb
+++ b/spec/models/event/unassignment_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Event::Unassignment do
     end
 
     it 'notifies the app store' do
-      event = instance_double(Event)
+      event = Event.send(:new)
       expect(described_class).to receive(:create).and_return(event)
       expect(NotifyEventAppStore).to receive(:perform_later).with(event:)
 
@@ -48,7 +48,7 @@ RSpec.describe Event::Unassignment do
     end
 
     it 'notifies the app store' do
-      event = instance_double(Event)
+      event = Event.send(:new)
       expect(described_class).to receive(:create).and_return(event)
       expect(NotifyEventAppStore).to receive(:perform_later).with(event:)
 

--- a/spec/services/app_store_client_spec.rb
+++ b/spec/services/app_store_client_spec.rb
@@ -173,4 +173,40 @@ RSpec.describe AppStoreClient, :stub_oauth_token do
       end
     end
   end
+
+  describe '#create_event' do
+    let(:application_id) { SecureRandom.uuid }
+    let(:message) { [{ event: :data }] }
+    let(:response) { double(:response, code:) }
+    let(:code) { 201 }
+    let(:username) { nil }
+
+    before do
+      allow(described_class).to receive(:post).and_return(response)
+    end
+
+    it 'puts the message to default localhost url' do
+      expect(described_class).to receive(:post).with("http://localhost:8000/v1/submissions/#{application_id}/events",
+                                                     body: message.to_json,
+                                                     headers: { authorization: 'Bearer test-bearer-token' })
+
+      subject.create_event(application_id, message)
+    end
+
+    context 'when response code is 201 - created' do
+      it 'returns a created status' do
+        expect(subject.create_event(application_id, message)).to eq(:success)
+      end
+    end
+
+    context 'when response code is unexpected (neither 200 or 201)' do
+      let(:code) { 501 }
+
+      it 'raises an error' do
+        expect { subject.create_event(application_id, message) }.to raise_error(
+          'Unexpected response from AppStore - status 501 on create subscription'
+        )
+      end
+    end
+  end
 end

--- a/spec/services/app_store_client_spec.rb
+++ b/spec/services/app_store_client_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe AppStoreClient, :stub_oauth_token do
     end
   end
 
-  describe '#create_event' do
+  describe '#create_events' do
     let(:application_id) { SecureRandom.uuid }
     let(:message) { [{ event: :data }] }
     let(:response) { double(:response, code:) }
@@ -190,12 +190,12 @@ RSpec.describe AppStoreClient, :stub_oauth_token do
                                                      body: message.to_json,
                                                      headers: { authorization: 'Bearer test-bearer-token' })
 
-      subject.create_event(application_id, message)
+      subject.create_events(application_id, message)
     end
 
     context 'when response code is 201 - created' do
       it 'returns a created status' do
-        expect(subject.create_event(application_id, message)).to eq(:success)
+        expect(subject.create_events(application_id, message)).to eq(:success)
       end
     end
 
@@ -203,8 +203,8 @@ RSpec.describe AppStoreClient, :stub_oauth_token do
       let(:code) { 501 }
 
       it 'raises an error' do
-        expect { subject.create_event(application_id, message) }.to raise_error(
-          'Unexpected response from AppStore - status 501 on create subscription'
+        expect { subject.create_events(application_id, message) }.to raise_error(
+          'Unexpected response from AppStore - status 501 on create events'
         )
       end
     end

--- a/spec/services/notify_event_app_store_spec.rb
+++ b/spec/services/notify_event_app_store_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe NotifyEventAppStore do
+  subject { described_class.new }
+
+  let(:event) { instance_double(Event, submission_id:, as_json:) }
+  let(:submission_id) { SecureRandom.uuid }
+  let(:as_json) { { event: :json } }
+
+  describe '#perform' do
+    let(:http_notifier) { instance_double(AppStoreClient, create_event: true) }
+
+    before do
+      allow(AppStoreClient).to receive(:new).and_return(http_notifier)
+    end
+
+    it 'creates a new AppStoreClient instance' do
+      expect(AppStoreClient).to receive(:new)
+
+      subject.perform(event:)
+    end
+
+    it 'sends a HTTP message' do
+      expect(http_notifier).to receive(:create_event).with(submission_id, events: [as_json])
+
+      subject.perform(event:)
+    end
+
+    describe 'when error during notify process' do
+      before do
+        allow(http_notifier).to receive(:create_event).and_raise('annoying_error')
+      end
+
+      it 'allows the error to be raised - should reset the sidekiq job' do
+        expect { subject.perform(event:) }.to raise_error('annoying_error')
+      end
+    end
+  end
+end

--- a/spec/services/notify_event_app_store_spec.rb
+++ b/spec/services/notify_event_app_store_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe NotifyEventAppStore do
   let(:as_json) { { event: :json } }
 
   describe '#perform' do
-    let(:http_notifier) { instance_double(AppStoreClient, create_event: true) }
+    let(:http_notifier) { instance_double(AppStoreClient, create_events: true) }
 
     before do
       allow(AppStoreClient).to receive(:new).and_return(http_notifier)
@@ -21,14 +21,14 @@ RSpec.describe NotifyEventAppStore do
     end
 
     it 'sends a HTTP message' do
-      expect(http_notifier).to receive(:create_event).with(submission_id, events: [as_json])
+      expect(http_notifier).to receive(:create_events).with(submission_id, events: [as_json])
 
       subject.perform(event:)
     end
 
     describe 'when error during notify process' do
       before do
-        allow(http_notifier).to receive(:create_event).and_raise('annoying_error')
+        allow(http_notifier).to receive(:create_events).and_raise('annoying_error')
       end
 
       it 'allows the error to be raised - should reset the sidekiq job' do


### PR DESCRIPTION
## Description of change
Push reportring events (Assignment, Unassignment and NewVersion to app store as they are created. Other events are synced once a decision/RFI request is made.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1665)

