### PR TITLE
CRM457-1676: Optional grant comments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,6 +281,8 @@ GEM
     nio4r (2.7.3)
     nokogiri (1.16.6-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.16.6-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.6-x86_64-linux)
       racc (~> 1.4)
     notifications-ruby-client (5.4.0)
@@ -569,6 +571,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  x86_64-darwin-23
   x86_64-linux
 
 DEPENDENCIES

--- a/app/controllers/nsm/make_decisions_controller.rb
+++ b/app/controllers/nsm/make_decisions_controller.rb
@@ -29,7 +29,7 @@ module Nsm
 
     def decision_params
       params.require(:nsm_make_decision_form).permit(
-        :state, :partial_comment, :reject_comment
+        :state, :grant_comment, :partial_comment, :reject_comment
       ).merge(current_user:)
     end
   end

--- a/app/forms/nsm/make_decision_form.rb
+++ b/app/forms/nsm/make_decision_form.rb
@@ -11,6 +11,7 @@ module Nsm
     ].freeze
 
     attribute :state
+    attribute :grant_comment
     attribute :partial_comment
     attribute :reject_comment
     attribute :current_user
@@ -40,6 +41,8 @@ module Nsm
 
     def comment
       case state
+      when GRANTED
+        grant_comment
       when PART_GRANT
         partial_comment
       when REJECTED

--- a/app/views/nsm/make_decisions/edit.html.erb
+++ b/app/views/nsm/make_decisions/edit.html.erb
@@ -10,12 +10,14 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with model: decision, url: nsm_claim_make_decision_path(claim_id: claim.id), method: :put, id: dom_id(decision) do |f| %>
       <%= f.govuk_radio_buttons_fieldset :state, legend: { size: 's' } do %>
-        <%= f.govuk_radio_button :state, Nsm::MakeDecisionForm::GRANTED %>
+        <%= f.govuk_radio_button :state, Nsm::MakeDecisionForm::GRANTED  do %>
+          <%= f.govuk_text_area :grant_comment, width: 'one-third', autocomplete: 'off', label: { size: 's' } %>
+        <% end %>
         <%= f.govuk_radio_button :state, Nsm::MakeDecisionForm::PART_GRANT do %>
-          <%= f.govuk_text_area :partial_comment, width: 'one-third', autocomplete: 'off', label: { size: 'm' } %>
+          <%= f.govuk_text_area :partial_comment, width: 'one-third', autocomplete: 'off', label: { size: 's' } %>
         <% end %>
         <%= f.govuk_radio_button :state, Nsm::MakeDecisionForm::REJECTED do %>
-          <%= f.govuk_text_area :reject_comment, width: 'one-third', autocomplete: 'off', label: { size: 'm' } %>
+          <%= f.govuk_text_area :reject_comment, width: 'one-third', autocomplete: 'off', label: { size: 's' } %>
         <% end %>
       <% end %>
 

--- a/config/locales/en/nsm/make_decisions.yml
+++ b/config/locales/en/nsm/make_decisions.yml
@@ -21,10 +21,12 @@ en:
           granted: Grant it
           part_grant: Part grant it
           rejected: Reject it
+        grant_comment: Additional comments (optional)
         partial_comment: Explain your decision
         reject_comment: Explain your decision
     hint:
       nsm_make_decision_form:
+        grant_comment: We’ll share this information with the provider
         partial_comment: We’ll share this information with the provider
         reject_comment: We’ll share this information with the provider
 

--- a/spec/forms/nsm/make_decision_form_spec.rb
+++ b/spec/forms/nsm/make_decision_form_spec.rb
@@ -111,13 +111,15 @@ RSpec.describe Nsm::MakeDecisionForm do
   end
 
   describe '#comment' do
-    let(:params) { { state: state, partial_comment: 'part comment', reject_comment: 'reject comment' } }
+    let(:params) do
+      { state: state, partial_comment: 'part comment', reject_comment: 'reject comment', grant_comment: 'grant comment' }
+    end
 
     context 'when state is granted' do
       let(:state) { 'granted' }
 
-      it 'ignores all comment fields' do
-        expect(subject.comment).to be_nil
+      it 'uses the grant comment' do
+        expect(subject.comment).to eq('grant comment')
       end
     end
 
@@ -134,6 +136,14 @@ RSpec.describe Nsm::MakeDecisionForm do
 
       it 'uses the reject_comment field' do
         expect(subject.comment).to eq('reject comment')
+      end
+    end
+
+    context 'when state is not set' do
+      let(:state) { nil }
+
+      it 'returns nil' do
+        expect(subject.comment).to be_nil
       end
     end
   end

--- a/spec/system/nsm/assessment_spec.rb
+++ b/spec/system/nsm/assessment_spec.rb
@@ -16,10 +16,14 @@ Rails.describe 'Assessment', :stub_oauth_token, :stub_update_claim do
       visit nsm_claim_claim_details_path(claim)
       click_link_or_button 'Make a decision'
       choose 'Grant it'
+      fill_in 'nsm-make-decision-form-grant-comment-field', with: 'Test Data'
 
       expect do
         click_link_or_button 'Submit decision'
       end.to have_enqueued_job(NotifyAppStore)
+
+      visit nsm_claim_history_path(claim)
+      expect(page).to have_content 'Test Data'
     end
   end
 


### PR DESCRIPTION
## Description of change
Allow providers to enter a comment when granting a claim

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1676)
