### PR TITLE
Tidy up custom_seeds task

### DIFF
--- a/db/seeds/de2d6169-c769-4571-b3f2-220bcf8c3ce9/version.json
+++ b/db/seeds/de2d6169-c769-4571-b3f2-220bcf8c3ce9/version.json
@@ -45,7 +45,7 @@
       "contact_email": "f.solomon@solicitor.com",
       "reference_number": "1212333",
       "contact_first_name": "Frank",
-      "contact_last_name": "Solomon",
+      "contact_last_name": "Solomon"
     },
     "claim_type": {
       "value": "non_standard_magistrate",

--- a/db/seeds/f1ba0909-020f-4373-a167-9100923bdcaa/version.json
+++ b/db/seeds/f1ba0909-020f-4373-a167-9100923bdcaa/version.json
@@ -35,7 +35,7 @@
             "contact_email": null,
             "reference_number": "jj",
             "contact_first_name": null,
-            "contact_last_name": null,
+            "contact_last_name": null
         },
         "claim_type": {
             "value": "non_standard_magistrate",

--- a/lib/tasks/custom_seeds.rake
+++ b/lib/tasks/custom_seeds.rake
@@ -40,15 +40,13 @@ namespace :custom_seeds do
       auth_subject_id: SecureRandom.uuid,
     )
 
-    Dir[Rails.root.join("db/seeds/*")].each do |path|
+    Dir[Rails.root.join("db/seeds/**/*.json")].map{ |d| File.dirname(d) }.uniq.each do |path|
       claim_id = path.split('/').last
       puts "Processing import for claim: #{claim_id}"
 
       begin
         claim_hash = JSON.parse(File.read("#{path}/claim.json"))
         version_hash = JSON.parse(File.read("#{path}/version.json"))
-
-
 
         claim = Claim.find_by(id: claim_id)
 


### PR DESCRIPTION
## Description of change

Having a trailing comma on the last element inside an object is invalid.

Also ensures that only a valid folder is parsed when seeding (otherwise it attempts to load the other ruby files as directories)

No ticket associated, just noticed during setup.

This still fails trying to authenticate to "something" (see below screenshot), but I'm raising this draft PR now so it's not lost at least.

![image](https://github.com/ministryofjustice/laa-assess-crime-forms/assets/2872862/060abd81-cd2c-4018-b079-c3b42dd1ae06)