### PR TITLE
CRM457-1319: Swallow team-only notification client errors on DEV/UAT

### DIFF
--- a/app/mailers/notify_mailer.rb
+++ b/app/mailers/notify_mailer.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class NotifyMailer < GovukNotifyRails::Mailer
+  rescue_from 'Notifications::Client::BadRequestError' do |e|
+    if HostEnv.production? || e.message.exclude?('team-only API')
+      Rails.logger.warn("Reraising exception #{e.class} with message \"#{e.message}\"")
+      raise e
+    else
+      Rails.logger.warn("Swallowing exception #{e.class} with message \"#{e.message}\"")
+    end
+  end
+end

--- a/app/mailers/nsm/submission_feedback_mailer.rb
+++ b/app/mailers/nsm/submission_feedback_mailer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Nsm
-  class SubmissionFeedbackMailer < GovukNotifyRails::Mailer
+  class SubmissionFeedbackMailer < NotifyMailer
     def notify(submission)
       feedback_template = feedback_message(submission)
       set_template(feedback_template.template)

--- a/app/mailers/prior_authority/submission_feedback_mailer.rb
+++ b/app/mailers/prior_authority/submission_feedback_mailer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module PriorAuthority
-  class SubmissionFeedbackMailer < GovukNotifyRails::Mailer
+  class SubmissionFeedbackMailer < NotifyMailer
     class InvalidState < StandardError; end
 
     FEEDBACK_MESSAGE_KLASSES = {

--- a/spec/mailers/nsm/submission_feedback_mailer_spec.rb
+++ b/spec/mailers/nsm/submission_feedback_mailer_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Nsm::SubmissionFeedbackMailer, type: :mailer do
 
   describe 'granted' do
     context 'with maat id' do
-      let(:claim) { build(:claim, state: 'granted') }
+      let(:submission) { build(:claim, state: 'granted') }
       let(:feedback_template) { '80c0dcd2-597b-4c82-8c94-f6e26af71a40' }
       let(:personalisation) do
         [laa_case_reference:, ufn:, main_defendant_name:, defendant_reference:, claim_total:, date:]
@@ -24,7 +24,7 @@ RSpec.describe Nsm::SubmissionFeedbackMailer, type: :mailer do
 
     context 'with cntp id' do
       let(:defendant_reference) { "Client's CNTP number: CNTP12345" }
-      let(:claim) do
+      let(:submission) do
         build(:claim, state: 'granted').tap do |claim|
           claim.data['cntp_order'] = 'CNTP12345'
           claim.data['defendants'].first['maat'] = nil
@@ -41,7 +41,7 @@ RSpec.describe Nsm::SubmissionFeedbackMailer, type: :mailer do
   end
 
   describe 'part granted' do
-    let(:claim) { build(:claim, state: 'part_grant') }
+    let(:submission) { build(:claim, state: 'part_grant') }
     let(:feedback_template) { '9df38f19-f76b-42f9-a4e1-da36a65d6aca' }
     let(:part_grant_total) { '£325.97' }
     let(:caseworker_decision_explanation) { '' }
@@ -55,7 +55,7 @@ RSpec.describe Nsm::SubmissionFeedbackMailer, type: :mailer do
   end
 
   describe 'rejected' do
-    let(:claim) { build(:claim, state: 'rejected') }
+    let(:submission) { build(:claim, state: 'rejected') }
     let(:feedback_template) { '7e807120-b661-452c-95a6-1ae46f411cfe' }
     let(:caseworker_decision_explanation) { '' }
     let(:personalisation) do
@@ -67,7 +67,7 @@ RSpec.describe Nsm::SubmissionFeedbackMailer, type: :mailer do
   end
 
   describe 'further information' do
-    let(:claim) { build(:claim, state: 'further_information') }
+    let(:submission) { build(:claim, state: 'further_information') }
     let(:feedback_template) { '9ecdec30-83d7-468d-bec2-cf770a2c9828' }
     let(:date_to_respond_by) { 7.days.from_now.to_fs(:stamp) }
     let(:caseworker_information_requested) { '' }
@@ -81,7 +81,7 @@ RSpec.describe Nsm::SubmissionFeedbackMailer, type: :mailer do
   end
 
   describe 'provider requested' do
-    let(:claim) { build(:claim, state: 'provider_requested') }
+    let(:submission) { build(:claim, state: 'provider_requested') }
     let(:feedback_template) { 'bfd28bd8-b9d8-4b18-8ce0-3fb763123573' }
     let(:personalisation) do
       [laa_case_reference:, ufn:, main_defendant_name:, defendant_reference:, claim_total:, date:]
@@ -91,7 +91,7 @@ RSpec.describe Nsm::SubmissionFeedbackMailer, type: :mailer do
   end
 
   describe 'other status' do
-    let(:claim) { build(:claim, state: 'fake') }
+    let(:submission) { build(:claim, state: 'fake') }
     let(:feedback_template) { '9ecdec30-83d7-468d-bec2-cf770a2c9828' }
     let(:date_to_respond_by) { 7.days.from_now.to_fs(:stamp) }
     let(:caseworker_information_requested) { '' }
@@ -102,5 +102,9 @@ RSpec.describe Nsm::SubmissionFeedbackMailer, type: :mailer do
     end
 
     include_examples 'creates a feedback mailer'
+  end
+
+  it_behaves_like 'notification client error handler' do
+    let(:submission) { build(:claim, state: 'granted') }
   end
 end

--- a/spec/support/shared_examples/shared_claim_feedback_mailer.rb
+++ b/spec/support/shared_examples/shared_claim_feedback_mailer.rb
@@ -2,17 +2,17 @@
 
 RSpec.shared_examples 'creates a feedback mailer' do
   describe '#notify' do
-    subject(:mail) { described_class.notify(claim) }
+    subject(:mail) { described_class.notify(submission) }
 
     it 'is a govuk_notify delivery' do
       expect(mail.delivery_method).to be_a(GovukNotifyRails::Delivery)
     end
 
-    it 'sets the recipient from config' do
+    it 'sets the expected recipient' do
       expect(mail.to).to eq([recipient])
     end
 
-    it 'sets the template' do
+    it 'sets the expected template' do
       expect(
         mail.govuk_notify_template
       ).to eq feedback_template
@@ -26,28 +26,77 @@ RSpec.shared_examples 'creates a feedback mailer' do
   end
 end
 
-RSpec.shared_examples 'creates a prior authority feedback mailer' do
-  describe '#notify' do
-    subject(:mail) { described_class.notify(application) }
+RSpec.shared_examples 'notification client error handler' do
+  context 'when client error response received' do
+    before do
+      allow(Notifications::Client).to receive(:new)
+        .and_return(notify_client)
+      allow(notify_client).to receive(:send_email)
+        .and_raise(Notifications::Client::BadRequestError.new(response))
 
-    it 'is a govuk_notify delivery' do
-      expect(mail.delivery_method).to be_a(GovukNotifyRails::Delivery)
+      allow(Rails.logger).to receive(:warn)
     end
 
-    it 'sets the recipient to be the solicitors contact email' do
-      expect(mail.to).to eq([recipient])
+    let(:notify_client) { double('Notifications::Client') }
+
+    context 'when on DEV or UAT environment' do
+      before do
+        allow(HostEnv).to receive(:production?).and_return(false)
+      end
+
+      context 'with a team API key client error' do
+        let(:response) { double(code: 400, body: "Can't send to this recipient using a team-only API key") }
+
+        it 'does not raise error' do
+          expect { described_class.notify(submission).deliver_now }.not_to raise_error
+        end
+
+        it 'logs the rescued error' do
+          described_class.notify(submission).deliver_now
+
+          expect(Rails.logger)
+            .to have_received(:warn)
+            .with(/Swallowing exception Notifications::Client::BadRequestError with/)
+        end
+      end
+
+      context 'with another kind of client error' do
+        let(:response) { double(code: 400, body: 'some other client error') }
+
+        it 'raises error' do
+          expect { described_class.notify(submission).deliver_now }
+            .to raise_error(Notifications::Client::BadRequestError, 'some other client error')
+        end
+
+        it 'logs the rescued error' do
+          described_class.notify(submission).deliver_now
+        rescue Notifications::Client::BadRequestError
+          expect(Rails.logger)
+            .to have_received(:warn)
+            .with(/Reraising exception Notifications::Client::BadRequestError with/)
+        end
+      end
     end
 
-    it 'sets the template' do
-      expect(
-        mail.govuk_notify_template
-      ).to eq feedback_template
-    end
+    context 'when on production environment' do
+      before do
+        allow(HostEnv).to receive(:production?).and_return(true)
+      end
 
-    it 'sets personalisation from args' do
-      expect(
-        mail.govuk_notify_personalisation
-      ).to include(*personalisation)
+      let(:response) { double(code: 400, body: "Can't send to this recipient using a team-only API key") }
+
+      it 'raises error' do
+        expect { described_class.notify(submission).deliver_now }
+          .to raise_error(Notifications::Client::BadRequestError, "Can't send to this recipient using a team-only API key")
+      end
+
+      it 'logs the rescued error' do
+        described_class.notify(submission).deliver_now
+      rescue Notifications::Client::BadRequestError
+        expect(Rails.logger)
+          .to have_received(:warn)
+          .with(/Reraising exception Notifications::Client::BadRequestError with/)
+      end
     end
   end
 end


### PR DESCRIPTION
## Description of change
Swallow team-only notification client errors on DEV/UAT

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1319)

When testing we often use invalid/non-team-member email addresses
and we are not interested in sentry or other alerting that results
from this on pre-prod environments

