### PR TITLE
CRM457-1529: Change snyk docker scanning approach

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,21 +255,28 @@ jobs:
 
   scan-docker-image:
     executor: test-executor
-    parallelism: 1
     steps:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
       - build-docker-image-for-scan
-      - snyk/scan:
+      - snyk/install:
           token-variable: SNYK_TOKEN
-          docker-image-name: app
-          target-file: ./Dockerfile
-          organization: 'legal-aid-agency'
-          project: ministryofjustice/laa-assess-crime-forms
-          severity-threshold: "high"
-          fail-on-issues: true
-          additional-arguments: --policy-path=.snyk
+      - run:
+          name: Run static code analysis
+          command: snyk code test --severity-threshold=high
+      - run:
+          name: Test open source dependencies
+          command: snyk test --all-projects --policy-path=.snyk --severity-threshold=high
+      - run:
+          name: Monitor for open source vulnerabilities and license issues
+          command: snyk monitor --all-projects
+      - run:
+          name: Scan container image for vulnerabilities
+          command: snyk container test app --file=./Dockerfile --policy-path=.snyk --severity-threshold=high
+      - run:
+          name: Monitor container image for vulnerabilities
+          command: snyk container monitor app
 
   build-to-ecr:
     executor: aws-ecr/default

--- a/app/controllers/prior_authority/manual_assignments_controller.rb
+++ b/app/controllers/prior_authority/manual_assignments_controller.rb
@@ -1,5 +1,7 @@
 module PriorAuthority
   class ManualAssignmentsController < PriorAuthority::AssignmentsController
+    before_action :set_application, only: %i[new create]
+
     def new
       @form = ManualAssignmentForm.new
     end
@@ -16,7 +18,6 @@ module PriorAuthority
     private
 
     def process_assignment(comment)
-      application = PriorAuthorityApplication.find(params[:application_id])
       application.with_lock do
         if application.assignments.none?
           assign_and_redirect(application, comment)
@@ -24,6 +25,14 @@ module PriorAuthority
           redirect_to prior_authority_application_path(application), flash: { notice: t('.already_assigned') }
         end
       end
+    end
+
+    def set_application
+      application
+    end
+
+    def application
+      @application ||= PriorAuthorityApplication.find(params[:application_id])
     end
   end
 end

--- a/app/controllers/prior_authority/unassignments_controller.rb
+++ b/app/controllers/prior_authority/unassignments_controller.rb
@@ -1,15 +1,16 @@
 module PriorAuthority
   class UnassignmentsController < PriorAuthority::BaseController
+    before_action :set_application, only: %i[new create]
+
     def new
-      @form = UnassignmentForm.new application_id: params[:application_id]
+      @form = UnassignmentForm.new(application_id: application.id)
     end
 
     def create
-      @form = UnassignmentForm.new(params.require(:prior_authority_unassignment_form).permit(:comment).merge(
-                                     application_id: params[:application_id]
-                                   ))
+      @form = UnassignmentForm.new(params.require(:prior_authority_unassignment_form)
+                                         .permit(:comment)
+                                         .merge(application_id: application.id))
       if @form.valid?
-        application = PriorAuthorityApplication.find(params[:application_id])
         assignment = application.assignments.first
         process_unassignment(@form.comment, application, assignment)
       else
@@ -31,6 +32,14 @@ module PriorAuthority
       else
         redirect_to prior_authority_application_path(application), flash: { notice: t('.not_assigned') }
       end
+    end
+
+    def set_application
+      application
+    end
+
+    def application
+      @application ||= PriorAuthorityApplication.find(params[:application_id])
     end
   end
 end

--- a/app/views/nsm/assignments/new.html.erb
+++ b/app/views/nsm/assignments/new.html.erb
@@ -4,13 +4,13 @@
   <div class="govuk-grid-column-two-thirds" id="travel-cost-adjustment-container">
     <%= govuk_error_summary(@form) %>
     <h1 class="govuk-heading-xl"><%= t('.page_title') %></h1>
-    <%= form_with model: @form, url: nsm_claim_assignments_path(params[:claim_id]) do |f| %>
+    <%= form_with model: @form, url: nsm_claim_assignments_path(@claim.id) do |f| %>
       <%= f.govuk_text_area :comment,
                             label: { size: 's', text: t('.label') },
                             hint: { size: 's', text: t('.hint') } %>
 
       <%= f.govuk_submit t('.button_text') do %>
-        <%= link_to t('shared.cancel'), nsm_claim_claim_details_path(params[:claim_id]), class: 'govuk-link', data: { turbo: 'false' } %>
+        <%= link_to t('shared.cancel'), nsm_claim_claim_details_path(@claim.id), class: 'govuk-link', data: { turbo: 'false' } %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/prior_authority/manual_assignments/new.html.erb
+++ b/app/views/prior_authority/manual_assignments/new.html.erb
@@ -8,13 +8,13 @@
   <div class="govuk-grid-column-two-thirds" id="travel-cost-adjustment-container">
     <%= govuk_error_summary(@form) %>
     <h1 class="govuk-heading-xl"><%= t('.page_title') %></h1>
-    <%= form_with model: @form, url: prior_authority_application_manual_assignments_path(params[:application_id]) do |f| %>
+    <%= form_with model: @form, url: prior_authority_application_manual_assignments_path(@application.id) do |f| %>
       <%= f.govuk_text_area :comment,
                             label: { size: 's', text: t('.label') },
                             hint: { size: 's', text: t('.hint') } %>
 
       <%= f.govuk_submit t('.button_text') do %>
-        <%= link_to t('shared.cancel'), prior_authority_application_path(params[:application_id]), class: 'govuk-link', data: { turbo: 'false' } %>
+        <%= link_to t('shared.cancel'), prior_authority_application_path(@application.id), class: 'govuk-link', data: { turbo: 'false' } %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/prior_authority/unassignments/new.html.erb
+++ b/app/views/prior_authority/unassignments/new.html.erb
@@ -9,13 +9,13 @@
     <%= govuk_error_summary(@form) %>
     <h1 class="govuk-heading-xl"><%= t('.page_title', caseworker: @form.caseworker_name) %></h1>
     <p><%= t('.paragraph') %></p>
-    <%= form_with model: @form, url: prior_authority_application_unassignments_path(params[:application_id]) do |f| %>
+    <%= form_with model: @form, url: prior_authority_application_unassignments_path(@application.id) do |f| %>
       <%= f.govuk_text_area :comment,
                             label: { size: 's', text: t('.label') },
                             hint: { size: 's', text: t('.hint') } %>
 
       <%= f.govuk_submit t('.button_text') do %>
-        <%= link_to t('shared.cancel'), prior_authority_application_path(params[:application_id]), class: 'govuk-link', data: { turbo: 'false' } %>
+        <%= link_to t('shared.cancel'), prior_authority_application_path(@application.id), class: 'govuk-link', data: { turbo: 'false' } %>
       <% end %>
     <% end %>
   </div>


### PR DESCRIPTION
## Description of change
Change snyk docker scanning approach

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1529)

## Notes for reviewer
This implements all but the IaC scan. The reason for not implementing IaC scanning now is:
- IaC needs rendered terraform or k8s manifests to scan, not helm templates
- attempts to render the manifests and pass them to the `snyk IaC test` hit various problems to do with helm install on test-executor (overcome), requiring k8s login for rendering the manifest (requiring cloud-platform-executor) or snyk install on cloud-platform-executor, and it has not been possible to test whether a helm upgrade --dry-run output would work. Certainly a `helm template blah` command as suggested by snyk docs is insufficient in our case. Ideally the cloud-platform-executor would have snyk installed so we can render manifests and then, hopefully these can be scanned by `snyk iac test`
