### PR TITLE
CRM457 -1714: Better dummy data

### DIFF
--- a/app/jobs/nsm/fake_assess.rb
+++ b/app/jobs/nsm/fake_assess.rb
@@ -9,7 +9,7 @@ module Nsm
     end
 
     def assess(claim)
-      case SecureRandom.rand(5)
+      case SecureRandom.rand(6)
       when 0
         grant(claim)
       when 1
@@ -21,22 +21,24 @@ module Nsm
       when 4
         mark_provider_requested(claim)
       else
-        raise 'Unexpected randomness outcome - did someone mess up a refactor?'
+        leave_unassessed(claim)
       end
     end
 
     private
 
     def grant(claim)
-      Nsm::MakeDecisionForm.new(claim: claim, current_user: User.first, state: 'granted').save
+      assign(claim)
+      Nsm::MakeDecisionForm.new(claim: claim, current_user: claim.assignments.first.user, state: 'granted').save
     end
 
     def part_grant(claim)
+      assign(claim)
       adjust(claim)
 
       Nsm::MakeDecisionForm.new(
         claim: claim,
-        current_user: User.first,
+        current_user: claim.assignments.first.user,
         partial_comment: Faker::Lorem.paragraph,
         state: 'part_grant'
       ).save
@@ -52,37 +54,50 @@ module Nsm
         uplift: 0,
         time_spent: Faker::Number.between(from: 1, to: 300),
         explanation: Faker::Lorem.paragraph,
-        current_user: User.first,
+        current_user: claim.assignments.first.user,
         id: item.id
       )
       form.save
     end
 
     def reject(claim)
+      assign(claim)
       Nsm::MakeDecisionForm.new(
         claim: claim,
-        current_user: User.first,
+        current_user: claim.assignments.first.user,
         reject_comment: Faker::Lorem.paragraph,
         state: 'rejected'
       ).save
     end
 
     def request_further_info(claim)
+      assign(claim)
       Nsm::SendBackForm.new(
         claim: claim,
-        current_user: User.first,
+        current_user: claim.assignments.first.user,
         state: 'further_info',
         comment: Faker::Lorem.paragraph
       ).save
     end
 
     def mark_provider_requested(claim)
+      assign(claim)
       Nsm::SendBackForm.new(
         claim: claim,
-        current_user: User.first,
+        current_user: claim.assignments.first.user,
         state: 'provider_requested',
         comment: Faker::Lorem.paragraph
       ).save
+    end
+
+    def leave_unassessed(_)
+      nil
+    end
+
+    def assign(claim)
+      user = User.order('RANDOM()').first
+      claim.assignments.create!(user:)
+      ::Event::Assignment.build(submission: claim, current_user: user)
     end
   end
 end

--- a/app/jobs/prior_authority/fake_assess.rb
+++ b/app/jobs/prior_authority/fake_assess.rb
@@ -8,7 +8,7 @@ module PriorAuthority
     end
 
     def assess(application)
-      case SecureRandom.rand(5)
+      case SecureRandom.rand(6)
       when 0
         grant(application)
       when 1
@@ -20,22 +20,26 @@ module PriorAuthority
       when 4
         request_correction(application)
       else
-        raise 'Unexpected randomness outcome - did someone mess up a refactor?'
+        leave_unassessed(application)
       end
     end
 
     private
 
     def grant(application)
-      PriorAuthority::DecisionForm.new(submission: application, current_user: User.first, pending_decision: 'granted').save
+      assign(application)
+      PriorAuthority::DecisionForm.new(submission: application,
+                                       current_user: application.assignments.first.user,
+                                       pending_decision: 'granted').save
     end
 
     def part_grant(application)
+      assign(application)
       adjust(application)
 
       PriorAuthority::DecisionForm.new(
         submission: application,
-        current_user: User.first,
+        current_user: application.assignments.first.user,
         pending_decision: 'part_grant',
         pending_part_grant_explanation: Faker::Lorem.paragraph
       ).save
@@ -44,44 +48,60 @@ module PriorAuthority
     def adjust(submission)
       primary_quote = V1::Quote.build(:quote, submission, 'quotes').find(&:primary)
       item = BaseViewModel.build(:service_cost, submission, 'quotes').find { _1.id == primary_quote.id }
-      current_user = User.first
+      current_user = submission.assignments.first.user
       form = ServiceCostForm.new(submission:, item:, current_user:, **item.form_attributes)
-      form.assign_attributes(
+      form.assign_attributes(fake_adjustment_attributes)
+      form.save
+    end
+
+    def fake_adjustment_attributes
+      {
         items: Faker::Number.between(from: 1, to: 6),
         cost_per_item: Faker::Number.between(from: 1.0, to: 99.0).round(2),
         period: Faker::Number.between(from: 1, to: 300),
         cost_per_hour: Faker::Number.between(from: 1.0, to: 99.0).round(2),
         explanation: Faker::Lorem.paragraph,
-      )
-
-      form.save
+      }
     end
 
     def reject(application)
+      assign(application)
       PriorAuthority::DecisionForm.new(
         submission: application,
-        current_user: User.first,
+        current_user: application.assignments.first.user,
         pending_decision: 'rejected',
         pending_rejected_explanation: Faker::Lorem.paragraph
       ).save
     end
 
     def request_further_info(application)
+      assign(application)
       PriorAuthority::SendBackForm.new(
         submission: application,
-        current_user: User.first,
+        current_user: application.assignments.first.user,
         updates_needed: ['further_information'],
         further_information_explanation: Faker::Lorem.paragraph
       ).save
     end
 
     def request_correction(application)
+      assign(application)
       PriorAuthority::SendBackForm.new(
         submission: application,
-        current_user: User.first,
+        current_user: application.assignments.first.user,
         updates_needed: ['incorrect_information'],
         incorrect_information_explanation: Faker::Lorem.paragraph
       ).save
+    end
+
+    def leave_unassessed(_)
+      nil
+    end
+
+    def assign(application)
+      user = User.order('RANDOM()').first
+      application.assignments.create!(user:)
+      ::Event::Assignment.build(submission: application, current_user: user)
     end
   end
 end

--- a/lib/tasks/dummy_assessments.rake
+++ b/lib/tasks/dummy_assessments.rake
@@ -1,5 +1,5 @@
 namespace :dummy_assessments do
-  desc 'assess all pending assessments randomly'
+  desc 'assess most pending assessments randomly'
 
   task create: :environment do
     PriorAuthorityApplication.where(state: PriorAuthorityApplication::ASSESSABLE_STATES)

--- a/spec/jobs/nsm/fake_assess_spec.rb
+++ b/spec/jobs/nsm/fake_assess_spec.rb
@@ -80,13 +80,13 @@ RSpec.describe Nsm::FakeAssess do
         expect(NotifyAppStore).to have_received(:perform_later).with(submission: claim)
       end
     end
-  end
 
-  context 'when randomness goes wrong' do
-    before { allow(SecureRandom).to receive(:rand).and_return 5 }
+    context 'when leaving as-is' do
+      let(:random_choice) { 5 }
 
-    it 'raises an error' do
-      expect { subject.perform([claim.id]) }.to raise_error StandardError
+      it 'does not modify claim' do
+        expect(claim.reload.state).to eq 'submitted'
+      end
     end
   end
 end

--- a/spec/jobs/prior_authority/fake_assess_spec.rb
+++ b/spec/jobs/prior_authority/fake_assess_spec.rb
@@ -81,20 +81,21 @@ RSpec.describe PriorAuthority::FakeAssess do
       end
 
       it 'specifies corrections needed' do
-        expect(application.reload.events.last['details']['updates_needed']).to include('incorrect_information')
+        send_back_event = application.reload.events.find_by(event_type: 'PriorAuthority::Event::SendBack')
+        expect(send_back_event['details']['updates_needed']).to include('incorrect_information')
       end
 
       it 'notifies the app store' do
         expect(NotifyAppStore).to have_received(:perform_later).with(submission: application)
       end
     end
-  end
 
-  context 'when randomness goes wrong' do
-    before { allow(SecureRandom).to receive(:rand).and_return 5 }
+    context 'when leaving as-is' do
+      let(:random_choice) { 5 }
 
-    it 'raises an error' do
-      expect { subject.perform([application.id]) }.to raise_error StandardError
+      it 'does not modify application' do
+        expect(application.reload).to be_submitted
+      end
     end
   end
 end


### PR DESCRIPTION
## Description of change
Update the dummy assessment task so that it leaves some submissions as 'submitted' to allow for more varied test data, and also assigns a caseworker before assessing.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1714)
