### PR TITLE
CRM457-1672: Concurrent migrations

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,0 +1,24 @@
+namespace :db do
+  namespace :preparation do
+    desc "Run db:prepare and retry if 2-pods-running-this-at-once issues encountered"
+    task run_with_retry: :environment do
+      attempts = 0
+      begin
+        Rake::Task["db:prepare"].reenable
+        Rake::Task["db:prepare"].invoke
+      # If 2 pods try to run a migration at once on the same database, a ConcurrentMigrationError may be encountered.
+      # If 2 pods try to do initial setup at once on the same database, a RecordNotUnique error may be encountered
+      # as they both try to create the schema_migrations table. RecordNotUnique could indicate an error with the
+      # migration itself. If so, this will keep failing after multiple retries so will eventually be raised here.
+      rescue ActiveRecord::ConcurrentMigrationError, ActiveRecord::RecordNotUnique
+        attempts += 1
+        if attempts <= 3
+          sleep(5)
+          retry
+        else
+          raise
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -6,11 +6,14 @@ namespace :db do
       begin
         Rake::Task["db:prepare"].reenable
         Rake::Task["db:prepare"].invoke
+      # If the DB isn't ready yet, ConnectionNotEstablished will be thrown
       # If 2 pods try to run a migration at once on the same database, a ConcurrentMigrationError may be encountered.
       # If 2 pods try to do initial setup at once on the same database, a RecordNotUnique error may be encountered
       # as they both try to create the schema_migrations table. RecordNotUnique could indicate an error with the
       # migration itself. If so, this will keep failing after multiple retries so will eventually be raised here.
-      rescue ActiveRecord::ConcurrentMigrationError, ActiveRecord::RecordNotUnique
+      rescue ActiveRecord::ConcurrentMigrationError,
+             ActiveRecord::RecordNotUnique,
+             ActiveRecord::ConnectionNotEstablished
         attempts += 1
         if attempts <= 3
           sleep(5)

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 cd /usr/src/app
 
-bundle exec bin/rails db:prepare && bundle exec pumactl -F config/puma.rb start
+bundle exec bin/rails db:preparation:run_with_retry && bundle exec pumactl -F config/puma.rb start


### PR DESCRIPTION
## Description of change
Sometimes 2 pods run migrations at the same time, one loses the race, and we get error messages on Slack even though nothing bad has happened. This should prevent those false positives.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1672)

