### PR TITLE
[CRM457-1733] update dev env config template

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -6,6 +6,8 @@
 #
 DATABASE_URL=postgresql://postgres@localhost/laa_assess_non_standard_magistrate_fee_dev
 
+REDIS_URL=redis://localhost:6379/2
+
 # Local datastore url - default is http://localhost:8000
 APP_STORE_URL=http://localhost:8000
 
@@ -40,10 +42,10 @@ ENABLE_SYNC_TRIGGER_ENDPOINT=true
 # - uncomment all and add secret values from k8s to autheticate
 #   Note that the configured app store must NOT have AUTHAUTHENTICATION_REQUIRED=false in this case.
 #
-APP_STORE_CLIENT_ID=not-a-real-key
-APP_STORE_TENANT_ID=not-a-real-key
-CASEWORKER_CLIENT_ID=not-a-real-key
-CASEWORKER_CLIENT_SECRET=not-a-real-key
+#APP_STORE_CLIENT_ID=not-a-real-key
+#APP_STORE_TENANT_ID=not-a-real-key
+#CASEWORKER_CLIENT_ID=not-a-real-key
+#CASEWORKER_CLIENT_SECRET=not-a-real-key
 
 # ingress and protocol for webhook subscription to app store - must match local apps's rails server
 HOSTS=localhost:3002


### PR DESCRIPTION
## Description of change

[[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-XXX)](https://dsdmoj.atlassian.net/browse/CRM457-1733)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
`env.development.local` created without default redis_url

### After changes:
`env.development.local` includes default redis_url

## How to manually test the feature
provider, app-store, caseworker should be able to fetch/update CRMs between them in a new dev env setup
