### PR TITLE
Make modsec state configurable

### DIFF
--- a/helm_deploy/templates/ingress.yaml
+++ b/helm_deploy/templates/ingress.yaml
@@ -24,7 +24,8 @@ metadata:
     nginx.ingress.kubernetes.io/custom-http-errors: "423"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |
-      SecRuleEngine On
+      SecAuditEngine {{ .Values.ingress.modsec.auditState }}
+      SecRuleEngine {{ .Values.ingress.modsec.ruleState }}
       SecRequestBodyNoFilesLimit 524288
       SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-forms-team,status:423"
       SecDefaultAction "phase:4,pass,log,tag:github_team=laa-crime-forms-team,status:423"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -26,6 +26,9 @@ ingress:
   enabled: true
   namespace: laa-assess-crime-forms-dev
   className: modsec
+  modsec:
+    ruleState: "On"
+    auditState: "RelevantOnly"
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: laa-assess-crime-forms-app-laa-assess-crime-forms-dev-green
   hosts:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -26,6 +26,9 @@ ingress:
   enabled: true
   namespace: laa-assess-crime-forms-prod
   className: modsec
+  modsec:
+    ruleState: "On"
+    auditState: "RelevantOnly"
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: laa-assess-crime-forms-app-laa-assess-crime-forms-prod-green
   hosts:

--- a/helm_deploy/values-uat.yaml
+++ b/helm_deploy/values-uat.yaml
@@ -26,6 +26,9 @@ ingress:
   enabled: true
   namespace: laa-assess-crime-forms-uat
   className: modsec
+  modsec:
+    ruleState: "DetectionOnly"
+    auditState: "On"
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: laa-assess-crime-forms-app-laa-assess-crime-forms-uat-green
   hosts:


### PR DESCRIPTION
For an ITHC audit we want to stop modsec intervening on UAT. We can't easily switch it off entirely without outages, so this PR switches modsec to detection only mode.