### PR TITLE
CRM457-1368: Unsub from app store on branch deletion

### DIFF
--- a/.github/actions/delete-dev-release/action.yml
+++ b/.github/actions/delete-dev-release/action.yml
@@ -82,6 +82,7 @@ runs:
 
         if [[ ! -z "$found" ]]
         then
+          kubectl exec deploy/$release_name -it -- bundle exec rails app_store:unsubscribe
           helm delete $release_name
           kubectl delete pvc data-$release_name-postgresql-0
           kubectl delete pvc redis-data-$release_name-redis-master-0

--- a/app/services/app_store_client.rb
+++ b/app/services/app_store_client.rb
@@ -37,7 +37,7 @@ class AppStoreClient
     when 200..204
       :success
     else
-      raise "Unexpected response from AppStore - status #{response.code} on create subscription"
+      raise "Unexpected response from AppStore - status #{response.code} on #{action} subscription"
     end
   end
 

--- a/app/services/app_store_client.rb
+++ b/app/services/app_store_client.rb
@@ -29,8 +29,9 @@ class AppStoreClient
     end
   end
 
-  def create_subscription(payload)
-    response = self.class.post("#{host}/v1/subscriber", **options(payload))
+  def trigger_subscription(payload, action: :create)
+    method = action == :create ? :post : :delete
+    response = self.class.send(method, "#{host}/v1/subscriber", **options(payload))
 
     case response.code
     when 200..204

--- a/app/services/app_store_subscriber.rb
+++ b/app/services/app_store_subscriber.rb
@@ -1,13 +1,19 @@
 class AppStoreSubscriber
   include Rails.application.routes.url_helpers
 
-  def self.call
-    new.subscribe
+  def self.subscribe
+    new.change_subscription(:create)
   rescue StandardError => e
     Sentry.capture_exception(e)
   end
 
-  def subscribe
+  def self.unsubscribe
+    new.change_subscription(:destroy)
+  rescue StandardError => e
+    Sentry.capture_exception(e)
+  end
+
+  def change_subscription(action)
     hostname = ENV.fetch('INTERNAL_HOST_NAME', ENV.fetch('HOSTS', nil)&.split(',')&.first)
     return if hostname.blank?
 
@@ -16,8 +22,9 @@ class AppStoreSubscriber
       protocol: 'http'
     )
 
-    AppStoreClient.new.create_subscription(
-      { webhook_url: url, subscriber_type: :caseworker }
+    AppStoreClient.new.trigger_subscription(
+      { webhook_url: url, subscriber_type: :caseworker },
+      action:,
     )
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -81,7 +81,7 @@ module LaaAssessNonStandardMagistrateFee
     config.x.contact.feedback_url = 'tbc'
     config.after_initialize do
       Rails.application.reload_routes!
-      AppStoreSubscriber.call
+      AppStoreSubscriber.subscribe
     end
   end
 end

--- a/lib/tasks/app_store.rake
+++ b/lib/tasks/app_store.rake
@@ -1,0 +1,7 @@
+namespace :app_store do
+  desc 'Unsubscribe this branch deployment from app store notifications'
+
+  task unsubscribe: :environment do
+    AppStoreSubscriber.unsubscribe
+  end
+end

--- a/spec/lib/tasks/app_store_unsubscribe_spec.rb
+++ b/spec/lib/tasks/app_store_unsubscribe_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+describe 'app_store:', type: :task do
+  describe 'unsubscribe' do
+    subject { Rake::Task['app_store:unsubscribe'] }
+
+    before do
+      Rails.application.load_tasks if Rake::Task.tasks.empty?
+      allow(AppStoreSubscriber).to receive(:unsubscribe)
+    end
+
+    after do
+      Rake::Task['app_store:unsubscribe']
+    end
+
+    it 'calls the service' do
+      subject.invoke
+      expect(AppStoreSubscriber).to have_received(:unsubscribe)
+    end
+  end
+end

--- a/spec/services/app_store_subscriber_spec.rb
+++ b/spec/services/app_store_subscriber_spec.rb
@@ -1,18 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe AppStoreSubscriber do
-  describe '.call' do
+  describe '.subscribe' do
     let(:client) { instance_double(AppStoreClient) }
 
     before do
       allow(AppStoreClient).to receive(:new).and_return(client)
-      allow(client).to receive(:create_subscription)
+      allow(client).to receive(:trigger_subscription)
     end
 
     context 'when there is no defined host' do
       it 'does not make a request' do
         expect(AppStoreClient).not_to receive(:new)
-        described_class.call
+        described_class.subscribe
       end
     end
 
@@ -24,20 +24,21 @@ RSpec.describe AppStoreSubscriber do
       end
 
       it 'makes a request' do
-        described_class.call
-        expect(client).to have_received(:create_subscription).with(
-          webhook_url: 'http://example.com/app_store_webhook', subscriber_type: :caseworker
+        described_class.subscribe
+        expect(client).to have_received(:trigger_subscription).with(
+          { webhook_url: 'http://example.com/app_store_webhook', subscriber_type: :caseworker },
+          action: :create
         )
       end
 
       context 'when the app store request errors out' do
         before do
-          allow(client).to receive(:create_subscription).and_raise(StandardError)
+          allow(client).to receive(:trigger_subscription).and_raise(StandardError)
           allow(Sentry).to receive(:capture_exception)
         end
 
         it 'passes the error to Sentry' do
-          expect { described_class.call }.not_to raise_error
+          expect { described_class.subscribe }.not_to raise_error
           expect(Sentry).to have_received(:capture_exception)
         end
       end
@@ -51,9 +52,10 @@ RSpec.describe AppStoreSubscriber do
       end
 
       it 'picks the first one' do
-        described_class.call
-        expect(client).to have_received(:create_subscription).with(
-          webhook_url: 'http://other.com/app_store_webhook', subscriber_type: :caseworker
+        described_class.subscribe
+        expect(client).to have_received(:trigger_subscription).with(
+          { webhook_url: 'http://other.com/app_store_webhook', subscriber_type: :caseworker },
+          action: :create
         )
       end
     end
@@ -66,10 +68,46 @@ RSpec.describe AppStoreSubscriber do
       end
 
       it 'uses that' do
-        described_class.call
-        expect(client).to have_received(:create_subscription).with(
-          webhook_url: 'http://internal.svc.local/app_store_webhook', subscriber_type: :caseworker
+        described_class.subscribe
+        expect(client).to have_received(:trigger_subscription).with(
+          { webhook_url: 'http://internal.svc.local/app_store_webhook', subscriber_type: :caseworker },
+          action: :create
         )
+      end
+    end
+  end
+
+  describe '.unsubscribe' do
+    let(:client) { instance_double(AppStoreClient) }
+
+    before do
+      allow(AppStoreClient).to receive(:new).and_return(client)
+      allow(client).to receive(:trigger_subscription)
+    end
+
+    around do |example|
+      ENV['HOSTS'] = 'example.com'
+      example.run
+      ENV['HOSTS'] = nil
+    end
+
+    it 'uses the right action' do
+      described_class.unsubscribe
+      expect(client).to have_received(:trigger_subscription).with(
+        { webhook_url: 'http://example.com/app_store_webhook', subscriber_type: :caseworker },
+        action: :destroy
+      )
+    end
+
+    context 'when the app store request errors out' do
+      before do
+        allow(client).to receive(:trigger_subscription).and_raise(StandardError)
+        allow(Sentry).to receive(:capture_exception)
+      end
+
+      it 'passes the error to Sentry' do
+        expect { described_class.unsubscribe }.not_to raise_error
+        expect(Sentry).to have_received(:capture_exception)
       end
     end
   end


### PR DESCRIPTION
## Description of change
So that the app store stops trying to send notifications to deleted branches.

If this works I'll replicate on provider.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1368)
