### PR TITLE
CRM457-1744: Fix for non-iso chars

### DIFF
--- a/app/controllers/prior_authority/downloads_controller.rb
+++ b/app/controllers/prior_authority/downloads_controller.rb
@@ -4,10 +4,11 @@ module PriorAuthority
     PRESIGNED_EXPIRY = 60
 
     def show
+      file_name = params[:file_name].encode(Encoding.find('ISO-8859-1'), invalid: :replace, undef: :replace, replace: '')
       download_url = S3_BUCKET.object(params[:id])
                               .presigned_url(:get,
                                              expires_in: PRESIGNED_EXPIRY,
-                                             response_content_disposition: "attachment; filename=\"#{params[:file_name]}\"")
+                                             response_content_disposition: "attachment; filename=\"#{file_name}\"")
       redirect_to download_url, allow_other_host: true
     end
   end

--- a/spec/system/prior_authority/view_applications_spec.rb
+++ b/spec/system/prior_authority/view_applications_spec.rb
@@ -24,7 +24,11 @@ RSpec.describe 'View applications' do
             period: 180,
             cost_per_hour: '3.50',
             travel_time: nil,
-            travel_cost_per_hour: nil
+            travel_cost_per_hour: nil,
+            document: {
+              'file_name' => 'test – with odd-char.pdf',
+              'file_path' => '123123123'
+            }
           ),
           build(:alternative_quote)
         ]
@@ -75,7 +79,7 @@ RSpec.describe 'View applications' do
         within('#primary-quote.govuk-summary-card') do
           expect(page).to have_content "Service requiredPathologist report\n" \
                                        "Service detailsABC DEFABC, HIJ, SW1 1AA\n" \
-                                       "Quote uploadtest.pdf\n" \
+                                       "Quote uploadtest – with odd-char.pdf\n" \
                                        'Existing prior authority grantedYes'
           expect(page).to have_content 'Cost typeAmountRateTotal requested' \
                                        'Service3 hours 0 minutes£3.50£10.50' \
@@ -131,9 +135,9 @@ RSpec.describe 'View applications' do
       end
 
       it 'lets me view associated files' do
-        click_on 'test.pdf'
+        click_on 'test – with odd-char.pdf'
         expect(page).to have_current_path(
-          %r{/123123123\?response-content-disposition=attachment%3B%20filename%3D%22test\.pdf%22}
+          %r{/123123123\?response-content-disposition=attachment%3B%20filename%3D%22test%20%20with%20odd-char\.pdf}
         )
       end
     end


### PR DESCRIPTION
## Description of change
S3 craps out if the filename in the header has chars that don't conform to ISO-8859-1
[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1744)
