### PR TITLE
CRM457-1749: Sending back a claim removes assignments

### DIFF
--- a/app/forms/nsm/send_back_form.rb
+++ b/app/forms/nsm/send_back_form.rb
@@ -20,6 +20,7 @@ module Nsm
       Claim.transaction do
         claim.data['status'] = FURTHER_INFO
         claim.update!(state: FURTHER_INFO)
+        claim.assignments.destroy_all
         Nsm::Event::SendBack.build(submission: claim, comment: comment, previous_state: previous_state,
                                    current_user: current_user)
         NotifyAppStore.perform_later(submission: claim)

--- a/spec/forms/nsm/send_back_form_spec.rb
+++ b/spec/forms/nsm/send_back_form_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Nsm::SendBackForm do
 
   describe '#persistance' do
     let(:user) { instance_double(User) }
-    let(:claim) { create(:claim) }
+    let(:claim) { create(:claim, assignments: [build(:assignment)]) }
     let(:params) { { claim: claim, comment: 'some comment', current_user: user } }
 
     before do
@@ -39,6 +39,10 @@ RSpec.describe Nsm::SendBackForm do
     it 'updates the claim' do
       subject.save
       expect(claim.reload).to have_attributes(state: 'further_info')
+    end
+
+    it 'removes the assignment' do
+      expect { subject.save }.to change { claim.assignments.count }.from(1).to(0)
     end
 
     it 'creates a Decision event' do


### PR DESCRIPTION
## Description of change
Remove the assignment from a claim when it's send back. This brings claims in line with PA applications.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1749)
