### PR TITLE
Return correct uplift when value is nil

### DIFF
--- a/app/view_models/nsm/v1/work_item.rb
+++ b/app/view_models/nsm/v1/work_item.rb
@@ -92,7 +92,7 @@ module Nsm
           '.date' => format_in_zone(completed_on),
           '.time_spent' => format_period(original_time_spent),
           '.fee_earner' => fee_earner.to_s,
-          '.uplift_claimed' => "#{original_uplift}%",
+          '.uplift_claimed' => "#{original_uplift.to_i}%",
         }
         if vat_registered?
           rows['.vat'] = NumberTo.percentage(vat_rate)


### PR DESCRIPTION
When editing a work item, if the uplift is nil it doesn't display anything in the provider submission table.

Using type coercion, we can convert the false-y nil value to 0.

## Screenshots of changes (if applicable)

### Before changes:
![image](https://github.com/user-attachments/assets/a6153064-56d6-49d3-9b11-04fdafe385f9)


### After changes:
<img width="625" alt="image" src="https://github.com/user-attachments/assets/91aac9b0-2a9e-418f-8aef-2949392b5344">
