### PR TITLE
CRM457-1757: Display last_updated date on search results

### DIFF
--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -22,7 +22,9 @@ class SearchForm
   validate :at_least_one_field_set
 
   def results
-    @search_response[:raw_data].map { SearchResult.new(_1) }
+    @search_response[:data].each_with_object([]).with_index do |(view_data, results), i|
+      results << SearchResult.new(view_data, @search_response[:raw_data][i])
+    end
   end
 
   def pagy

--- a/app/view_models/search_result.rb
+++ b/app/view_models/search_result.rb
@@ -2,8 +2,9 @@ class SearchResult
   include NameConstructable
   include SubmissionTagHelper
 
-  def initialize(data)
-    @data = data.deep_stringify_keys
+  def initialize(view_data, raw_data)
+    @view_data = view_data.deep_stringify_keys
+    @data = raw_data.deep_stringify_keys
   end
 
   delegate :id, to: :submission
@@ -29,8 +30,8 @@ class SearchResult
     submission.assignments.first&.display_name || I18n.t('search.unassigned')
   end
 
-  def date_updated
-    submission.updated_at.to_fs(:stamp)
+  def last_updated
+    @view_data['last_updated'].to_time.to_fs(:stamp)
   end
 
   def state_tag

--- a/app/views/prior_authority/searches/show.html.erb
+++ b/app/views/prior_authority/searches/show.html.erb
@@ -103,7 +103,7 @@
                   <%= search_result.caseworker %>
                 </td>
                 <td class="govuk-table__cell">
-                  <%= search_result.date_updated %>
+                  <%= search_result.last_updated %>
                 </td>
                 <td class="govuk-table__cell">
                   <%= search_result.state_tag %>

--- a/spec/system/prior_authority/search_spec.rb
+++ b/spec/system/prior_authority/search_spec.rb
@@ -20,10 +20,12 @@ RSpec.describe 'Search', :stub_oauth_token do
 
   context 'when I search for an application that has already been imported' do
     let(:application) { create :prior_authority_application }
+
     let(:stub) do
       stub_request(:post, endpoint).with(body: payload).to_return(
         status: 201,
         body: { metadata: { total_results: 1 },
+                data: [{ last_updated: Time.current.iso8601 }],
                 raw_data: [{ application_id: application.id, application: application.data }] }.to_json
       )
     end
@@ -51,6 +53,8 @@ RSpec.describe 'Search', :stub_oauth_token do
 
   context 'when the app store has unsynced records' do
     let(:id) { SecureRandom.uuid }
+    let(:view_record) { { last_updated: Time.current.iso8601 } }
+
     let(:record) do
       {
         application: build(:prior_authority_data),
@@ -68,7 +72,7 @@ RSpec.describe 'Search', :stub_oauth_token do
     before do
       stub_request(:post, endpoint).with(body: payload).to_return(
         status: 201,
-        body: { metadata: { total_results: 1 }, raw_data: [record] }.to_json
+        body: { metadata: { total_results: 1 }, data: [view_record], raw_data: [record] }.to_json
       )
     end
 
@@ -89,7 +93,7 @@ RSpec.describe 'Search', :stub_oauth_token do
     before do
       stub_request(:post, endpoint).with(body: payload).to_return(
         status: 201,
-        body: { metadata: { total_results: 0 }, raw_data: [] }.to_json
+        body: { metadata: { total_results: 0 }, data: [], raw_data: [] }.to_json
       )
     end
 
@@ -130,6 +134,7 @@ sort_direction: 'ascending' },
       payloads.map do |payload|
         stub_request(:post, endpoint).with(body: payload).to_return(
           status: 201, body: { metadata: { total_results: 21 },
+                               data: applications.map { { last_updated: Time.current.iso8601 } },
                                raw_data: applications.map { { application_id: _1.id, application: _1.data } } }.to_json
         )
       end
@@ -161,10 +166,11 @@ sort_direction: 'ascending' },
         updated_to: '2023-04-23'
       }
     end
+
     let(:stub) do
       stub_request(:post, endpoint).with(body: payload).to_return(
         status: 201,
-        body: { metadata: { total_results: 0 }, raw_data: [] }.to_json
+        body: { metadata: { total_results: 0 }, data: [], raw_data: [] }.to_json
       )
     end
 


### PR DESCRIPTION
## Description of change
*TBD*

Display last_updated date on search results

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1757)

This is one option for handling edge cases where a submissions
updated_at goes out sync with events.

The "last_updated" date is the actual date that is both filtered and sorted
on by the appstore searches API and should therefore match the search results
returned exactly.

This option does, however, create a divide between the search results page
and other index pages that show "your", "open" and "closed" applications
sorted|sortable by submission.updated_at.

## Alternative
Another option is to sync the top-level`last_updated_at` on appstore wtih submissions
on caseworker. However, aside from adding the column to submissions in caseworker, backfilling 
it and syncing via the UpdateSubmission service we would also need to handle the fact that an event
would need to update it in caseworker, as it does in appstore.

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
