### PR TITLE
Pull latest AWS RDS certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,8 +77,8 @@ RUN chmod +x run.sh
 # Download RDS certificates bundle -- needed for SSL verification
 # We set the path to the bundle in the ENV, and use it in `/config/database.yml`
 #
-ENV RDS_COMBINED_CA_BUNDLE /usr/src/app/config/rds-combined-ca-bundle.pem
-ADD https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem $RDS_COMBINED_CA_BUNDLE
+ENV RDS_COMBINED_CA_BUNDLE /usr/src/app/config/global-bundle.pem
+ADD https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem $RDS_COMBINED_CA_BUNDLE
 RUN chmod +r $RDS_COMBINED_CA_BUNDLE
 
 ARG APP_BRANCH_NAME


### PR DESCRIPTION
## Description of change
Pull latest AWS RDS certs

In case we actually are using them, which i do not believe
we are as we are not setting sslmode and sslrootcert in
database.yml

```
  sslmode: <%= ENV.fetch('DATABASE_SSLMODE', 'verify-full') %>
  sslrootcert: <%= ENV['RDS_COMBINED_CA_BUNDLE'] %>
```


## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
