### PR TITLE
CRM457-1757: Make sure "last updated" is accurate

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -24,7 +24,9 @@ class Event < ApplicationRecord
   LOCAL_EVENTS = [
     'Event::ChangeRisk',
     'Event::DraftDecision',
+    'Event::Edit',
     'Event::Note',
+    'Event::UndoEdit',
     'PriorAuthority::Event::DraftSendBack',
   ].freeze
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -20,7 +20,16 @@ class Event < ApplicationRecord
     'PriorAuthority::Event::DraftSendBack',
     'PriorAuthority::Event::SendBack',
   ].freeze
+
+  NOTIFYING_EVENTS = [
+    'Event::Assignment',
+    'Event::Unassignment',
+    'Event::NewVersion',
+  ].freeze
+
   scope :history, -> { where(event_type: HISTORY_EVENTS).order(created_at: :desc) }
+
+  scope :notifying, -> { where(event_type: NOTIFYING_EVENTS) }
 
   # simplifies the rehydrate process
   attribute :public

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -21,15 +21,16 @@ class Event < ApplicationRecord
     'PriorAuthority::Event::SendBack',
   ].freeze
 
-  NOTIFYING_EVENTS = [
-    'Event::Assignment',
-    'Event::Unassignment',
-    'Event::NewVersion',
+  LOCAL_EVENTS = [
+    'Event::ChangeRisk',
+    'Event::DraftDecision',
+    'Event::Note',
+    'PriorAuthority::Event::DraftSendBack',
   ].freeze
 
   scope :history, -> { where(event_type: HISTORY_EVENTS).order(created_at: :desc) }
 
-  scope :notifying, -> { where(event_type: NOTIFYING_EVENTS) }
+  scope :non_local, -> { where.not(event_type: LOCAL_EVENTS) }
 
   # simplifies the rehydrate process
   attribute :public

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -21,4 +21,25 @@ class Submission < ApplicationRecord
   def latest_provider_update_event
     events.latest_provider_update
   end
+
+  def last_updated_at
+    # This method will always¹ return the same value as the app store
+    # 'last_updated' value in its search results provided the following
+    # always hold true:
+
+    # - all and only Event::NOTIFYING_EVENTS trigger an app store update
+    #   that is not accompanied by sending a new version to the app store
+    # - the provider app never sends any events to the app store without
+    #   also sending a new version
+    # - any time a new version is synced from the app store, this triggers a
+    #   NewVersion event which then gets sent BACK to the app store
+
+    # The fallback to `updated_at` is for the edge case where somehow a submission
+    # gets created without an accompanying NewVersion event
+
+    # ¹ The exceptions are in the brief window between the app store receiving a new
+    # version from the provider and the caseworker completing sending a NewVersion
+    # event _back_ to the app store.
+    events.notifying.maximum(:created_at) || updated_at
+  end
 end

--- a/app/view_models/nsm/v1/table_row.rb
+++ b/app/view_models/nsm/v1/table_row.rb
@@ -8,7 +8,7 @@ module Nsm
       attribute :firm_office
       attribute :submission
       attribute :risk
-      delegate :updated_at, to: :submission
+      delegate :last_updated_at, to: :submission
 
       def main_defendant_name
         main_defendant = defendants.detect { |defendant| defendant['main'] }
@@ -20,7 +20,7 @@ module Nsm
       end
 
       def date_updated
-        updated_at.to_fs(:stamp)
+        last_updated_at.to_fs(:stamp)
       end
 
       def case_worker_name

--- a/app/view_models/prior_authority/v1/application_summary.rb
+++ b/app/view_models/prior_authority/v1/application_summary.rb
@@ -46,7 +46,7 @@ module PriorAuthority
       end
 
       def date_updated_str
-        submission.updated_at.to_fs(:stamp)
+        submission.last_updated_at.to_fs(:stamp)
       end
 
       def rep_order_date_str

--- a/app/view_models/prior_authority/v1/table_row.rb
+++ b/app/view_models/prior_authority/v1/table_row.rb
@@ -19,7 +19,7 @@ module PriorAuthority
       end
 
       def date_updated_str
-        submission.updated_at.to_fs(:stamp)
+        submission.last_updated_at.to_fs(:stamp)
       end
 
       def service_name

--- a/app/view_models/search_result.rb
+++ b/app/view_models/search_result.rb
@@ -30,7 +30,7 @@ class SearchResult
   end
 
   def date_updated
-    submission.updated_at.to_fs(:stamp)
+    submission.last_updated_at.to_fs(:stamp)
   end
 
   def state_tag

--- a/spec/system/prior_authority/view_applications_spec.rb
+++ b/spec/system/prior_authority/view_applications_spec.rb
@@ -255,8 +255,12 @@ RSpec.describe 'View applications' do
 
   context 'when application has been assessed' do
     before do
-      application.update(state: 'rejected', updated_at: DateTime.new(2023, 6, 5, 4, 3, 2))
-      create(:event, :decision, submission: application, details: { comment: 'Not good use of money' })
+      application.update(state: 'rejected')
+      create(:event,
+             :decision,
+             submission: application,
+             details: { comment: 'Not good use of money' },
+             created_at: DateTime.new(2023, 6, 5, 4, 3, 2))
       click_on 'LAA-1234'
     end
 
@@ -306,11 +310,12 @@ RSpec.describe 'View applications' do
           sections_changed: %w[ufn alternative_quote_1],
           requested_at: DateTime.new(2023, 5, 2, 4, 3, 2), },
       ]
-      application.update!(state: 'provider_updated', updated_at: DateTime.new(2023, 6, 5, 4, 3, 2))
+      application.update!(state: 'provider_updated')
       create(:event, :provider_updated,
              submission: application,
              details: { comment: 'Added more info',
-                        corrected_info: %w[ufn alternative_quote_1] })
+                        corrected_info: %w[ufn alternative_quote_1] },
+             created_at: DateTime.new(2023, 6, 5, 4, 3, 2))
       application.assignments.destroy_all
       click_on 'LAA-1234'
     end


### PR DESCRIPTION
## Description of change
Alternative approach to https://github.com/ministryofjustice/laa-assess-crime-forms/pull/628. This will make 'last updated' almost entirely consistent with the app store value used to filter search results, while keeping it entirely consistent across the caseworker app.

I think the 'almost' above is such an extremely edgy edge case that it's ok for now, and the long-term solution is to pull data directly from the app store instead of a local database for all list and details views of applications.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1757)
