### PR TITLE
Adjust pagination to remember position

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  helper Turbo::FramesHelper if Rails.env.test?
+  helper Turbo::StreamsHelper if Rails.env.test?
   include Pagy::Backend
   include ApplicationHelper
   include CookieConcern

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,6 +1,7 @@
 import "@hotwired/turbo-rails"
 import "./controllers"
 import "./component/nsm/letters_calls_adjustment"
+import "./component/nsm/fix-pagination.js"
 import "./component/nsm/work_item_adjustment"
 import "./component/nsm/disbursement_adjustment"
 import "./component/prior_authority/service_cost_adjustment"

--- a/app/javascript/component/nsm/fix-pagination.js
+++ b/app/javascript/component/nsm/fix-pagination.js
@@ -1,0 +1,59 @@
+function waitForElm(selector) {
+  return new Promise(function (resolve) {
+    if (document.querySelector(selector)) {
+      return resolve(document.querySelector(selector));
+    }
+
+    const observer = new MutationObserver(function (_mutations) {
+      if (document.querySelector(selector)) {
+        observer.disconnect();
+        resolve(document.querySelector(selector));
+      }
+    });
+
+    // If you get "parameter 1 is not of type 'Node'" error, see https://stackoverflow.com/a/77855838/492336
+    observer.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+  });
+}
+
+document.addEventListener("DOMContentLoaded", function () {
+  waitForElm("turbo-frame tr.govuk-table__row").then(function () {
+    if (sessionStorage.getItem("jumpPage")) {
+      const page = sessionStorage.getItem("jumpPage");
+      waitForElm(`turbo-frame .govuk-pagination a[href$='page=${page}']`).then(
+        function (elem) {
+          setTimeout(function () {
+            elem.click();
+            sessionStorage.removeItem("jumpPage");
+          }, 100);
+        },
+      );
+    }
+
+    if (sessionStorage.getItem("jumpIndex")) {
+      const index = sessionStorage.getItem("jumpIndex");
+      const elem = document.querySelector(
+        `turbo-frame tr.govuk-table__row:nth-child(${index})`,
+      );
+      if (elem) {
+        elem.scrollIntoView({ behavior: "smooth" });
+        sessionStorage.removeItem("jumpIndex");
+      }
+    }
+
+    waitForElm("turbo-frame").then(function (elem) {
+      elem.addEventListener("click", function (e) {
+        if (!e.target.closest(".govuk-pagination")) {
+          const tab = e.target.closest("turbo-frame");
+          const page = new URL(tab.src).searchParams.get("page");
+          sessionStorage.setItem("jumpPage", page ?? 1);
+          sessionStorage.setItem("jumpIndex", e.target.closest("tr").rowIndex);
+          console.log(page ?? 1);
+        }
+      });
+    });
+  });
+});

--- a/spec/system/nsm/assessment_spec.rb
+++ b/spec/system/nsm/assessment_spec.rb
@@ -75,4 +75,28 @@ Rails.describe 'Assessment', :stub_oauth_token, :stub_update_claim do
       end.to have_enqueued_job(NotifyAppStore)
     end
   end
+
+  context 'Review and Adjust' do
+    it 'correctly scrolls to a selected row', :javascript do
+      page_index = 3
+      row_index = 95
+      visit nsm_claim_adjustments_path(claim)
+      page.execute_script('document.querySelector("turbo-frame").scrollIntoView()')
+
+      click_link_or_button 'Work items'
+      find(".govuk-pagination a[href$='page=#{page_index}']", wait: 5).click
+      find("tr.govuk-table__row:nth-child(#{row_index}) .govuk-table__header a").click
+
+      expect(page).to have_current_path edit_nsm_claim_work_item_path(claim, claim.data['work_items'][0]['id'])
+      sleep(0.5)
+      expect(page.evaluate_script("window.sessionStorage.getItem('jumpPage') == '#{page_index}'")).to be true
+      expect(page.evaluate_script("window.sessionStorage.getItem('jumpIndex') == '#{row_index}'")).to be true
+
+      click_link_or_button 'Back'
+      expect(page).to have_current_path nsm_claim_adjustments_path(claim)
+      sleep(0.5)
+      expect(page.evaluate_script("window.sessionStorage.getItem('jumpPage') == null")).to be true
+      expect(page.evaluate_script("window.sessionStorage.getItem('jumpIndex') == null")).to be true
+    end
+  end
 end


### PR DESCRIPTION
## Description of change

Resolves issues around navigating large, paginated tables contained in turbo frames.

When you click on a new page, a new frame is rendered with the results of a different route (determined by the `?page=` query parameter. However, this doesn't reflect in the page's query parameters so this information is lost when navigating to edit something and going back.

According to the [handbook](https://turbo.hotwired.dev/reference/frames), there are attributes that can control whether the route should update the page's params too (namely `data-turbo-frame`). However, this could break the page later if pagination was added there too.

So instead what this solution aims to do is a purely client-side solution which adds a click listener to the turbo frame (events bubble, so this is to ensure that all children get the listener without having to be polled) and when you click on one of the edit links it saves the row index and the page you are on to `sessionStorage` (which clears when the tab is closed and isn't shared between tabs), and when the page loads it checks if the index and page are stored and jumps nicely to them before clearing them (so it'll only do it once). This solution works for the simple flows referred to from the ticket, but perhaps not in more complex flows

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1753)

## UX Considerations

This ticket touches a number of UX pain-points that don't have a clean solution, so these would need to be resolved before this can sensibly go in

### Lazy loading the frames
Because of how the lazy loading works for the turbo frames, they're only loaded when they're in the browser viewport. As such, any attempts to scroll to the elements from the page load doesn't do anything until the frame is scrolled to at which point the jump takes over.

If the lazy load is removed from the frames, everything works as expected and this would end up being preferential overall; but this could maybe impact page load times.

### `localStorage` vs `sessionStorage`
I made a conscious decision to use `sessionStorage` here as it doesn't persist past closing the tab and the data isn't shared across multiple tabs, so each tab won't overwrite each other.

I think this is the preferential solution, but using `localStorage` could be seen as preferred based on how users interact with the system.

### Smooth scrolling vs jumping
The [behaviour](https://github.com/ministryofjustice/laa-assess-crime-forms/compare/CRM457-1753/fix-pagination?expand=1#diff-a419245768035ba3d2be5e1551e7b7f1042a46c4b3f8cf1c2d772c06079181fcR42) by default is to smoothly scroll to the last row you clicked on, by removing the `behaviour: smooth` this ends up being a jump to the row instead.

I can see cases for both here, so whichever is preferred makes sense. It's a quick fix.

### How the page "jump" works
So the only way I could think of having the page jump work (because I don't yet know the boundaries between rails and the client) was to simulate a click on the page, which obviously means that the first page is loaded first pointlessly before we then jump to the correct page.

If there's a simple way to pass the current page to Pagy from the client then that would be ideal.

## Screenshots of changes (if applicable)

### Before changes:


https://github.com/user-attachments/assets/015ced20-2fc6-49be-a55c-f28ebb08ea18



### After changes:

Starts with a refresh to prove that nothing happens by default.

https://github.com/user-attachments/assets/1b12f31d-9ff3-4bb0-9104-13beeaabedbf


## How to manually test the feature
1. Navigate to the claims adjustments page => review and adjust tab
2. Optionally make the below change to seed lots of work items 

```diff
diff --git a/app/controllers/nsm/work_items_controller.rb b/app/controllers/nsm/work_items_controller.rb
index 1ca8fc6..84fe634 100644
--- a/app/controllers/nsm/work_items_controller.rb
+++ b/app/controllers/nsm/work_items_controller.rb
@@ -8,6 +8,12 @@ module Nsm
     def index
       claim = Claim.find(params[:claim_id])
       items = BaseViewModel.build(:work_item, claim, 'work_items')
+      items = items + items + items
+      items = items + items + items
+      items = items + items + items
+      items = items + items + items
+      items = items + items + items
+      items = items + items + items
       sorted_items = Sorters::WorkItemsSorter.call(items, @sort_by, @sort_direction)
       pagy, work_items = pagy_array(sorted_items, items: ITEM_COUNT_OVERRIDE)
       work_item_summary = BaseViewModel.build(:work_item_summary, claim)
```
3. Also optionally disable lazy loading on the turbo frame

```diff
diff --git a/app/views/nsm/adjustments/show.html.erb b/app/views/nsm/adjustments/show.html.erb
index 91bfa80..5620bef 100644
--- a/app/views/nsm/adjustments/show.html.erb
+++ b/app/views/nsm/adjustments/show.html.erb
@@ -41,7 +41,7 @@
       </ul>
 
       <div class="govuk-tabs__panel" id="work-items-tab">
-        <%= turbo_frame_tag 'work_items', src: nsm_claim_work_items_path(claim), loading: :lazy do %>
+        <%= turbo_frame_tag 'work_items', src: nsm_claim_work_items_path(claim) do %>
           Loading
         <% end %>
       </div>
```

4. Go to a different page and click on a random work item
5. Go back
6. The page should scroll to the row you clicked on before