### PR TITLE
Ensure that turbo frames render during tests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  # These are needed otherwise turbo frames don't render in tests
+  helper Turbo::FramesHelper if Rails.env.test?
+  helper Turbo::StreamsHelper if Rails.env.test?
+
   include Pagy::Backend
   include ApplicationHelper
   include CookieConcern


### PR DESCRIPTION
## Description of change

Noticed during #635, turbo frames don't render inside the Capybara environment without these helpers enabled.

[Discussion](https://discuss.hotwired.dev/t/turbo-frame-not-works-with-capybara/3990)