### PR TITLE
CRM457-1790: Discard  all adjustments prior to sending back

### DIFF
--- a/app/forms/prior_authority/send_back_form.rb
+++ b/app/forms/prior_authority/send_back_form.rb
@@ -30,6 +30,7 @@ module PriorAuthority
       return false unless valid?
 
       PriorAuthorityApplication.transaction do
+        discard_all_adjustments
         stash(add_draft_send_back_event: false)
         update_local_records
         NotifyAppStore.perform_later(submission:)
@@ -50,6 +51,11 @@ module PriorAuthority
                                                  updates_needed:,
                                                  comments:,
                                                  current_user:)
+    end
+
+    def discard_all_adjustments
+      app_store_record = AppStoreClient.new.get_submission(submission)
+      submission.update!(data: app_store_record['application'])
     end
 
     def update_local_records

--- a/spec/jobs/prior_authority/fake_assess_spec.rb
+++ b/spec/jobs/prior_authority/fake_assess_spec.rb
@@ -6,9 +6,13 @@ RSpec.describe PriorAuthority::FakeAssess do
   let(:application) { create(:prior_authority_application, state: :submitted) }
 
   context 'when harnessing the power of randomness' do
+    let(:client) { instance_double(AppStoreClient, get_submission: app_store_record) }
+    let(:app_store_record) { { 'application' => application.data } }
+
     before do
       create(:caseworker)
       allow(NotifyAppStore).to receive(:perform_later)
+      allow(AppStoreClient).to receive(:new).and_return(client)
       allow(SecureRandom).to receive(:rand).and_return random_choice
       subject.perform([application.id])
     end

--- a/spec/services/sorters/work_items_sorter_spec.rb
+++ b/spec/services/sorters/work_items_sorter_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.shared_examples 'a correctly ordered results (both ascending and descending)' do |results|
+RSpec.shared_examples 'correctly ordered work item results (both ascending and descending)' do |results|
   it { expect(subject).to eq(results) }
 
   context 'when descending order' do
@@ -36,7 +36,7 @@ sort_field => sort_value_c1),
     let(:sort_by) { 'item' }
     let(:sort_field) { 'uplift' }
 
-    it_behaves_like 'a correctly ordered results (both ascending and descending)', %w[A1 B1 C1]
+    it_behaves_like 'correctly ordered work item results (both ascending and descending)', %w[A1 B1 C1]
   end
 
   context 'when sorting by work_type' do
@@ -45,7 +45,7 @@ sort_field => sort_value_c1),
     let(:sort_value_a1) { 'Waiting' }
     let(:sort_value_b1) { 'Travel' }
 
-    it_behaves_like 'a correctly ordered results (both ascending and descending)', %w[B1 C1 A1]
+    it_behaves_like 'correctly ordered work item results (both ascending and descending)', %w[B1 C1 A1]
   end
 
   context 'when sorting by completed_on' do
@@ -55,7 +55,7 @@ sort_field => sort_value_c1),
     let(:sort_value_b1) { Date.new(2023, 1, 4) }
     let(:sort_value_c1) { Date.new(2023, 1, 1) }
 
-    it_behaves_like 'a correctly ordered results (both ascending and descending)', %w[C1 A1 B1]
+    it_behaves_like 'correctly ordered work item results (both ascending and descending)', %w[C1 A1 B1]
   end
 
   context 'when sorting by claimed uplift' do
@@ -65,7 +65,7 @@ sort_field => sort_value_c1),
     let(:sort_value_b1) { nil } # nil treated as 0
     let(:sort_value_c1) { 100 }
 
-    it_behaves_like 'a correctly ordered results (both ascending and descending)', %w[B1 A1 C1]
+    it_behaves_like 'correctly ordered work item results (both ascending and descending)', %w[B1 A1 C1]
   end
 
   context 'when sorting by allowed uplift' do
@@ -75,7 +75,7 @@ sort_field => sort_value_c1),
     let(:sort_value_b1) { nil } # nil treated as 0
     let(:sort_value_c1) { 100 }
 
-    it_behaves_like 'a correctly ordered results (both ascending and descending)', %w[B1 A1 C1]
+    it_behaves_like 'correctly ordered work item results (both ascending and descending)', %w[B1 A1 C1]
   end
 
   context 'when sorting allowed_net_cost uplift' do
@@ -85,12 +85,12 @@ sort_field => sort_value_c1),
     let(:sort_value_b1) { 100 } # nil treated as 0
     let(:sort_value_c1) { 50 }
 
-    it_behaves_like 'a correctly ordered results (both ascending and descending)', %w[C1 A1 B1]
+    it_behaves_like 'correctly ordered work item results (both ascending and descending)', %w[C1 A1 B1]
 
     context 'when no adjustments exists on some records' do
       let(:adjustments_b1) { false }
 
-      it_behaves_like 'a correctly ordered results (both ascending and descending)', %w[B1 C1 A1]
+      it_behaves_like 'correctly ordered work item results (both ascending and descending)', %w[B1 C1 A1]
     end
   end
 end

--- a/spec/system/prior_authority/send_back_spec.rb
+++ b/spec/system/prior_authority/send_back_spec.rb
@@ -5,6 +5,11 @@ RSpec.describe 'Send an application back', :stub_oauth_token do
   let(:application) { create(:prior_authority_application, state: 'submitted') }
 
   before do
+    stub_request(:get, "https://appstore.example.com/v1/submissions/#{application.id}").to_return(
+      status: 200,
+      body: { 'application' => application.data }.to_json,
+    )
+
     sign_in caseworker
     create(:assignment, submission: application, user: caseworker)
     visit '/'


### PR DESCRIPTION
## Description of change
If I make adjustments then send an application back, those adjustments are effectively ignored, in that the provider app does not pick them up and when the provider app pushes a new version to the app store, those adjustments are overwritten anyway. BUT there's an unintended side effect, which is that when trying to work out which fields the provider has changed, the provider app diffs its database with the latest app store version. It picks up on the adjustments in the diff, with the end result that in the caseworker UI the fields the caseworker previously adjusted end up being highlighted as ones the _provider_ has adjusted in the RFI loop.

This PR undoes caseworker adjustments when an application is sent back, so that the version available in the app store has no adjustments, so the "what has the provider changed?" diff no longer gets messed with.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1790)
