### PR TITLE
[CRM457-1753] Ensure table rows act like anchors

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -6,6 +6,7 @@ import "./component/nsm/disbursement_adjustment"
 import "./component/prior_authority/service_cost_adjustment"
 import "./component/prior_authority/travel_cost_adjustment"
 import "./component/prior_authority/additional_cost_adjustment"
+import "./lib/table-item-anchors.js"
 
 // https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#javascript
 import { initAll } from 'govuk-frontend'

--- a/app/javascript/lib/table-item-anchors.js
+++ b/app/javascript/lib/table-item-anchors.js
@@ -1,0 +1,12 @@
+document.addEventListener("DOMContentLoaded", function () {
+  [...document.querySelectorAll("table.govuk-table tr[id] a")].map(
+    function (link) {
+      link.addEventListener("click", function () {
+        const nearestRow = link.closest("tr");
+        if (nearestRow) {
+          history.replaceState({}, "", `#${nearestRow.id}`);
+        }
+      });
+    },
+  );
+});

--- a/app/javascript/lib/table-item-anchors.js
+++ b/app/javascript/lib/table-item-anchors.js
@@ -1,12 +1,20 @@
 document.addEventListener("DOMContentLoaded", function () {
+  [...document.querySelectorAll("a#back-button")].map(function (btn) {
+    btn.addEventListener("click", function (evt) {
+      evt.preventDefault();
+      history.back();
+    });
+    return btn;
+  });
   [...document.querySelectorAll("table.govuk-table tr[id] a")].map(
     function (link) {
       link.addEventListener("click", function () {
         const nearestRow = link.closest("tr");
         if (nearestRow) {
-          history.replaceState({}, "", `#${nearestRow.id}`);
+          history.replaceState(history.state, "", `#${nearestRow.id}`);
         }
       });
+      return link;
     },
   );
 });

--- a/app/javascript/lib/table-item-anchors.js
+++ b/app/javascript/lib/table-item-anchors.js
@@ -1,12 +1,12 @@
 document.addEventListener("DOMContentLoaded", function () {
-  [...document.querySelectorAll("a#back-button")].map(function (btn) {
+  [...document.querySelectorAll("a#back-button")].forEach(function (btn) {
     btn.addEventListener("click", function (evt) {
       evt.preventDefault();
       history.back();
     });
     return btn;
   });
-  [...document.querySelectorAll("table.govuk-table tr[id] a")].map(
+  [...document.querySelectorAll("table[data-anchor-rows] tr[id] a")].forEach(
     function (link) {
       link.addEventListener("click", function () {
         const nearestRow = link.closest("tr");

--- a/app/views/nsm/disbursements/_adjusted.html.erb
+++ b/app/views/nsm/disbursements/_adjusted.html.erb
@@ -22,7 +22,7 @@
     </thead>
     <tbody class="govuk-table__body app-task-list__items">
       <% records.each do |disbursement| %>
-        <tr class="govuk-table__row app-task-list__item">
+        <tr id="<%= disbursement.id %>" class="govuk-table__row app-task-list__item">
           <th class="govuk-table__header" scope="row"><%= disbursement.position %></th>
           <th class="govuk-table__header" scope="row">
             <%=

--- a/app/views/nsm/disbursements/_adjusted.html.erb
+++ b/app/views/nsm/disbursements/_adjusted.html.erb
@@ -1,7 +1,7 @@
 <% if records.size.zero? %>
   <p><%= t('.no_data') %></p>
 <% else %>
-  <table class="govuk-table" data-module="moj-sortable-table">
+  <table class="govuk-table" data-anchor-rows="true" data-module="moj-sortable-table">
     <caption class="govuk-visually-hidden"><%= t('.table_caption') %></caption>
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">

--- a/app/views/nsm/disbursements/_index.html.erb
+++ b/app/views/nsm/disbursements/_index.html.erb
@@ -1,7 +1,7 @@
 <% if records.size.zero? %>
   <p><%= t('.no_data') %></p>
 <% else %>
-  <table class="govuk-table" data-module="moj-sortable-table">
+  <table class="govuk-table" data-anchor-rows="true" data-module="moj-sortable-table">
     <caption class="govuk-visually-hidden"><%= t('.table_caption') %></caption>
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">

--- a/app/views/nsm/disbursements/_index.html.erb
+++ b/app/views/nsm/disbursements/_index.html.erb
@@ -18,7 +18,7 @@
     </thead>
     <tbody class="govuk-table__body app-task-list__items">
       <% records.each do |disbursement| %>
-        <tr class="govuk-table__row app-task-list__item">
+        <tr id="<%= disbursement.id %>"  class="govuk-table__row app-task-list__item">
           <th class="govuk-table__header" scope="row"><%= disbursement.position %></th>
           <th class="govuk-table__header" scope="row">
             <%=

--- a/app/views/nsm/disbursements/edit.html.erb
+++ b/app/views/nsm/disbursements/edit.html.erb
@@ -1,7 +1,7 @@
 <% title t('.page_title') %>
 
 <% content_for(:back_link) do %>
-  <%= link_to t('helpers.back_link'), :back, class: 'govuk-back-link', data: { turbo: 'false' } %>
+  <%= link_to t('helpers.back_link'), "", id: "back-button", class: 'govuk-back-link', data: { turbo: 'false' } %>
 <% end %>
 
 <div class="govuk-grid-row">
@@ -88,7 +88,7 @@
           <%= f.govuk_text_area :explanation, label: { text: t('.explain'), size: 's' }, hint: { text: t('.explain_hint')}, rows: 5 %>
 
           <%= f.govuk_submit t('shared.save_changes') do %>
-            <%= govuk_link_to(t('shared.cancel'), :back, data: { turbo: 'false' }) %>
+            <%= govuk_link_to(t('shared.cancel'), "", id: "back-button", data: { turbo: 'false' }) %>
           <% end %>
         <% end %>
     </div>

--- a/app/views/nsm/disbursements/show.html.erb
+++ b/app/views/nsm/disbursements/show.html.erb
@@ -1,7 +1,7 @@
 <% title t('.page_title') %>
 
 <% content_for(:back_link) do %>
-  <%= link_to t('helpers.back_link'), :back, class: 'govuk-back-link', data: { turbo: 'false' } %>
+  <%= link_to t('helpers.back_link'), "", id: "back-button", class: 'govuk-back-link', data: { turbo: 'false' } %>
 <% end %>
 
 <div class="govuk-grid-row">
@@ -36,6 +36,6 @@
       %>
     <% end %>
 
-    <%= govuk_link_to(t('shared.cancel'), :back, data: { turbo: 'false' }) %>
+    <%= govuk_link_to(t('shared.cancel'), "", id: "back-button", data: { turbo: 'false' }) %>
   </div>
 </div>

--- a/app/views/nsm/work_items/_adjusted.html.erb
+++ b/app/views/nsm/work_items/_adjusted.html.erb
@@ -1,7 +1,7 @@
 <% if records.size.zero? %>
   <p><%= t('.no_data') %></p>
 <% else %>
-  <table class="govuk-table" data-module="moj-sortable-table">
+  <table class="govuk-table" data-anchor-rows="true" data-module="moj-sortable-table">
     <caption class="govuk-visually-hidden"><%= t('.table_caption') %></caption>
     <thead class="govuk-table__head">
       <tr class="govuk-table__row">

--- a/app/views/nsm/work_items/_adjusted.html.erb
+++ b/app/views/nsm/work_items/_adjusted.html.erb
@@ -23,7 +23,7 @@
 
     <tbody class="govuk-table__body app-task-list__items">
       <% records.each do |work_item| %>
-        <tr class="govuk-table__row app-task-list__item">
+        <tr id="<%= work_item.id %>" class="govuk-table__row app-task-list__item">
           <th class="govuk-table__header" scope="row"><%= work_item.position %></th>
           <th class="govuk-table__header" scope="row">
             <%=

--- a/app/views/nsm/work_items/_index.html.erb
+++ b/app/views/nsm/work_items/_index.html.erb
@@ -17,7 +17,7 @@
   <%= govuk_button_link_to(t(".remove_uplift_all"), edit_nsm_claim_work_items_uplift_path(claim), secondary: true, data: { turbo: 'false' }) %>
 <% end %>
 
-<table class="govuk-table data-table" data-module="moj-sortable-table">
+<table class="govuk-table data-table" data-anchor-rows="true" data-module="moj-sortable-table">
   <caption class="govuk-visually-hidden"><%= t('.table_caption') %></caption>
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">

--- a/app/views/nsm/work_items/_index.html.erb
+++ b/app/views/nsm/work_items/_index.html.erb
@@ -35,7 +35,7 @@
 
   <tbody class="govuk-table__body app-task-list__items">
     <% records.each do |work_item| %>
-      <tr class="govuk-table__row app-task-list__item">
+      <tr id="<%= work_item.id  %>" class="govuk-table__row app-task-list__item">
         <th class="govuk-table__header" scope="row"><%= work_item.position %></th>
         <th class="govuk-table__header" scope="row">
           <%=

--- a/app/views/nsm/work_items/edit.html.erb
+++ b/app/views/nsm/work_items/edit.html.erb
@@ -1,7 +1,7 @@
 <% title t('.page_title') %>
 
 <% content_for(:back_link) do %>
-  <%= link_to t('helpers.back_link'), :back, class: 'govuk-back-link', data: { turbo: 'false' } %>
+  <%= link_to t('helpers.back_link'), "", id: "back-button", class: 'govuk-back-link', data: { turbo: 'false' } %>
 <% end %>
 
 <div class="govuk-grid-row" id="work-items-adjustment-container">
@@ -63,7 +63,7 @@
       </div>
       <%= f.govuk_text_area :explanation, label: { size: 's' }, rows: 5 %>
       <%= f.govuk_submit t('shared.save_changes') do %>
-        <%= link_to t('shared.cancel'), :back, class: 'govuk-link', data: { turbo: 'false' } %>
+        <%= link_to t('shared.cancel'), "", id: "back-button", class: 'govuk-link', data: { turbo: 'false' } %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/nsm/work_items/show.html.erb
+++ b/app/views/nsm/work_items/show.html.erb
@@ -1,7 +1,7 @@
 <% title t('.page_title') %>
 
 <% content_for(:back_link) do %>
-  <%= link_to t('helpers.back_link'), :back, class: 'govuk-back-link', data: { turbo: 'false' } %>
+  <%= link_to t('helpers.back_link'), "", id: "back-button", class: 'govuk-back-link', data: { turbo: 'false' } %>
 <% end %>
 
 <div class="govuk-grid-row" id="work-items-adjustment-container">

--- a/spec/system/nsm/assessment_spec.rb
+++ b/spec/system/nsm/assessment_spec.rb
@@ -115,21 +115,28 @@ Rails.describe 'Assessment', :stub_oauth_token, :stub_update_claim do
     it 'includes the disbursement ID when navigating back' do
       visit nsm_claim_disbursements_path(claim)
 
-      find('tbody tr:nth-child(8) a').click
+      expect(evaluate_script('window.scrollY')).to eq 0
+
+      find('tbody tr:nth-child(9) a').click
 
       click_link_or_button 'Back'
 
       expect(current_url).to end_with "##{claim.data['disbursements'][0]['id']}"
+      sleep(0.1) # Wait for the anchor jump to happen
+      expect(evaluate_script('window.scrollY')).to be > 0
     end
 
     it 'includes the work item ID when navigating back' do
       visit nsm_claim_work_items_path(claim)
 
+      expect(evaluate_script('window.scrollY')).to eq 0
       find('tbody tr:nth-child(8) a').click
 
       click_link_or_button 'Back'
 
       expect(current_url).to end_with "##{claim.data['work_items'][0]['id']}"
+      sleep(0.1) # Wait for the anchor jump to happen
+      expect(evaluate_script('window.scrollY')).to be > 0
     end
   end
 end

--- a/spec/system/nsm/assessment_spec.rb
+++ b/spec/system/nsm/assessment_spec.rb
@@ -75,4 +75,61 @@ Rails.describe 'Assessment', :stub_oauth_token, :stub_update_claim do
       end.to have_enqueued_job(NotifyAppStore)
     end
   end
+
+  context 'navigation', :javascript do
+    let(:claim) do
+      disbursement = {
+        'id' => '1c0f36fd-fd39-498a-823b-0a3837454563',
+        'details' => 'Details',
+        'pricing' => 1.0,
+        'vat_rate' => 0.2,
+        'apply_vat' => 'false',
+        'other_type' => {
+          'en' => 'Apples',
+          'value' => 'Apples'
+        },
+        'vat_amount' => 0.0,
+        'prior_authority' => 'yes',
+        'disbursement_date' => '2022-12-12',
+        'disbursement_type' => {
+          'en' => 'Other',
+          'value' => 'other'
+        },
+        'total_cost_without_vat' => 100.0
+      }
+      work_item = {
+        'id' => 'cf5e303e-98dd-4b0f-97ea-3560c4c5f137',
+          'uplift' => 95,
+          'pricing' => 24.0,
+          'work_type' => {
+            'en' => 'Waiting',
+            'value' => 'waiting'
+          },
+          'fee_earner' => 'aaa',
+          'time_spent' => 161,
+          'completed_on' => '2022-12-12'
+      }
+      create(:claim, disbursements: Array.new(200, disbursement), work_items: Array.new(200, work_item))
+    end
+
+    it 'includes the disbursement ID when navigating back' do
+      visit nsm_claim_disbursements_path(claim)
+
+      find('tbody tr:nth-child(8) a').click
+
+      click_link_or_button 'Back'
+
+      expect(current_url).to end_with "##{claim.data['disbursements'][0]['id']}"
+    end
+
+    it 'includes the work item ID when navigating back' do
+      visit nsm_claim_work_items_path(claim)
+
+      find('tbody tr:nth-child(8) a').click
+
+      click_link_or_button 'Back'
+
+      expect(current_url).to end_with "##{claim.data['work_items'][0]['id']}"
+    end
+  end
 end


### PR DESCRIPTION
## Description of change

This enables a workflow of clicking on a work item or disbursement from a table and being able to navigate back directly to the row in question.

I've had to adjust the back buttons thanks to [how `link_to :back`](https://api.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-link_to) interacts with the Content-Security-Policy, but if there's a nicer way to handle this then I'd love to know how.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1753)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
