### PR TITLE
CMR457-1812: Backfill NSM claim disbursements to have positions

### DIFF
--- a/db/migrate/20240807074430_backfill_disbursement_position.rb
+++ b/db/migrate/20240807074430_backfill_disbursement_position.rb
@@ -1,0 +1,19 @@
+class BackfillDisbursementPosition < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def up
+    # We need to update NSM claims (only) with one or more nil/null disbursement positions.
+    #
+    # These claims should have all their disbursements position attributes updated to be a 1-based
+    # index value when sorted by disbursement_date and "translated disbursement type description". This
+    # sorting algorithm should match what is used for newly submitted claims BUT should not "touch" any
+    # updated_at column values.
+    #
+    claims = Submission.where(application_type: "crm7")
+
+    claims.each do |claim|
+      updater = DataMigrationTools::DisbursementPositionUpdater.new(claim)
+      updater.call
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_25_163719) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_07_074430) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"

--- a/lib/data_migration_tools/disbursement_position_updater.rb
+++ b/lib/data_migration_tools/disbursement_position_updater.rb
@@ -1,0 +1,46 @@
+module DataMigrationTools
+  class DisbursementPositionUpdater
+    def initialize(submission)
+      @submission = submission
+    end
+
+    def call
+      disbursements ||= @submission.data['disbursements']
+      return unless disbursements
+
+      disbursements.each_with_index do |disbursement, idx|
+        position = disbursement_position(disbursement)
+        @submission.data['disbursements'][idx]['position'] = position
+      end
+
+      @submission.save!(touch: false)
+    end
+
+    private
+
+    def disbursements
+      @submission.data['disbursements']
+    end
+
+    def disbursement_position(disbursement)
+      sorted_disbursement_ids.index(disbursement['id']) + 1
+    end
+
+    def sorted_disbursement_ids
+      @sorted_disbursement_ids = disbursements.sort_by do |disb|
+        [
+          disb['disbursement_date'].to_date || 100.years.ago,
+          translated_disbursement_type(disb)&.downcase || '',
+        ]
+      end.pluck('id')
+    end
+
+    def translated_disbursement_type(disbursement)
+      if disbursement['disbursement_type']['value'] == 'other'
+        disbursement['other_type']['en']
+      else
+        disbursement['disbursement_type']['en']
+      end
+    end
+  end
+end

--- a/spec/factories/disbursements.rb
+++ b/spec/factories/disbursements.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :disbursement, class: Hash do
+    initialize_with { attributes }
+    id { SecureRandom.uuid }
+    details { 'my disbursement' }
+    miles { '100.0' }
+    pricing { 0.45 }
+    vat_rate { 0.2 }
+    vat_amount { 9.0 }
+    prior_authority { 'yes' }
+    other_type { { 'en' => nil, 'value' => nil } }
+    disbursement_date { Date.current.iso8601 }
+    disbursement_type { { 'en' => 'Car mileage', 'value' => 'car' } }
+    total_cost_without_vat { 45.0 }
+  end
+end

--- a/spec/lib/data_migration_tools/disbursement_position_updater_spec.rb
+++ b/spec/lib/data_migration_tools/disbursement_position_updater_spec.rb
@@ -1,0 +1,70 @@
+require 'rails_helper'
+
+RSpec.describe DataMigrationTools::DisbursementPositionUpdater do
+  subject(:updater) { described_class.new(claim) }
+
+  let(:claim) { create(:claim, data: { disbursements: }) }
+
+  context 'when disbursements exist on claim' do
+    let(:disbursements) do
+      [
+        build(:disbursement, id: 'bbb222', position: nil,
+              disbursement_date: 2.days.ago.to_date.iso8601,
+              disbursement_type: { 'en' => 'Car mileage', 'value' => 'car' }),
+
+        build(:disbursement, id: 'bbb111', position: nil,
+              disbursement_date: 3.days.ago.to_date.iso8601,
+              disbursement_type: { 'en' => 'Car mileage', 'value' => 'car' }),
+
+        build(:disbursement, id: 'aaa111', position: nil,
+              disbursement_date: 3.days.ago.to_date.iso8601,
+              disbursement_type: { 'en' => 'Bike mileage', 'value' => 'bike' }),
+
+        build(:disbursement,
+              id: 'bbb333',
+              position: nil,
+              disbursement_date: 2.days.ago.to_date.iso8601,
+              disbursement_type: { 'en' => 'Other foobar', 'value' => 'other' },
+              other_type: { 'en' => 'Facial Mapping Experts', 'value' => 'facial_mapping_experts' }),
+
+        build(:disbursement,
+              id: 'bbb444',
+              position: nil,
+              disbursement_date: 1.day.ago.to_date.iso8601,
+              disbursement_type: { 'en' => 'Other foobar', 'value' => 'other' },
+              other_type: { 'value' => 'facial_mapping_experts' }),
+      ]
+    end
+
+    it 'updates existing disbursements with sorted position value' do
+      expect { updater.call }
+        .to change { claim.reload.data['disbursements'] }
+        .from([hash_including({ 'id' => 'bbb222', 'position' => nil }),
+               hash_including({ 'id' => 'bbb111', 'position' => nil }),
+               hash_including({ 'id' => 'aaa111', 'position' => nil }),
+               hash_including({ 'id' => 'bbb333', 'position' => nil }),
+               hash_including({ 'id' => 'bbb444', 'position' => nil })])
+        .to([hash_including({ 'id' => 'bbb222', 'position' => 3 }),
+             hash_including({ 'id' => 'bbb111', 'position' => 2 }),
+             hash_including({ 'id' => 'aaa111', 'position' => 1 }),
+             hash_including({ 'id' => 'bbb333', 'position' => 4 }),
+             hash_including({ 'id' => 'bbb444', 'position' => 5 })])
+    end
+
+    it 'does not update the objects timestamps' do
+      travel_to(1.hour.ago) do
+        claim
+      end
+
+      expect { updater.call }.not_to change(claim, :updated_at)
+    end
+  end
+
+  context 'when disbursements do NOT exist on claim' do
+    let(:disbursements) { nil }
+
+    it 'does not raise an error' do
+      expect { updater.call }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Backfill NSM claim disbursements to have positions

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1812)

Inline with designs on submit and app store for displaying
disbursements in a specific order.

## Notes for reviewer
Should be merged shortly after [this submit PR](https://github.com/ministryofjustice/laa-submit-crime-forms/pull/1039)
