### PR TITLE
CRM457-1355: Add sentry-sidekiq-monitoring

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'pagy'
 # Exception monitoring
 gem 'sentry-rails', '>= 5.17.3'
 gem 'sentry-ruby'
+gem 'sentry-sidekiq'
 gem 'with_advisory_lock'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -493,6 +493,9 @@ GEM
     sentry-ruby (5.18.2)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
+    sentry-sidekiq (5.18.2)
+      sentry-ruby (~> 5.18.2)
+      sidekiq (>= 3.0)
     sidekiq (7.3.0)
       concurrent-ruby (< 2)
       connection_pool (>= 2.3.0)
@@ -630,6 +633,7 @@ DEPENDENCIES
   selenium-webdriver
   sentry-rails (>= 5.17.3)
   sentry-ruby
+  sentry-sidekiq
   sidekiq (~> 7.3, >= 7.3.0)
   sidekiq-cron
   sidekiq_alive (~> 2.4)


### PR DESCRIPTION
## Description of change
We want to ensure that when 'retry_on' is explicitly specified for a Sidekiq job, all failures are still sent to Sentry. This does not appear to be happening, and I suspect it's because we don't have the sentry-sidekiq gem in place.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1355)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
