### PR TITLE
CRM457-1847: Remove 'retry_on'

### DIFF
--- a/app/services/notify_app_store.rb
+++ b/app/services/notify_app_store.rb
@@ -1,6 +1,5 @@
 class NotifyAppStore < ApplicationJob
   queue_as :default
-  retry_on StandardError, wait: :polynomially_longer, attempts: 10
 
   def perform(submission:, trigger_email: true)
     notify(MessageBuilder.new(submission:))

--- a/app/services/notify_event_app_store.rb
+++ b/app/services/notify_event_app_store.rb
@@ -1,6 +1,5 @@
 class NotifyEventAppStore < ApplicationJob
   queue_as :default
-  retry_on StandardError, wait: :polynomially_longer, attempts: 10
 
   def perform(event:)
     result = client.create_events(event.submission_id, events: [event.as_json])


### PR DESCRIPTION
retry_on is part of the ActiveJob DSL that causes errors to be swallowed until a certain number of retries, after which the error is allowed to bubble up to the underlying mechanism (in our case Sidekiq, which will report the error to Sentry) This isn't actually the behaviour we want - if a job is failing we want Sentry to be informed immediately the first time it fails, on the grounds that normally this is going to be the indication of a problem, not some harmless transient error, so we want as much heads up as possible.