### PR TITLE
CRM457-1772: Set current section correctly

### DIFF
--- a/app/controllers/nsm/claims_controller.rb
+++ b/app/controllers/nsm/claims_controller.rb
@@ -3,6 +3,7 @@ module Nsm
     before_action :set_default_table_sort_options, only: %i[your open closed]
 
     def your
+      @current_section = :your
       pagy, filtered_claims = order_and_paginate(Claim.pending_and_assigned_to(current_user))
       your_claims = filtered_claims.map { |claim| BaseViewModel.build(:table_row, claim) }
 
@@ -10,11 +11,13 @@ module Nsm
     end
 
     def open
+      @current_section = :open
       @pagy, claims = order_and_paginate(Claim.pending_decision)
       @claims = claims.map { |claim| BaseViewModel.build(:table_row, claim) }
     end
 
     def closed
+      @current_section = :closed
       @pagy, claims = order_and_paginate(Claim.decision_made)
       @claims = claims.map { |claim| BaseViewModel.build(:table_row, claim) }
     end

--- a/app/controllers/nsm/searches_controller.rb
+++ b/app/controllers/nsm/searches_controller.rb
@@ -1,5 +1,7 @@
 module Nsm
   class SearchesController < BaseController
+    before_action :set_current_section
+
     def show
       @search_form = SearchForm.new(search_params)
       @search_form.execute if @search_form.valid?
@@ -31,6 +33,10 @@ module Nsm
         application_type: Submission::APPLICATION_TYPES[:nsm],
         page: params.fetch(:page, '1')
       }
+    end
+
+    def set_current_section
+      @current_section = :search
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -67,4 +67,18 @@ module ApplicationHelper
 
     number_with_precision(value, precision: 2, delimiter: ',')
   end
+
+  def infer_claim_section
+    claim_id = params.fetch(:claim_id, params.fetch(:id, nil))
+    return unless claim_id
+
+    current_claim = Claim.find(claim_id)
+    if current_claim.assessed? || current_claim.sent_back?
+      :closed
+    elsif current_claim.assigned_to?(current_user)
+      :your
+    else
+      :open
+    end
+  end
 end

--- a/app/views/layouts/nsm/_primary_navigation.html.erb
+++ b/app/views/layouts/nsm/_primary_navigation.html.erb
@@ -1,21 +1,21 @@
-<% current ||= :your %>
+<% current ||= (@current_section || infer_claim_section || :open) %>
 <div class="moj-primary-navigation">
   <div class="moj-primary-navigation__container">
     <div class="moj-primary-navigation__nav">
         <nav class="moj-primary-navigation" aria-label="Primary navigation">
           <ul class="moj-primary-navigation__list">
               <li class="moj-primary-navigation__item">
-                <%= link_to t('layouts.primary_navigation.your_claims'), your_nsm_claims_path, class: 'moj-primary-navigation__link', 'aria-current': (controller.action_name == 'your' ? 'page' : nil) %>
+                <%= link_to t('layouts.primary_navigation.your_claims'), your_nsm_claims_path, class: 'moj-primary-navigation__link', 'aria-current': (current == :your ? 'page' : nil) %>
               </li>
               <li class="moj-primary-navigation__item">
-                <%= link_to t('layouts.primary_navigation..all_claims'), open_nsm_claims_path, class: 'moj-primary-navigation__link', 'aria-current': (controller.action_name == 'open' ? 'page' : nil) %>
+                <%= link_to t('layouts.primary_navigation..all_claims'), open_nsm_claims_path, class: 'moj-primary-navigation__link', 'aria-current': (current == :open ? 'page' : nil) %>
               </li>
               <li class="moj-primary-navigation__item">
-                <%= link_to t('layouts.primary_navigation.assessed_claims'), closed_nsm_claims_path, class: 'moj-primary-navigation__link', 'aria-current': (controller.action_name == 'closed' ? 'page' : nil) %>
+                <%= link_to t('layouts.primary_navigation.assessed_claims'), closed_nsm_claims_path, class: 'moj-primary-navigation__link', 'aria-current': (current == :closed ? 'page' : nil) %>
               </li>
               <% if FeatureFlags.search.enabled? %>
                 <li class="moj-primary-navigation__item">
-                  <%= link_to t('layouts.primary_navigation.search'), new_nsm_search_path, class: 'moj-primary-navigation__link', 'aria-current': (controller.controller_name == 'searches' ? 'page' : nil) %>
+                  <%= link_to t('layouts.primary_navigation.search'), new_nsm_search_path, class: 'moj-primary-navigation__link', 'aria-current': (current == :search ? 'page' : nil) %>
                 </li>
               <% end %>
           </ul>

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -230,4 +230,37 @@ RSpec.describe ApplicationHelper, type: :helper do
       end
     end
   end
+
+  describe '#infer_claim_section' do
+    it 'returns nothing if there is no relevant param' do
+      expect(helper.infer_claim_section).to be_nil
+    end
+
+    context 'when there is a claim param' do
+      before do
+        allow(helper).to receive_messages(params: { claim_id: claim.id }, current_user: user)
+      end
+
+      let(:claim) { create :claim }
+      let(:user) { create :caseworker }
+
+      it { expect(helper.infer_claim_section).to eq :open }
+
+      context 'when the claim is assessed' do
+        let(:claim) do
+          create :claim, state: 'granted'
+        end
+
+        it { expect(helper.infer_claim_section).to eq :closed }
+      end
+
+      context 'when the claim is assigned to current user' do
+        before do
+          claim.assignments.create(user:)
+        end
+
+        it { expect(helper.infer_claim_section).to eq :your }
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Description of change
Add logic so that we show the right section of the sub-nav as 'current' depending on the state of the current claim.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1772)

