### PR TITLE
Move perform_laters out of transactions to avoid race conditions

### DIFF
--- a/app/forms/nsm/make_decision_form.rb
+++ b/app/forms/nsm/make_decision_form.rb
@@ -33,8 +33,8 @@ module Nsm
                                 comment: comment,
                                 previous_state: previous_state,
                                 current_user: current_user)
-        NotifyAppStore.perform_later(submission: claim)
       end
+      NotifyAppStore.perform_later(submission: claim)
 
       true
     end

--- a/app/forms/nsm/send_back_form.rb
+++ b/app/forms/nsm/send_back_form.rb
@@ -18,8 +18,9 @@ module Nsm
 
       Claim.transaction do
         update_local_data
-        NotifyAppStore.perform_later(submission: claim)
       end
+
+      NotifyAppStore.perform_later(submission: claim)
 
       true
     end

--- a/app/forms/prior_authority/decision_form.rb
+++ b/app/forms/prior_authority/decision_form.rb
@@ -39,8 +39,9 @@ module PriorAuthority
                                 comment: explanation,
                                 previous_state: previous_state,
                                 current_user: current_user)
-        NotifyAppStore.perform_later(submission:)
       end
+
+      NotifyAppStore.perform_later(submission:)
 
       true
     end

--- a/app/forms/prior_authority/send_back_form.rb
+++ b/app/forms/prior_authority/send_back_form.rb
@@ -33,8 +33,9 @@ module PriorAuthority
         discard_all_adjustments
         stash(add_draft_send_back_event: false)
         update_local_records
-        NotifyAppStore.perform_later(submission:)
       end
+
+      NotifyAppStore.perform_later(submission:)
 
       true
     end

--- a/app/services/update_submission.rb
+++ b/app/services/update_submission.rb
@@ -27,6 +27,8 @@ class UpdateSubmission
       autogrant if cached_autograntable
     end
 
+    NotifyAppStore.perform_later(submission:) if cached_autograntable
+
     submission
   end
 
@@ -78,6 +80,5 @@ class UpdateSubmission
     submission.update!(state: PriorAuthorityApplication::AUTO_GRANT)
 
     Event::AutoDecision.build(submission:, previous_state:)
-    NotifyAppStore.perform_later(submission:)
   end
 end


### PR DESCRIPTION
## Description of change
Calling `perform_later` inside a transaction (including a lock) risks a race condition where the job might run before the transaction has been committed so will run using stale DB data. This can causing stale data to be sent to the app store, which is not ideal. This PR moves the perform_laters until after the transactions have been committed.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1858)

