### PR TITLE
CRM457-1857 remove auto-grants from select filter on CRM7 search/filter

### DIFF
--- a/app/controllers/nsm/searches_controller.rb
+++ b/app/controllers/nsm/searches_controller.rb
@@ -3,19 +3,19 @@ module Nsm
     before_action :set_current_section
 
     def show
-      @search_form = SearchForm.new(search_params)
+      @search_form = Nsm::SearchForm.new(search_params)
       @search_form.execute if @search_form.valid?
     end
 
     def new
-      @search_form = SearchForm.new(default_params)
+      @search_form = Nsm::SearchForm.new(default_params)
       render :show
     end
 
     private
 
     def search_params
-      params.require(:search_form).permit(
+      params.require(:nsm_search_form).permit(
         :query,
         :submitted_from,
         :submitted_to,

--- a/app/controllers/prior_authority/searches_controller.rb
+++ b/app/controllers/prior_authority/searches_controller.rb
@@ -1,19 +1,19 @@
 module PriorAuthority
   class SearchesController < BaseController
     def show
-      @search_form = SearchForm.new(search_params)
+      @search_form = PriorAuthority::SearchForm.new(search_params)
       @search_form.execute if @search_form.valid?
     end
 
     def new
-      @search_form = SearchForm.new(default_params)
+      @search_form = PriorAuthority::SearchForm.new(default_params)
       render :show
     end
 
     private
 
     def search_params
-      params.require(:search_form).permit(
+      params.require(:prior_authority_search_form).permit(
         :query,
         :submitted_from,
         :submitted_to,

--- a/app/forms/nsm/search_form.rb
+++ b/app/forms/nsm/search_form.rb
@@ -4,12 +4,10 @@ module Nsm
       [show_all] + %i[
         not_assigned
         in_progress
-        provider_updated
         sent_back
         granted
         part_grant
         rejected
-        expired
       ].map { Option.new(_1, I18n.t("search.statuses.#{_1}")) }
     end
   end

--- a/app/forms/nsm/search_form.rb
+++ b/app/forms/nsm/search_form.rb
@@ -1,0 +1,16 @@
+module Nsm
+  class SearchForm < ::SearchForm
+    def statuses
+      [show_all] + %i[
+        not_assigned
+        in_progress
+        provider_updated
+        sent_back
+        granted
+        part_grant
+        rejected
+        expired
+      ].map { Option.new(_1, I18n.t("search.statuses.#{_1}")) }
+    end
+  end
+end

--- a/app/forms/prior_authority/search_form.rb
+++ b/app/forms/prior_authority/search_form.rb
@@ -1,0 +1,4 @@
+module PriorAuthority
+  class SearchForm < ::SearchForm
+  end
+end

--- a/app/views/dashboards/_tab_content.html.erb
+++ b/app/views/dashboards/_tab_content.html.erb
@@ -1,5 +1,13 @@
 <% if @nav_select == 'prior_authority' || @nav_select == 'nsm' %>
   <%= render partial: 'overview' %>
 <% else %>
-  <%= render partial: 'shared/search', locals: { form_url: dashboard_path(nav_select: 'search', anchor: 'search-results'), title: false, choose_application_type: true, clear_all_path: new_dashboard_path(nav_select: 'search'), additional_param: { key: 'nav_select', value: 'search'}, translation_prefix: 'dashboards.search', controller_path: 'dashboards' }  %>
+  <%= render partial: 'shared/search', locals: { form_url: dashboard_path(nav_select: 'search', anchor: 'search-results'),
+                                                 title: false,
+                                                 choose_application_type: true,
+                                                 clear_all_path: new_dashboard_path(nav_select: 'search'),
+                                                 additional_param: { key: 'nav_select', value: 'search'},
+                                                 translation_prefix: 'dashboards.search',
+                                                 controller_path: 'dashboards',
+                                                 search_form_type: :search_form} %>
+
 <% end %>

--- a/app/views/nsm/searches/show.html.erb
+++ b/app/views/nsm/searches/show.html.erb
@@ -1,2 +1,9 @@
 <% title t('.page_title') %>
-<%= render partial: 'shared/search', locals: { form_url: nsm_search_path(anchor: 'search-results'), title: true, choose_application_type: false, clear_all_path: new_nsm_search_path, additional_param: nil, translation_prefix: 'nsm.searches.show', controller_path: 'nsm/searches'} %>
+<%= render partial: 'shared/search', locals: { form_url: nsm_search_path(anchor: 'search-results'),
+                                               title: true,
+                                               choose_application_type: false,
+                                               clear_all_path: new_nsm_search_path,
+                                               additional_param: nil,
+                                               translation_prefix: 'nsm.searches.show',
+                                               controller_path: 'nsm/searches',
+                                               search_form_type: :nsm_search_form} %>

--- a/app/views/prior_authority/searches/show.html.erb
+++ b/app/views/prior_authority/searches/show.html.erb
@@ -2,4 +2,11 @@
   <% render 'layouts/prior_authority/primary_navigation', current: :search %>
 <% end %>
 <% title t('.page_title') %>
-<%= render partial: 'shared/search', locals: { form_url: prior_authority_search_path(anchor: 'search-results'), title: true, choose_application_type: false, clear_all_path: new_prior_authority_search_path, additional_param: nil, translation_prefix: 'prior_authority.searches.show', controller_path: 'prior_authority/searches'} %>
+<%= render partial: 'shared/search', locals: { form_url: prior_authority_search_path(anchor: 'search-results'),
+                                               title: true,
+                                               choose_application_type: false,
+                                               clear_all_path: new_prior_authority_search_path,
+                                               additional_param: nil,
+                                               translation_prefix: 'prior_authority.searches.show',
+                                               controller_path: 'prior_authority/searches',
+                                               search_form_type: :prior_authority_search_form } %>

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -88,13 +88,13 @@
                   <% if additional_param.present? %>
                     <%= table_header_with_link(key,
                                               'shared.search.table.header',
-                                              { 'controller' => controller_path, 'action' => 'show', additional_param[:key] => additional_param[:value], 'search_form' => @search_form.attributes },
-                                              @search_form.sort_by, @search_form.sort_direction, :search_form) %>
+                                              { 'controller' => controller_path, 'action' => 'show', additional_param[:key] => additional_param[:value], search_form_type => @search_form.attributes },
+                                              @search_form.sort_by, @search_form.sort_direction, search_form_type) %>
                   <% else %>
                     <%= table_header_with_link(key,
                                             'shared.search.table.header',
-                                            { controller: controller_path, action: 'show', search_form: @search_form.attributes },
-                                            @search_form.sort_by, @search_form.sort_direction, :search_form) %>
+                                            { 'controller' => controller_path, 'action' => 'show',  search_form_type => @search_form.attributes },
+                                            @search_form.sort_by, @search_form.sort_direction, search_form_type) %>
                   <% end %>
                 <% end %>
               <% end %>

--- a/spec/forms/nsm/search_form_spec.rb
+++ b/spec/forms/nsm/search_form_spec.rb
@@ -4,9 +4,11 @@ RSpec.describe Nsm::SearchForm do
   subject { described_class.new }
 
   describe '#statuses' do
-    it 'does not contain auto_grant status' do
+    it 'does not contain auto_grant, provider_updated, expired status' do
       statuses = subject.statuses.map(&:value)
-      refute(statuses.include?(:auto_granted))
+      %i[auto_grant provider_updated expired].each do |status|
+        refute(statuses.include?(status))
+      end
     end
   end
 end

--- a/spec/forms/nsm/search_form_spec.rb
+++ b/spec/forms/nsm/search_form_spec.rb
@@ -1,4 +1,3 @@
-
 require 'rails_helper'
 
 RSpec.describe Nsm::SearchForm do

--- a/spec/forms/nsm/search_form_spec.rb
+++ b/spec/forms/nsm/search_form_spec.rb
@@ -1,0 +1,13 @@
+
+require 'rails_helper'
+
+RSpec.describe Nsm::SearchForm do
+  subject { described_class.new }
+
+  describe '#statuses' do
+    it 'does not contain auto_grant status' do
+      statuses = subject.statuses.map(&:value)
+      refute(statuses.include?(:auto_granted))
+    end
+  end
+end

--- a/spec/system/nsm/search_spec.rb
+++ b/spec/system/nsm/search_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe 'Search', :stub_oauth_token do
     end
 
     it 'tells me if there are no results' do
-      visit nsm_search_path(search_form: { query: 'QUERY' })
+      visit nsm_search_path(nsm_search_form: { query: 'QUERY' })
       expect(page).to have_content 'There are no results that match the search criteria'
     end
   end
@@ -79,7 +79,7 @@ RSpec.describe 'Search', :stub_oauth_token do
 
     it 'notifies sentry and shows an error' do
       expect(Sentry).to receive(:capture_exception)
-      visit nsm_search_path(search_form: { query: 'QUERY' })
+      visit nsm_search_path(nsm_search_form: { query: 'QUERY' })
       expect(page).to have_content 'Something went wrong trying to perform this search'
     end
   end
@@ -109,7 +109,7 @@ sort_direction: 'ascending' },
     before { stubs }
 
     it 'lets me sort and paginate' do
-      visit nsm_search_path(search_form: { query: 'QUERY' })
+      visit nsm_search_path(nsm_search_form: { query: 'QUERY' })
       within('.govuk-table__head') { click_link 'LAA reference' }
       within('.govuk-pagination__list') { click_on '2' }
       expect(stubs).to all have_been_requested

--- a/spec/system/prior_authority/search_spec.rb
+++ b/spec/system/prior_authority/search_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe 'Search', :stub_oauth_token do
     end
 
     it 'imports records it did not have yet' do
-      visit prior_authority_search_path(search_form: { query: 'QUERY' })
+      visit prior_authority_search_path(prior_authority_search_form: { query: 'QUERY' })
       expect(PriorAuthorityApplication.find_by(id:)).not_to be_nil
     end
   end
@@ -94,7 +94,7 @@ RSpec.describe 'Search', :stub_oauth_token do
     end
 
     it 'tells me if there are no results' do
-      visit prior_authority_search_path(search_form: { query: 'QUERY' })
+      visit prior_authority_search_path(prior_authority_search_form: { query: 'QUERY' })
       expect(page).to have_content 'There are no results that match the search criteria'
     end
   end
@@ -108,7 +108,7 @@ RSpec.describe 'Search', :stub_oauth_token do
 
     it 'notifies sentry and shows an error' do
       expect(Sentry).to receive(:capture_exception)
-      visit prior_authority_search_path(search_form: { query: 'QUERY' })
+      visit prior_authority_search_path(prior_authority_search_form: { query: 'QUERY' })
       expect(page).to have_content 'Something went wrong trying to perform this search'
     end
   end
@@ -138,7 +138,7 @@ sort_direction: 'ascending' },
     before { stubs }
 
     it 'lets me sort and paginate' do
-      visit prior_authority_search_path(search_form: { query: 'QUERY' })
+      visit prior_authority_search_path(prior_authority_search_form: { query: 'QUERY' })
       within('.govuk-table__head') { click_link 'LAA reference' }
       within('.govuk-pagination__list') { click_on '2' }
       expect(stubs).to all have_been_requested


### PR DESCRIPTION
## Description of change
remove auto-grant filter from CRM7 search/filter

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1857)

## Notes for reviewer
i've namespaced the search_forms under their specific application types to absorb similar changes down the line.  If having these `search_form` in their own namespace seems more not less of a faff quite happy to replace this with a one-liner in `search_forms` 😅 

## Screenshots of changes (if applicable)

### Before changes:
![Screenshot 2024-08-14 at 09 13 57](https://github.com/user-attachments/assets/56a6a00c-47cf-4f5b-8187-be500baa7daa)

### After changes:
![Screenshot 2024-08-14 at 09 13 35](https://github.com/user-attachments/assets/6f101886-a5db-4d3a-b6c2-86294d884388)

## How to manually test the feature

1. caseworker enter CRM7 search tab
2. select `status` select drop-down



