### PR TITLE
CRM457-1815: Make test data more realistic to fix view coverage blind spot

### DIFF
--- a/spec/system/nsm/overview_spec.rb
+++ b/spec/system/nsm/overview_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe 'Overview', type: :system do
 
   context 'when claim has been assessed as part granted' do
     let(:claim) { create(:claim, state: 'part_grant') }
-    let(:part_grant_event) { create(:event, :part_granted, claim:) }
+    let(:part_grant_event) { create(:event, :part_granted, claim: claim, details: { comment: 'Part grant reason' }) }
 
     before do
       part_grant_event


### PR DESCRIPTION
## Description of change
We previously had a broken view on the view part granted claim page, but our tests didn't pick it up because the page didn't render a section. We fixed the breakage [separately](https://github.com/ministryofjustice/laa-assess-crime-forms/commit/b21a76c589f573b3756987e3097b6cdb0925f652), this just adjusts the test to give us proper coverage.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1815)
