### PR TITLE
CRM457-1901: Adjust how disbursement adjustments are validated

### DIFF
--- a/app/forms/nsm/disbursements_form.rb
+++ b/app/forms/nsm/disbursements_form.rb
@@ -54,9 +54,9 @@ module Nsm
     end
 
     def data_has_changed?
-      return true if apply_vat != item.original_apply_vat
+      return true if apply_vat != item.apply_vat
 
-      mileage_based? ? miles != item.original_miles : total_cost_without_vat != item.original_total_cost_without_vat
+      mileage_based? ? miles != item.miles : total_cost_without_vat != item.total_cost_without_vat
     end
 
     def explanation_required?

--- a/config/locales/en/nsm/disbursements.yml
+++ b/config/locales/en/nsm/disbursements.yml
@@ -109,7 +109,7 @@ en:
         nsm/disbursements_form:
           attributes:
             base:
-              no_change: The new values cannot be the same as the values submitted by the provider.
+              no_change: You cannot save changes as you have not changed anything. You can make a change and save it, or select cancel.
             total_cost_without_vat:
               blank: Enter the cost
               not_a_number: The cost must be a number

--- a/config/locales/en/nsm/letters_and_calls.yml
+++ b/config/locales/en/nsm/letters_and_calls.yml
@@ -124,20 +124,20 @@ en:
         nsm/letters_calls_form/letters:
           attributes:
             base:
-              no_change: The new number of letters cannot be the same as the number submitted by the provider
+              no_change: You cannot save changes as you have not changed anything. You can make a change and save it, or select cancel.
             count:
               blank: Enter the number of letters you want to change the total to
-              no_change: The new number of letters cannot be the same as the number submitted by the provider
+              no_change: You cannot save changes as you have not changed anything. You can make a change and save it, or select cancel.
               greater_than_or_equal_to: The number of letters must be 0 or more
               not_a_number: The number of letters must be a number
               not_an_integer: The number of letters must be a whole number
         nsm/letters_calls_form/calls:
           attributes:
             base:
-              no_change: The new number of calls cannot be the same as the number submitted by the provider
+              no_change: You cannot save changes as you have not changed anything. You can make a change and save it, or select cancel.
             count:
               blank: Enter the number of calls you want to change the total to
-              no_change: The new number of calls cannot be the same as the number submitted by the provider
+              no_change: You cannot save changes as you have not changed anything. You can make a change and save it, or select cancel.
               greater_than_or_equal_to: The number of calls must be 0 or more
               not_a_number: The number of calls must be a number
               not_an_integer: The number of calls must be a whole number

--- a/config/locales/en/nsm/work_items.yml
+++ b/config/locales/en/nsm/work_items.yml
@@ -127,7 +127,7 @@ en:
         nsm/work_item_form:
           attributes:
             base:
-              no_change: The new values cannot be the same as the values submitted by the provider
+              no_change: You cannot save changes as you have not changed anything. You can make a change and save it, or select cancel.
             uplift:
               inclusion: Select to include uplift or not
             time_spent:


### PR DESCRIPTION
## Description of change

This changes disbursement adjustments to only compare against the values submitted since the last update rather than the original values.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1901)
