### PR TITLE
Crm457 enable nsm insights

### DIFF
--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -18,7 +18,7 @@ feature_flags:
     local: <%= ENV.fetch("NSM_INSIGHTS_ENABLED", false) %>
     development: true
     uat: true
-    production: false
+    production: true
   maintenance_mode:
     local: <%= ENV.fetch("MAINTENANCE_MODE", false) %>
     development: false

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -74,7 +74,7 @@ redis:
 
 metabase:
   priorAuthorityDashboardIds: '3,2'
-  nsmDashboardIds: ''
+  nsmDashboardIds: '4'
   siteUrl: 'https://crime-forms-metabase.service.justice.gov.uk'
 
 customErrorService:


### PR DESCRIPTION
Now that we have onboarded providers onto CRM7/Non-standard magistrate claims, caseworkers will need to be able to review analytics for these claims. 

To do this we need to enable the nsm_insights feature flag and add the relevant dashboards 

This PR: 

- Enables nsm_insights in production
- Adds the [Non-standard magistrate: submissions and resubmissions dashboard](https://crime-forms-metabase.service.justice.gov.uk/dashboard/4-non-standard-magistrates-submissions-and-resubmissions) to the analaytics tab

NOTE: this is draft because we still need to set up the production dashboard