### PR TITLE
CRM457-1895: Resolve TODO

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -55,13 +55,13 @@ class Claim < Submission
   end
 
   def formatted_claimed_total
-    summed_costs.dig(:gross_cost, :text)
+    formatted_summed_costs.dig(:gross_cost, :text)
   end
 
   def formatted_allowed_total
-    return formatted_claimed_total if summed_costs[:allowed_gross_cost].blank? || granted_and_allowed_less_than_claim
+    return formatted_claimed_total if formatted_summed_costs[:allowed_gross_cost].blank? || granted_and_allowed_less_than_claim
 
-    summed_costs.dig(:allowed_gross_cost, :text)
+    formatted_summed_costs.dig(:allowed_gross_cost, :text)
   end
 
   def any_adjustments?
@@ -71,15 +71,14 @@ class Claim < Submission
   private
 
   def granted_and_allowed_less_than_claim
-    # TODO: https://dsdmoj.atlassian.net/browse/CRM457-1895
-    allowed_gross_cost = summed_costs.dig(:allowed_gross_cost, :text).gsub(/[^\d\.]/, '').to_f
-    gross_cost = summed_costs.dig(:gross_cost, :text).gsub(/[^\d\.]/, '').to_f
+    allowed_gross_cost = core_cost_summary.summed_fields[:allowed_gross_cost]
+    gross_cost = core_cost_summary.summed_fields[:gross_cost]
 
     granted? && allowed_gross_cost < gross_cost
   end
 
-  def summed_costs
-    @summed_costs ||= core_cost_summary.summed_fields
+  def formatted_summed_costs
+    @formatted_summed_costs ||= core_cost_summary.formatted_summed_fields
   end
 
   def core_cost_summary

--- a/app/view_models/nsm/v1/core_cost_summary.rb
+++ b/app/view_models/nsm/v1/core_cost_summary.rb
@@ -27,17 +27,22 @@ module Nsm
       end
 
       def summed_fields
-        data = table_fields(formatted: false)
+        @summed_fields ||= begin
+          data = table_fields(formatted: false)
 
-        {
-          name: t('total', numeric: false),
-          net_cost: format(data.sum { _1[:net_cost] }),
-          vat: format(data.sum { _1[:vat] }),
-          gross_cost: format(data.sum { _1[:gross_cost] }),
-          allowed_net_cost: format(sum_allowed(data, :net_cost)),
-          allowed_vat: format(sum_allowed(data, :vat)),
-          allowed_gross_cost: format(sum_allowed(data, :gross_cost)),
-        }
+          {
+            net_cost: data.sum { _1[:net_cost] },
+            vat: data.sum { _1[:vat] },
+            gross_cost: data.sum { _1[:gross_cost] },
+            allowed_net_cost: sum_allowed(data, :net_cost),
+            allowed_vat: sum_allowed(data, :vat),
+            allowed_gross_cost: sum_allowed(data, :gross_cost),
+          }
+        end
+      end
+
+      def formatted_summed_fields
+        { name: t('total', numeric: false) }.merge(summed_fields.transform_values { format(_1) })
       end
 
       def show_allowed?

--- a/app/views/nsm/review_and_adjusts/show.html.erb
+++ b/app/views/nsm/review_and_adjusts/show.html.erb
@@ -13,7 +13,7 @@
         caption = t('.cost_summary')
         head = core_cost_summary.headers
         rows = core_cost_summary.table_fields.map(&:values)
-        foot = core_cost_summary.summed_fields.map do |key, value|
+        foot = core_cost_summary.formatted_summed_fields.map do |key, value|
           value[:text] = (tag.span(t(".accessible.#{key}"), class: 'govuk-visually-hidden') + value[:text]) if key != :name && value.present?
           value
         end

--- a/spec/view_models/nsm/v1/core_cost_summary_spec.rb
+++ b/spec/view_models/nsm/v1/core_cost_summary_spec.rb
@@ -228,7 +228,7 @@ RSpec.describe Nsm::V1::CoreCostSummary do
     end
   end
 
-  describe '#summed_fields' do
+  describe '#formatted_summed_fields' do
     context 'when a single work item exists' do
       let(:work_items) do
         [
@@ -240,7 +240,7 @@ RSpec.describe Nsm::V1::CoreCostSummary do
       end
 
       it 'returns the summed time and cost' do
-        expect(subject.summed_fields).to eq(
+        expect(subject.formatted_summed_fields).to eq(
           {
             allowed_gross_cost: { numeric: true, text: '£180.00' }, allowed_net_cost: { numeric: true, text: '£180.00' },
             allowed_vat: { numeric: true, text: '£0.00' }, gross_cost: { numeric: true, text: '£200.00' },
@@ -262,7 +262,7 @@ RSpec.describe Nsm::V1::CoreCostSummary do
       end
 
       it 'returns the summed time and cost' do
-        expect(subject.summed_fields).to eq(
+        expect(subject.formatted_summed_fields).to eq(
           {
             allowed_gross_cost: '', allowed_net_cost: '', allowed_vat: '', gross_cost: { numeric: true, text: '£180.00' },
             name: { numeric: false, text: 'Total', width: nil }, net_cost: { numeric: true, text: '£180.00' },
@@ -284,7 +284,7 @@ RSpec.describe Nsm::V1::CoreCostSummary do
       end
 
       it 'returns the summed time and cost' do
-        expect(subject.summed_fields).to eq(
+        expect(subject.formatted_summed_fields).to eq(
           {
             allowed_gross_cost: '', allowed_net_cost: '', allowed_vat: '', gross_cost: { numeric: true, text: '£196.00' },
             name: { numeric: false, text: 'Total', width: nil }, net_cost: { numeric: true, text: '£180.00' },
@@ -309,7 +309,7 @@ RSpec.describe Nsm::V1::CoreCostSummary do
       end
 
       it 'returns the summed cost' do
-        expect(subject.summed_fields).to eq(
+        expect(subject.formatted_summed_fields).to eq(
           {
             allowed_gross_cost: { numeric: true, text: '£260.00' }, allowed_net_cost: { numeric: true, text: '£260.00' },
             allowed_vat: { numeric: true, text: '£0.00' }, gross_cost: { numeric: true, text: '£300.00' },
@@ -335,7 +335,7 @@ RSpec.describe Nsm::V1::CoreCostSummary do
       end
 
       it 'returns the summed cost' do
-        expect(subject.summed_fields).to eq(
+        expect(subject.formatted_summed_fields).to eq(
           {
             allowed_gross_cost: { numeric: true, text: '£260.00' }, allowed_net_cost: { numeric: true, text: '£260.00' },
             allowed_vat: { numeric: true, text: '£0.00' }, gross_cost: { numeric: true, text: '£300.00' },
@@ -355,7 +355,7 @@ RSpec.describe Nsm::V1::CoreCostSummary do
       end
 
       it 'returns the summed cost' do
-        expect(subject.summed_fields).to eq(
+        expect(subject.formatted_summed_fields).to eq(
           {
             allowed_gross_cost: '',
             allowed_net_cost: '',
@@ -381,7 +381,7 @@ RSpec.describe Nsm::V1::CoreCostSummary do
       let(:state) { 'rejected' }
 
       it 'returns the summed time and cost' do
-        expect(subject.summed_fields).to eq(
+        expect(subject.formatted_summed_fields).to eq(
           {
             allowed_gross_cost: { numeric: true, text: '£0.00' }, allowed_net_cost: { numeric: true, text: '£0.00' },
             allowed_vat: { numeric: true, text: '£0.00' }, gross_cost: { numeric: true, text: '£180.00' },
@@ -404,7 +404,7 @@ RSpec.describe Nsm::V1::CoreCostSummary do
       let(:state) { 'granted' }
 
       it 'returns the summed time and cost' do
-        expect(subject.summed_fields).to eq(
+        expect(subject.formatted_summed_fields).to eq(
           {
             allowed_gross_cost: '', allowed_net_cost: '', allowed_vat: '', gross_cost: { numeric: true, text: '£180.00' },
             name: { numeric: false, text: 'Total', width: nil }, net_cost: { numeric: true, text: '£180.00' },


### PR DESCRIPTION
## Description of change
Make unformatted totals available in CoreCostSummary so that we don't have to parse a string back to a float.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1895)
