### PR TITLE
CMR457-1909: Add rake task for contact email update

### DIFF
--- a/lib/tasks/fixes.rake
+++ b/lib/tasks/fixes.rake
@@ -1,0 +1,16 @@
+namespace :fixes do
+  desc "Amend a contact email address. Typically because user has added a valid but undeliverable address"
+  task :update_contact_email, [:id, :new_contact_email] => :environment do |_, args|
+    submission = Submission.find(args[:id])
+
+    STDOUT.print "This will update #{submission.data['laa_reference']}'s contact email, \"#{submission.data['solicitor']['contact_email'] || 'nil'}\", to \"#{args[:new_contact_email]}\": Are you sure? (y/n): "
+    input = STDIN.gets.strip
+
+    if input.downcase.in?(['yes','y'])
+      print 'updating...'
+      submission.data['solicitor']['contact_email'] = args[:new_contact_email]
+      submission.save!(touch: false)
+      puts "#{submission.data['laa_reference']}'s contact email is now #{submission.reload.data['solicitor']['contact_email']}"
+    end
+  end
+end

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -52,15 +52,7 @@ FactoryBot.define do
           'en' => '1 - Offences against the person'
         },
         'concluded' => 'no',
-        'solicitor' => {
-          'first_name' => 'Barry',
-          'last_name' => 'Scott',
-          'reference_number' => '2P314B',
-          'contact_first_name' => nil,
-          'contact_last_name' => nil,
-          'contact_email' => nil,
-          'previous_id' => nil
-        },
+        'solicitor' => solicitor,
         'answer_equality' => {
           'value' => 'no',
           'en' => 'No, skip the equality questions'
@@ -188,6 +180,17 @@ FactoryBot.define do
           'address_line_1' => 'Suite 3',
           'address_line_2' => '5 Princess Road',
           'vat_registered' => vat_registered
+        }
+      end
+      solicitor do
+        {
+          'first_name' => 'Barry',
+          'last_name' => 'Scott',
+          'reference_number' => '2P314B',
+          'contact_first_name' => nil,
+          'contact_last_name' => nil,
+          'contact_email' => nil,
+          'previous_id' => nil
         }
       end
     end

--- a/spec/lib/tasks/fixes_spec.rb
+++ b/spec/lib/tasks/fixes_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+describe 'fixes:', type: :task do
+  before do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  describe 'update_contact_email' do
+    subject(:run) do
+      Rake::Task['fixes:update_contact_email'].execute(arguments)
+    end
+
+    let(:arguments) { Rake::TaskArguments.new [:id, :new_contact_email], [submission.id, 'correct@email.address'] }
+    let(:solicitor) { { 'contact_email' => 'wrong@email.address' } }
+
+    before { allow($stdin).to receive_message_chain(:gets, :strip).and_return('y') }
+
+    context 'with a claim submission' do
+      let(:submission) { create(:claim, solicitor:) }
+
+      it 'amends contact email' do
+        expect { run }.to change { submission.reload.data['solicitor']['contact_email'] }
+          .from('wrong@email.address')
+          .to('correct@email.address')
+      end
+    end
+
+    context 'with a prior authority application submission' do
+      let(:submission) { create(:prior_authority_application, data: build(:prior_authority_data, solicitor:)) }
+
+      it 'amends contact email' do
+        expect { run }.to change { submission.reload.data['solicitor']['contact_email'] }
+          .from('wrong@email.address')
+          .to('correct@email.address')
+      end
+    end
+
+    context 'when submission not found' do
+      let(:arguments) { Rake::TaskArguments.new [:id, :new_contact_email], ['non-existent-uuid', 'correct@email.address'] }
+
+      it 'raises not found error' do
+        expect { run }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description of change
Add take task to update contact email address

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1909)

Part of documenting undeliverable email handling

## Notes for reviewer
