### PR TITLE
CRM457-1946: Remove individual VAT figures

### DIFF
--- a/app/javascript/component/nsm/letters_calls_adjustment.js
+++ b/app/javascript/component/nsm/letters_calls_adjustment.js
@@ -27,7 +27,6 @@ function init() {
     const count = parseInt(countField?.value);
     const unitPrice = new Decimal(calculateChangeButton?.getAttribute('data-unit-price'));
     let upliftAmount = calculateChangeButton?.getAttribute('data-uplift-amount');
-    const vatMultiplier = new Decimal(calculateChangeButton?.getAttribute('data-vat-multiplier'));
 
     if (!(upliftAmount && upliftNoField.checked)) {
       upliftAmount = 0
@@ -35,7 +34,7 @@ function init() {
 
     const upliftFactor = new Decimal(upliftAmount).dividedBy(100).plus(1);
 
-    const unrounded = unitPrice.times(count).times(upliftFactor).times(vatMultiplier);
+    const unrounded = unitPrice.times(count).times(upliftFactor);
     return (`£${unrounded.toFixed(2)}`);
   }
 }

--- a/app/view_models/nsm/v1/letter_and_call.rb
+++ b/app/view_models/nsm/v1/letter_and_call.rb
@@ -8,8 +8,6 @@ module Nsm
       adjustable_attribute :count, :integer
       adjustable_attribute :uplift, :integer
       attribute :pricing, :decimal
-      attribute :vat_rate
-      attribute :firm_office
       attribute :adjustment_comment
 
       class << self
@@ -44,28 +42,12 @@ module Nsm
         end
       end
 
-      def vat_registered?
-        firm_office['vat_registered'] == 'yes'
-      end
-
       def provider_requested_amount
         calculate_cost(original: true)
       end
 
-      def provider_requested_amount_inc_vat
-        return provider_requested_amount unless vat_registered?
-
-        provider_requested_amount * (1 + vat_rate)
-      end
-
       def caseworker_amount
         @caseworker_amount ||= calculate_cost
-      end
-
-      def caseworker_amount_inc_vat
-        return caseworker_amount unless vat_registered?
-
-        caseworker_amount * (1 + vat_rate)
       end
 
       def type_name
@@ -78,7 +60,7 @@ module Nsm
 
       def form_attributes
         attributes.except(
-          'pricing', 'adjustment_comment', 'vat_rate', 'firm_office', 'count_original', 'uplift_original'
+          'pricing', 'adjustment_comment', 'count_original', 'uplift_original'
         ).merge(
           'type' => type.value,
           'explanation' => adjustment_comment,
@@ -129,8 +111,6 @@ module Nsm
           Rails.application.routes.url_helpers.nsm_claim_letters_and_calls_path(claim, anchor: id)
         end
       end
-
-      private
 
       def calculate_cost(original: false)
         scoped_count, scoped_uplift = original ? [original_count, original_uplift] : [count, uplift]

--- a/app/view_models/nsm/v1/letter_and_call.rb
+++ b/app/view_models/nsm/v1/letter_and_call.rb
@@ -106,20 +106,12 @@ module Nsm
       end
 
       def provider_fields
-        rows = {
+        {
           '.number' => original_count.to_s,
           '.rate' => NumberTo.pounds(pricing),
           '.uplift_requested' => "#{original_uplift.to_i}%",
+          '.total_claimed' =>  NumberTo.pounds(provider_requested_amount)
         }
-
-        if vat_registered?
-          rows['.vat'] = NumberTo.percentage(vat_rate)
-          rows['.total_claimed_inc_vate'] = NumberTo.pounds(provider_requested_amount_inc_vat)
-        else
-          rows['.total_claimed'] = NumberTo.pounds(provider_requested_amount)
-        end
-
-        rows
       end
 
       def uplift?

--- a/app/view_models/nsm/v1/work_item.rb
+++ b/app/view_models/nsm/v1/work_item.rb
@@ -121,15 +121,14 @@ module Nsm
       end
 
       def provider_fields
-        rows = build_basic_rows
-        if vat_registered?
-          rows['.vat'] = NumberTo.percentage(vat_rate)
-          rows['.total_claimed_inc_vate'] = NumberTo.pounds(provider_requested_amount_inc_vat)
-        else
-          rows['.total_claimed'] = NumberTo.pounds(provider_requested_amount)
-        end
-
-        rows
+        {
+          '.work_type' => original_work_type.translated,
+          '.date' => format_in_zone(completed_on),
+          '.fee_earner' => fee_earner.to_s,
+          '.time_spent' => format_period(original_time_spent),
+          '.uplift_claimed' => "#{original_uplift.to_i}%",
+          '.total_claimed' => NumberTo.pounds(provider_requested_amount),
+        }
       end
 
       def changed?
@@ -145,16 +144,6 @@ module Nsm
       end
 
       private
-
-      def build_basic_rows
-        {
-          '.work_type' => original_work_type.translated,
-          '.date' => format_in_zone(completed_on),
-          '.fee_earner' => fee_earner.to_s,
-          '.time_spent' => format_period(original_time_spent),
-          '.uplift_claimed' => "#{original_uplift.to_i}%",
-        }
-      end
 
       def calculate_cost(original: false)
         scoped_uplift, scoped_time_spent, scoped_pricing = if original

--- a/app/view_models/nsm/v1/work_item.rb
+++ b/app/view_models/nsm/v1/work_item.rb
@@ -14,8 +14,6 @@ module Nsm
       adjustable_attribute :pricing, :decimal
       adjustable_attribute :uplift, :integer
       attribute :fee_earner, :string
-      attribute :vat_rate, :decimal
-      attribute :firm_office
       attribute :adjustment_comment
 
       class << self
@@ -44,28 +42,12 @@ module Nsm
         end
       end
 
-      def vat_registered?
-        firm_office['vat_registered'] == 'yes'
-      end
-
       def provider_requested_amount
         @provider_requested_amount ||= calculate_cost(original: true)
       end
 
-      def provider_requested_amount_inc_vat
-        return provider_requested_amount unless vat_registered?
-
-        provider_requested_amount * (1 + vat_rate)
-      end
-
       def caseworker_amount
         @caseworker_amount ||= calculate_cost
-      end
-
-      def caseworker_amount_inc_vat
-        return caseworker_amount unless vat_registered?
-
-        caseworker_amount * (1 + vat_rate)
       end
 
       def uplift?

--- a/app/views/nsm/letters_and_calls/edit.html.erb
+++ b/app/views/nsm/letters_and_calls/edit.html.erb
@@ -54,7 +54,6 @@
             'unit-price': item.pricing,
             'uplift-amount': item.uplift,
             page: item.type.value,
-            'vat-multiplier': item.vat_registered? ? (1.0 + item.vat_rate) : 1.0,
           }
         )
       %>
@@ -71,7 +70,7 @@
 
           <%= table.with_body do |body| %>
             <%= body.with_row do |row| %>
-              <%= row.with_cell(text: NumberTo.pounds(item.provider_requested_amount_inc_vat),html_attributes: { id: 'letters_calls_provider_requested_amount' }) %>
+              <%= row.with_cell(text: NumberTo.pounds(item.provider_requested_amount),html_attributes: { id: 'letters_calls_provider_requested_amount' }) %>
               <%= row.with_cell(text: '--',html_attributes: { id: 'letters_calls_caseworker_allowed_amount' }) %>
               <%= row.with_cell(text: "#{item.uplift ? item.uplift : '0' }%",html_attributes: { id: 'letters_calls_uplift_allowed_amount' }) %>
             <% end %>

--- a/config/locales/en/nsm/letters_and_calls.yml
+++ b/config/locales/en/nsm/letters_and_calls.yml
@@ -35,8 +35,6 @@ en:
         rate: Item rate
         uplift_requested: "Uplift requested"
         total_claimed: Total claimed
-        vat: VAT
-        total_claimed_inc_vate: Claim cost (including vat)
         laa_adjustments: LAA adjustments
         calculate_button_text: Calculate my changes
         claim_cost_table:
@@ -56,8 +54,6 @@ en:
         rate: Item rate
         uplift_requested: "Uplift requested"
         total_claimed: Total claimed
-        vat: VAT
-        total_claimed_inc_vate: Claim cost (including VAT)
         laa_adjustments: LAA adjustments
         uplift_allowed: Uplift allowed
         number_allowed: "Number of %{type}"

--- a/config/locales/en/nsm/work_items.yml
+++ b/config/locales/en/nsm/work_items.yml
@@ -75,8 +75,6 @@ en:
         fee_earner: Fee earner initials
         uplift_claimed: Uplift claimed
         total_claimed: Net cost claimed
-        vat: VAT
-        total_claimed_inc_vate: Cost claimed (including VAT)
         laa_adjustments: LAA adjustments
         uplift_allowed: Uplift allowed
         work_type: Work type

--- a/spec/view_models/nsm/v1/letter_and_call_spec.rb
+++ b/spec/view_models/nsm/v1/letter_and_call_spec.rb
@@ -300,13 +300,12 @@ RSpec.describe Nsm::V1::LetterAndCall do
     context 'when vat registered' do
       let(:vat_registered) { 'yes' }
 
-      it 'calculates the correct provider requested amount' do
+      it 'only shows vat-exclusive amount' do
         expect(subject.provider_fields).to eq(
           '.number' => '12',
           '.rate' => '£3.56',
           '.uplift_requested' => '20%',
-          '.vat' => '20%',
-          '.total_claimed_inc_vate' => '£61.52',
+          '.total_claimed' => '£51.26',
         )
       end
     end

--- a/spec/view_models/nsm/v1/letter_and_call_spec.rb
+++ b/spec/view_models/nsm/v1/letter_and_call_spec.rb
@@ -3,32 +3,6 @@ require 'rails_helper'
 RSpec.describe Nsm::V1::LetterAndCall do
   subject { described_class.new(params) }
 
-  describe '#vat_registered?' do
-    let(:params) do
-      {
-        'firm_office' => { 'vat_registered' => vat_registered },
-      }
-    end
-
-    context 'when value is yes' do
-      let(:vat_registered) { 'yes' }
-
-      it { expect(subject).to be_vat_registered }
-    end
-
-    context 'when value is no' do
-      let(:vat_registered) { 'no' }
-
-      it { expect(subject).not_to be_vat_registered }
-    end
-
-    context 'when value is blank' do
-      let(:vat_registered) { '' }
-
-      it { expect(subject).not_to be_vat_registered }
-    end
-  end
-
   describe '#provider_requested_amount' do
     let(:params) { { count_original: 1, uplift_original: 10, pricing: 10.5 } }
 
@@ -41,34 +15,6 @@ RSpec.describe Nsm::V1::LetterAndCall do
 
       it 'calulates the initial uplift' do
         expect(subject.provider_requested_amount).to eq(10.0 * 1.1 * 1.95)
-      end
-    end
-  end
-
-  describe 'provider_requested_amount_inc_vat' do
-    let(:params) do
-      {
-        :count => 1,
-        :uplift => 5,
-        :pricing => 10.0,
-        'firm_office' => { 'vat_registered' => vat_registered },
-        'vat_rate' => 0.2,
-      }
-    end
-
-    context 'when vat registered' do
-      let(:vat_registered) { 'yes' }
-
-      it 'calculates the correct provider requested amount' do
-        expect(subject.provider_requested_amount_inc_vat).to eq(12.6)
-      end
-    end
-
-    context 'when not vat registered' do
-      let(:vat_registered) { 'no' }
-
-      it 'calculates the correct provider requested amount' do
-        expect(subject.provider_requested_amount_inc_vat).to eq(10.5)
       end
     end
   end
@@ -114,34 +60,6 @@ RSpec.describe Nsm::V1::LetterAndCall do
 
     it 'calculates the correct caseworker amount' do
       expect(subject.caseworker_amount).to eq(10.5)
-    end
-  end
-
-  describe 'caseworker_amount_inc_vat' do
-    let(:params) do
-      {
-        :count => 1,
-        :uplift => 5,
-        :pricing => 10.0,
-        'firm_office' => { 'vat_registered' => vat_registered },
-        'vat_rate' => 0.2,
-      }
-    end
-
-    context 'when vat registered' do
-      let(:vat_registered) { 'yes' }
-
-      it 'calculates the correct provider requested amount' do
-        expect(subject.caseworker_amount_inc_vat).to eq(12.6)
-      end
-    end
-
-    context 'when not vat registered' do
-      let(:vat_registered) { 'no' }
-
-      it 'calculates the correct provider requested amount' do
-        expect(subject.caseworker_amount_inc_vat).to eq(10.5)
-      end
     end
   end
 
@@ -292,35 +210,16 @@ RSpec.describe Nsm::V1::LetterAndCall do
         'uplift' => 0,
         'uplift_original' => 20,
         'pricing' => 3.56,
-        'firm_office' => { 'vat_registered' => vat_registered },
-        'vat_rate' => 0.2,
       }
     end
 
-    context 'when vat registered' do
-      let(:vat_registered) { 'yes' }
-
-      it 'only shows vat-exclusive amount' do
-        expect(subject.provider_fields).to eq(
-          '.number' => '12',
-          '.rate' => '£3.56',
-          '.uplift_requested' => '20%',
-          '.total_claimed' => '£51.26',
-        )
-      end
-    end
-
-    context 'when not vat registered' do
-      let(:vat_registered) { 'no' }
-
-      it 'calculates the correct provider requested amount' do
-        expect(subject.provider_fields).to eq(
-          '.number' => '12',
-          '.rate' => '£3.56',
-          '.uplift_requested' => '20%',
-          '.total_claimed' => '£51.26',
-        )
-      end
+    it 'calculates the correct provider requested amount' do
+      expect(subject.provider_fields).to eq(
+        '.number' => '12',
+        '.rate' => '£3.56',
+        '.uplift_requested' => '20%',
+        '.total_claimed' => '£51.26',
+      )
     end
   end
 

--- a/spec/view_models/nsm/v1/work_item_spec.rb
+++ b/spec/view_models/nsm/v1/work_item_spec.rb
@@ -293,15 +293,14 @@ RSpec.describe Nsm::V1::WorkItem do
     context 'when vat registered' do
       let(:vat_registered) { 'yes' }
 
-      it 'calculates the correct provider requested amount' do
+      it 'only shows vat-exclusive amount' do
         expect(subject.provider_fields).to eq(
           '.work_type' => 'Waiting',
           '.date' => '14 December 2022',
           '.time_spent' => '2 hours 51 minutes',
           '.fee_earner' => 'JGB',
           '.uplift_claimed' => '20%',
-          '.vat' => '20%',
-          '.total_claimed_inc_vate' => '£98.50',
+          '.total_claimed' => '£82.08',
         )
       end
     end

--- a/spec/view_models/nsm/v1/work_item_spec.rb
+++ b/spec/view_models/nsm/v1/work_item_spec.rb
@@ -3,32 +3,6 @@ require 'rails_helper'
 RSpec.describe Nsm::V1::WorkItem do
   subject { described_class.new(params) }
 
-  describe '#vat_registered?' do
-    let(:params) do
-      {
-        'firm_office' => { 'vat_registered' => vat_registered },
-      }
-    end
-
-    context 'when value is yes' do
-      let(:vat_registered) { 'yes' }
-
-      it { expect(subject).to be_vat_registered }
-    end
-
-    context 'when value is no' do
-      let(:vat_registered) { 'no' }
-
-      it { expect(subject).not_to be_vat_registered }
-    end
-
-    context 'when value is blank' do
-      let(:vat_registered) { '' }
-
-      it { expect(subject).not_to be_vat_registered }
-    end
-  end
-
   describe 'table fields' do
     let(:adjustment_comment) { 'something' }
     let(:params) do
@@ -118,34 +92,6 @@ RSpec.describe Nsm::V1::WorkItem do
     end
   end
 
-  describe 'provider_requested_amount_inc_vat' do
-    let(:params) do
-      {
-        'time_spent' => 171,
-        'uplift' => 10,
-        'pricing' => 24.0,
-        'firm_office' => { 'vat_registered' => vat_registered },
-        'vat_rate' => 0.2,
-      }
-    end
-
-    context 'when vat registered' do
-      let(:vat_registered) { 'yes' }
-
-      it 'calculates the correct provider requested amount' do
-        expect(subject.provider_requested_amount_inc_vat).to eq(90.288)
-      end
-    end
-
-    context 'when not vat registered' do
-      let(:vat_registered) { 'no' }
-
-      it 'calculates the correct provider requested amount' do
-        expect(subject.provider_requested_amount_inc_vat).to eq(75.24)
-      end
-    end
-  end
-
   describe 'original_time_spent' do
     let(:params) do
       {
@@ -170,34 +116,6 @@ RSpec.describe Nsm::V1::WorkItem do
 
     it 'calculates the correct caseworker requested amount' do
       expect(subject.caseworker_amount).to eq(68.4)
-    end
-  end
-
-  describe '#caseworker_amount_inc_vat' do
-    let(:params) do
-      {
-        'time_spent' => 171,
-        'uplift' => 0,
-        'pricing' => 24.0,
-        'firm_office' => { 'vat_registered' => vat_registered },
-        'vat_rate' => 0.2,
-      }
-    end
-
-    context 'when vat registered' do
-      let(:vat_registered) { 'yes' }
-
-      it 'calculates the correct provider requested amount' do
-        expect(subject.caseworker_amount_inc_vat).to eq(82.08)
-      end
-    end
-
-    context 'when not vat registered' do
-      let(:vat_registered) { 'no' }
-
-      it 'calculates the correct provider requested amount' do
-        expect(subject.caseworker_amount_inc_vat).to eq(68.4)
-      end
     end
   end
 
@@ -283,41 +201,20 @@ RSpec.describe Nsm::V1::WorkItem do
         'uplift' => 0,
         'uplift_original' => 20,
         'pricing' => 24.0,
-        'firm_office' => { 'vat_registered' => vat_registered },
-        'vat_rate' => 0.2,
         'fee_earner' => 'JGB',
         'work_type' => { 'value' => 'waiting', 'en' => 'Waiting' },
       }
     end
 
-    context 'when vat registered' do
-      let(:vat_registered) { 'yes' }
-
-      it 'only shows vat-exclusive amount' do
-        expect(subject.provider_fields).to eq(
-          '.work_type' => 'Waiting',
-          '.date' => '14 December 2022',
-          '.time_spent' => '2 hours 51 minutes',
-          '.fee_earner' => 'JGB',
-          '.uplift_claimed' => '20%',
-          '.total_claimed' => '£82.08',
-        )
-      end
-    end
-
-    context 'when not vat registered' do
-      let(:vat_registered) { 'no' }
-
-      it 'calculates the correct provider requested amount' do
-        expect(subject.provider_fields).to eq(
-          '.work_type' => 'Waiting',
-          '.date' => '14 December 2022',
-          '.time_spent' => '2 hours 51 minutes',
-          '.fee_earner' => 'JGB',
-          '.uplift_claimed' => '20%',
-          '.total_claimed' => '£82.08',
-        )
-      end
+    it 'calculates the correct provider requested amount' do
+      expect(subject.provider_fields).to eq(
+        '.work_type' => 'Waiting',
+        '.date' => '14 December 2022',
+        '.time_spent' => '2 hours 51 minutes',
+        '.fee_earner' => 'JGB',
+        '.uplift_claimed' => '20%',
+        '.total_claimed' => '£82.08',
+      )
     end
   end
 


### PR DESCRIPTION
## Description of change
We shouldn't show individual vat figures for work items or letters/calls, as VAT is only applied once things are summed up.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1946)
