### PR TITLE
Swallow output to stdout during tests for rake tasks

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -78,4 +78,9 @@ RSpec.configure do |config|
   config.after(:each, type: :system) do
     ActiveJob::Base.queue_adapter.enqueued_jobs.clear
   end
+
+  # swallow sdtdout to keep output from rspec clean
+  config.before(:each, type: :task) do
+    allow($stdout).to receive(:write)
+  end
 end


### PR DESCRIPTION
## Description of change
Silence output to console from testing of rake tasks

Rake tasks often have stdout output but this comes
out when running rspec and clutters the console.

## Notes for reviewer
