### PR TITLE
CRM457-1978: Only prioritise post-mortem pathologist reports

### DIFF
--- a/app/services/prior_authority/choose_application_for_assignment.rb
+++ b/app/services/prior_authority/choose_application_for_assignment.rb
@@ -1,20 +1,28 @@
 module PriorAuthority
   class ChooseApplicationForAssignment
+    PATHOLOGIST_REPORT_RELATING_TO_POST_MORTEM = <<~SQL.squish.freeze
+      CASE
+      WHEN (data->>'service_type' = 'pathologist_report')
+        AND EXISTS (
+          SELECT 1 FROM JSONB_ARRAY_ELEMENTS(data->'quotes') AS quotes WHERE quotes.value->>'related_to_post_mortem' = 'true'
+        ) THEN 0
+      ELSE 1
+      END as post_mortem_pathologist_report
+    SQL
+
+    CRIMINAL_COURT = "CASE WHEN data->>'court_type' = 'central_criminal_court' THEN 0 ELSE 1 END as criminal_court".freeze
+
     class << self
       def call(user)
-        criminal_court = "CASE WHEN data->>'court_type' = 'central_criminal_court' THEN 0 ELSE 1 END as criminal_court"
-        pathologist_report = <<~SQL.squish
-          CASE WHEN data->>'service_type' = 'pathologist_report' THEN 0 ELSE 1 END as pathologist_report
-        SQL
-
         date_order_clause = Arel.sql("DATE_TRUNC('day', app_store_updated_at) ASC")
-
         PriorAuthorityApplication.assignable(user)
-                                 .select('submissions.*', criminal_court, pathologist_report)
+                                 .select('submissions.*',
+                                         CRIMINAL_COURT,
+                                         Arel.sql(PATHOLOGIST_REPORT_RELATING_TO_POST_MORTEM))
                                  .order(
                                    date_order_clause,
                                    criminal_court: :asc,
-                                   pathologist_report: :asc,
+                                   post_mortem_pathologist_report: :asc,
                                    app_store_updated_at: :asc
                                  ).first
       end


### PR DESCRIPTION
## Description of change
Pathologist reports should only be prioritised if they relate to a post mortem
I also rewrote the logic explanation in the specs because I couldn't get my head around it without referring back to the video explanation.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1978)
