### PR TITLE
CRM457-1954: Disable turbo-links

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -10,7 +10,9 @@ import './component/date-picker'
 
 // https://frontend.design-system.service.gov.uk/importing-css-assets-and-javascript/#javascript
 import { initAll } from 'govuk-frontend'
-
 initAll()
 
-Turbo.setFormMode("off")
+// set turbo to opt-in
+// https://turbo.hotwired.dev/handbook/drive#disabling-turbo-drive-on-specific-links-or-forms
+import { Turbo } from "@hotwired/turbo-rails"
+Turbo.session.drive = false

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -9,10 +9,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <p>
-      <%= link_to(t('.prior_authority'), prior_authority_root_path, class: 'govuk-link--no-visited-state', data: { turbo: false }) %>
+      <%= link_to(t('.prior_authority'), prior_authority_root_path, class: 'govuk-link--no-visited-state') %>
     </p>
     <p>
-      <%= link_to(t('.nsm'), nsm_root_path, class: 'govuk-link--no-visited-state', data: { turbo: false }) %>
+      <%= link_to(t('.nsm'), nsm_root_path, class: 'govuk-link--no-visited-state') %>
     </p>
     <% if current_user.supervisor? && FeatureFlags.insights.enabled? %>
       <p>

--- a/app/views/layouts/_header_navigation.html.erb
+++ b/app/views/layouts/_header_navigation.html.erb
@@ -11,7 +11,7 @@
       <li class="govuk-header__navigation-item">
         <%# Signing out will reset the session ID which will reset the CSP nonce token, so turbo-based page replacement
             will fail as inline scripts will no longer have a valid nonce %>
-        <%= govuk_link_to t('.sign_out'), destroy_user_session_path, class: 'govuk-header__link', data: { turbo: false } %>
+        <%= govuk_link_to t('.sign_out'), destroy_user_session_path, class: 'govuk-header__link' %>
       </li>
 
       <% unless request.path == root_path %>

--- a/app/views/layouts/dashboard/_primary_navigation.html.erb
+++ b/app/views/layouts/dashboard/_primary_navigation.html.erb
@@ -12,7 +12,7 @@
                 </li>
               <% end %>
               <li class="moj-primary-navigation__item">
-                  <%= link_to t('.search'), new_dashboard_path(nav_select: 'search'), class: 'moj-primary-navigation__link', 'aria-current': (@nav_select == 'search' ? 'page' :nil), data: { turbo: false } %>
+                  <%= link_to t('.search'), new_dashboard_path(nav_select: 'search'), class: 'moj-primary-navigation__link', 'aria-current': (@nav_select == 'search' ? 'page' :nil) %>
               </li>
           </ul>
         </nav>

--- a/app/views/layouts/nsm/_primary_navigation.html.erb
+++ b/app/views/layouts/nsm/_primary_navigation.html.erb
@@ -17,7 +17,7 @@
             </li>
             <% if FeatureFlags.search.enabled? %>
               <li class="moj-primary-navigation__item">
-                <%= link_to t('layouts.primary_navigation.search'), new_nsm_search_path, class: 'moj-primary-navigation__link', 'aria-current': (current == :search ? 'page' : nil), data: { turbo: false } %>
+                <%= link_to t('layouts.primary_navigation.search'), new_nsm_search_path, class: 'moj-primary-navigation__link', 'aria-current': (current == :search ? 'page' : nil) %>
               </li>
             <% end %>
           </ul>

--- a/app/views/layouts/prior_authority/_primary_navigation.html.erb
+++ b/app/views/layouts/prior_authority/_primary_navigation.html.erb
@@ -17,7 +17,7 @@
               </li>
               <% if FeatureFlags.search.enabled? %>
                 <li class="moj-primary-navigation__item">
-                  <%= link_to t('prior_authority.search'), new_prior_authority_search_path, class: 'moj-primary-navigation__link', 'aria-current': (current == :search ? 'page' : nil), data: { turbo: false } %>
+                  <%= link_to t('prior_authority.search'), new_prior_authority_search_path, class: 'moj-primary-navigation__link', 'aria-current': (current == :search ? 'page' : nil) %>
                 </li>
               <% end %>
           </ul>

--- a/app/views/prior_authority/applications/_table.html.erb
+++ b/app/views/prior_authority/applications/_table.html.erb
@@ -18,7 +18,7 @@
         <% columns.values.each_with_index do |value_attribute, index| %>
           <td class="govuk-table__cell">
             <% if index.zero? %>
-              <%= link_to application.send(value_attribute), prior_authority_application_path(application.id), data: { turbo: false } %>
+              <%= link_to application.send(value_attribute), prior_authority_application_path(application.id) %>
             <% else %>
               <%= application.send(value_attribute) %>
             <% end %>

--- a/app/views/prior_authority/shared/_application_buttons.html.erb
+++ b/app/views/prior_authority/shared/_application_buttons.html.erb
@@ -1,6 +1,6 @@
 <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible govuk-!-margin-top-9">
 <div class="govuk-button-group">
-  <%= govuk_button_link_to(t('.make_a_decision'), new_prior_authority_application_decision_path(application_summary.id), data: { turbo: false }) %>
-  <%= govuk_button_link_to(t('.send_back'), new_prior_authority_application_send_back_path(application_summary.id), secondary: true, data: { turbo: false }) %>
+  <%= govuk_button_link_to(t('.make_a_decision'), new_prior_authority_application_decision_path(application_summary.id)) %>
+  <%= govuk_button_link_to(t('.send_back'), new_prior_authority_application_send_back_path(application_summary.id), secondary: true) %>
   <%= govuk_button_link_to(t('.save_and_exit'), your_prior_authority_applications_path, secondary: true) %>
 </div>

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -86,11 +86,11 @@
         </div>
         <% if additional_param.present? %>
           <%= f.govuk_submit t('.search'), name: additional_param[:key], value: additional_param[:value] do %>
-            <%= govuk_link_to t('.clear_all'), clear_all_path, data: { turbo: false } %>
+            <%= govuk_link_to t('.clear_all'), clear_all_path %>
           <% end %>
         <% else %>
           <%= f.govuk_submit t('.search') do %>
-            <%= govuk_link_to t('.clear_all'), clear_all_path, data: { turbo: false } %>
+            <%= govuk_link_to t('.clear_all'), clear_all_path %>
           <% end %>
         <% end %>
       <% end %>
@@ -127,7 +127,7 @@
             <% @search_form.results.each do |search_result| %>
               <tr class="govuk-table__row app-task-list__item">
                 <td class="govuk-table__cell">
-                  <%= link_to search_result.laa_reference, search_result.application_path, data: { turbo: false } %>
+                  <%= link_to search_result.laa_reference, search_result.application_path %>
                 </td>
                 <td class="govuk-table__cell">
                   <%= search_result.firm_name %>


### PR DESCRIPTION
## Description of change
Disable turbo-links generally

[bug ticket](https://dsdmoj.atlassian.net/browse/CRM457-2026)
[came out of ticket](https://dsdmoj.atlassian.net/browse/CRM457-1954)

More problems on search page due to turbolinks. When a sorting header column 
or pagination page link is clicked the date picker component is not initialised.

Rather than use more { data: turbo: false } for search, including the shared pagination
partial, and inline with this PR from submit i have disabled it entirely.

https://github.com/ministryofjustice/laa-submit-crime-forms/pull/688

## Notes for reviewer
Will do a manual regression test of potential impacted screens
