### PR TITLE
[CRM457-1945] update search filter with risk rating

### DIFF
--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -86,6 +86,6 @@ class DashboardsController < ApplicationController
   end
 
   def set_presenter
-    @presenter = SearchFormPresenter.new('analytics', current_user)
+    @presenter = SearchFormPresenter.new('analytics')
   end
 end

--- a/app/controllers/dashboards_controller.rb
+++ b/app/controllers/dashboards_controller.rb
@@ -1,5 +1,5 @@
 class DashboardsController < ApplicationController
-  before_action :authorize_supervisor
+  before_action :authorize_supervisor, :set_presenter
 
   layout 'dashboard'
 
@@ -44,6 +44,7 @@ class DashboardsController < ApplicationController
       :status_with_assignment,
       :caseworker_id,
       :sort_by,
+      :risk,
       :sort_direction,
       :application_type
     ).merge(default_params)
@@ -82,5 +83,9 @@ class DashboardsController < ApplicationController
 
       "#{ENV.fetch('METABASE_SITE_URL')}/embed/dashboard/#{token}#bordered=true&titled=true"
     end
+  end
+
+  def set_presenter
+    @presenter = SearchFormPresenter.new('analytics', current_user)
   end
 end

--- a/app/controllers/nsm/searches_controller.rb
+++ b/app/controllers/nsm/searches_controller.rb
@@ -38,7 +38,7 @@ module Nsm
     end
 
     def set_presenter
-      @presenter = SearchFormPresenter.new(Submission::APPLICATION_TYPES[:nsm], current_user)
+      @presenter = SearchFormPresenter.new(Submission::APPLICATION_TYPES[:nsm])
     end
 
     def set_current_section

--- a/app/controllers/nsm/searches_controller.rb
+++ b/app/controllers/nsm/searches_controller.rb
@@ -1,6 +1,7 @@
 module Nsm
   class SearchesController < BaseController
     before_action :set_current_section
+    before_action :set_presenter
 
     def show
       @search_form = Nsm::SearchForm.new(search_params)
@@ -22,6 +23,7 @@ module Nsm
         :updated_from,
         :updated_to,
         :status_with_assignment,
+        :risk,
         :caseworker_id,
         :sort_by,
         :sort_direction
@@ -33,6 +35,10 @@ module Nsm
         application_type: Submission::APPLICATION_TYPES[:nsm],
         page: params.fetch(:page, '1')
       }
+    end
+
+    def set_presenter
+      @presenter = SearchFormPresenter.new(Submission::APPLICATION_TYPES[:nsm], current_user)
     end
 
     def set_current_section

--- a/app/controllers/prior_authority/searches_controller.rb
+++ b/app/controllers/prior_authority/searches_controller.rb
@@ -1,5 +1,7 @@
 module PriorAuthority
   class SearchesController < BaseController
+    before_action :set_presenter
+
     def show
       @search_form = PriorAuthority::SearchForm.new(search_params)
       @search_form.execute if @search_form.valid?
@@ -31,6 +33,10 @@ module PriorAuthority
         application_type: Submission::APPLICATION_TYPES[:prior_authority],
         page: params.fetch(:page, '1')
       }
+    end
+
+    def set_presenter
+      @presenter = SearchFormPresenter.new(Submission::APPLICATION_TYPES[:prior_authority], current_user)
     end
   end
 end

--- a/app/controllers/prior_authority/searches_controller.rb
+++ b/app/controllers/prior_authority/searches_controller.rb
@@ -36,7 +36,7 @@ module PriorAuthority
     end
 
     def set_presenter
-      @presenter = SearchFormPresenter.new(Submission::APPLICATION_TYPES[:prior_authority], current_user)
+      @presenter = SearchFormPresenter.new(Submission::APPLICATION_TYPES[:prior_authority])
     end
   end
 end

--- a/app/forms/search_form.rb
+++ b/app/forms/search_form.rb
@@ -22,6 +22,7 @@ class SearchForm
   attribute :sort_by, :string, default: 'last_updated'
   attribute :sort_direction, :string, default: 'descending'
   attribute :application_type, :string
+  attribute :risk, :string
 
   validate :at_least_one_field_set
   validates :application_type, presence: true
@@ -68,12 +69,20 @@ class SearchForm
     self.class::APPLICATION_TYPES
   end
 
+  def risks
+    [show_all] + %i[
+      high
+      low
+      medium
+    ].map { Option.new(_1, I18n.t("search.risks.#{_1}")) }
+  end
+
   private
 
   def at_least_one_field_set
     fields = [:query, :submitted_from,
               :submitted_to, :updated_from,
-              :updated_to, :status_with_assignment,
+              :updated_to, :risk, :status_with_assignment,
               :caseworker_id]
 
     field_set = fields.any? do |field|

--- a/app/presenters/search_form_presenter.rb
+++ b/app/presenters/search_form_presenter.rb
@@ -1,0 +1,20 @@
+class SearchFormPresenter
+  attr_accessor :service, :current_user
+
+  def initialize(service, current_user)
+    @service = service
+    @current_user = current_user
+  end
+
+  def result_headers
+    headers = %i[laa_reference firm_name client_name caseworker last_updated status_with_assignment]
+    headers << :risk if show_risk_filter?
+    headers
+  end
+
+  def show_risk_filter?
+    return true if current_user.supervisor? && service == 'analytics'
+
+    service != 'crm4'
+  end
+end

--- a/app/presenters/search_form_presenter.rb
+++ b/app/presenters/search_form_presenter.rb
@@ -7,9 +7,10 @@ class SearchFormPresenter
   end
 
   def result_headers
-    headers = %i[laa_reference firm_name client_name caseworker last_updated status_with_assignment]
-    headers << :risk if show_risk_filter?
-    headers
+    risk_headers = %i[laa_reference firm_name client_name caseworker last_updated risk status_with_assignment]
+    return risk_headers if show_risk_filter?
+
+    %i[laa_reference firm_name client_name caseworker last_updated status_with_assignment]
   end
 
   def show_risk_filter?

--- a/app/presenters/search_form_presenter.rb
+++ b/app/presenters/search_form_presenter.rb
@@ -1,7 +1,7 @@
 class SearchFormPresenter
   attr_accessor :service, :current_user
 
-  def initialize(service, current_user)
+  def initialize(service)
     @service = service
     @current_user = current_user
   end
@@ -14,7 +14,7 @@ class SearchFormPresenter
   end
 
   def show_risk_filter?
-    return true if current_user.supervisor? && service == 'analytics'
+    return true if service == 'analytics'
 
     service != 'crm4'
   end

--- a/app/view_models/search_result.rb
+++ b/app/view_models/search_result.rb
@@ -37,7 +37,7 @@ class SearchResult
     submission_state_tag(submission)
   end
 
-  delegate :application_type, to: :submission
+  delegate :application_type, :risk, to: :submission
 
   # assuming all submissions have an application_type as this has to
   # be a valid value (i.e. not blank) - testing it is both arduous and redundant

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -152,14 +152,14 @@
                 <td class="govuk-table__cell">
                   <%= search_result.date_updated %>
                 </td>
+                <% if @presenter.show_risk_filter? %>
+                  <td class="govuk-table__cell">
+                    <%= search_result.risk&.capitalize %>
+                  </td>
+                <% end %>
                 <td class="govuk-table__cell">
                   <%= search_result.state_tag %>
                 </td>
-                <% if @presenter.show_risk_filter? %>
-                <td class="govuk-table__cell">
-                  <%= search_result.risk %>
-                </td>
-                <% end %>
               </tr>
             <% end %>
           </tbody>

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -65,6 +65,17 @@
           </fieldset>
         </div>
         <div>
+          <% if @presenter.show_risk_filter? %>
+            <div class="govuk-date-input__item">
+              <div class="govuk-form-group">
+                <%= f.govuk_collection_select :risk,
+                  @search_form.risks,
+                  :value,
+                  :label,
+                  label: { text: t(".risk") } %>
+              </div>
+            </div>
+          <% end %>
           <div class="govuk-date-input__item">
             <div class="govuk-form-group">
               <%= f.govuk_collection_select :status_with_assignment,
@@ -103,7 +114,7 @@
         <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="page-title">
           <thead class="govuk-table__head">
             <tr class="govuk-table__row">
-              <% %i[laa_reference firm_name client_name caseworker last_updated status_with_assignment].each do |key| %>
+              <% @presenter.result_headers.each do |key| %>
                 <% if key == :caseworker %>
                   <th scope='col' class='govuk-table__header'><%= t('.table.header.caseworker') %></th>
                 <% else %>
@@ -144,6 +155,11 @@
                 <td class="govuk-table__cell">
                   <%= search_result.state_tag %>
                 </td>
+                <% if @presenter.show_risk_filter? %>
+                <td class="govuk-table__cell">
+                  <%= search_result.risk %>
+                </td>
+                <% end %>
               </tr>
             <% end %>
           </tbody>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,6 +76,7 @@ en:
         none_para: Check you’ve entered the correct details
       result: result
       status: Status
+      risk: Risk
       caseworker: Caseworker
       table:
         header:
@@ -85,6 +86,7 @@ en:
           caseworker: Caseworker
           last_updated: Last updated
           status_with_assignment: Status
+          risk: Risk
 
   generic:
     cost: cost

--- a/config/locales/en/nsm/search.yml
+++ b/config/locales/en/nsm/search.yml
@@ -12,6 +12,10 @@ en:
       part_grant: Part granted
       rejected: Rejected
       expired: Expired
+    risks:
+      high: High
+      low: Low
+      medium: Medium
     unassigned: Unassigned
   nsm:
     searches:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -57,7 +57,7 @@ resources:
 
 variables:
   environment: development
-  appStoreUrl: https://main-nscc-store-dev.cloud-platform.service.justice.gov.uk
+  appStoreUrl: https://crm457-1945-add-ri-nscc-store-dev.cloud-platform.service.justice.gov.uk/
   enableSyncTriggerEndpoint: 'true'
   allowIndexing: 'false'
 

--- a/spec/presenters/search_form_presenter_spec.rb
+++ b/spec/presenters/search_form_presenter_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SearchFormPresenter do
       it 'adds risk column to headers' do
         expect(subject.result_headers).to eq %i[laa_reference
                                                 firm_name client_name caseworker
-                                                last_updated status_with_assignment risk]
+                                                last_updated risk status_with_assignment]
       end
     end
 
@@ -27,7 +27,7 @@ RSpec.describe SearchFormPresenter do
     let(:service) { 'crm4' }
 
     describe '.result_headers' do
-      it 'adds risk column to headers' do
+      it 'does not add risk column to headers' do
         expect(subject.result_headers).to eq %i[laa_reference
                                                 firm_name client_name caseworker
                                                 last_updated status_with_assignment]
@@ -49,7 +49,7 @@ RSpec.describe SearchFormPresenter do
       it 'adds risk column to headers' do
         expect(subject.result_headers).to eq %i[laa_reference
                                                 firm_name client_name caseworker
-                                                last_updated status_with_assignment risk]
+                                                last_updated risk status_with_assignment]
       end
     end
 

--- a/spec/presenters/search_form_presenter_spec.rb
+++ b/spec/presenters/search_form_presenter_spec.rb
@@ -1,9 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe SearchFormPresenter do
-  subject { described_class.new(service, user) }
-
-  let(:user) { create(:caseworker) }
+  subject { described_class.new(service) }
 
   let(:service) { 'crm7' }
 
@@ -43,7 +41,6 @@ RSpec.describe SearchFormPresenter do
 
   context 'analytics' do
     let(:service) { 'analytics' }
-    let(:user) { create(:supervisor) }
 
     describe '.result_headers' do
       it 'adds risk column to headers' do

--- a/spec/presenters/search_form_presenter_spec.rb
+++ b/spec/presenters/search_form_presenter_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe SearchFormPresenter do
+  subject { described_class.new(service, user) }
+
+  let(:user) { create(:caseworker) }
+
+  let(:service) { 'crm7' }
+
+  context 'cmr7' do
+    describe '.result_headers' do
+      it 'adds risk column to headers' do
+        expect(subject.result_headers).to eq %i[laa_reference
+                                                firm_name client_name caseworker
+                                                last_updated status_with_assignment risk]
+      end
+    end
+
+    describe '.show_risk_filer' do
+      it 'returns true' do
+        expect(subject.show_risk_filter?).to be true
+      end
+    end
+  end
+
+  context 'crm4' do
+    let(:service) { 'crm4' }
+
+    describe '.result_headers' do
+      it 'adds risk column to headers' do
+        expect(subject.result_headers).to eq %i[laa_reference
+                                                firm_name client_name caseworker
+                                                last_updated status_with_assignment]
+      end
+    end
+
+    describe '.show_risk_filer' do
+      it 'returns true' do
+        expect(subject.show_risk_filter?).to be false
+      end
+    end
+  end
+
+  context 'analytics' do
+    let(:service) { 'analytics' }
+    let(:user) { create(:supervisor) }
+
+    describe '.result_headers' do
+      it 'adds risk column to headers' do
+        expect(subject.result_headers).to eq %i[laa_reference
+                                                firm_name client_name caseworker
+                                                last_updated status_with_assignment risk]
+      end
+    end
+
+    describe '.show_risk_filer' do
+      it 'returns true' do
+        expect(subject.show_risk_filter?).to be true
+      end
+    end
+  end
+end

--- a/spec/system/nsm/search_spec.rb
+++ b/spec/system/nsm/search_spec.rb
@@ -157,6 +157,7 @@ RSpec.describe 'Search', :stub_oauth_token do
         sort_by: 'last_updated',
         sort_direction: 'descending',
         status_with_assignment: 'rejected',
+        risk: 'high',
         submitted_from: '20/4/2023',
         submitted_to: '21/4/2023',
         updated_from: '22/4/2023',
@@ -182,9 +183,19 @@ RSpec.describe 'Search', :stub_oauth_token do
       fill_in 'Last updated to', with: '23/4/2023'
       select caseworker.display_name, from: 'Caseworker'
       select 'Rejected', from: 'Status'
+      select 'High', from: 'Risk'
+
       within('main') { click_on 'Search' }
 
       expect(stub).to have_been_requested
+    end
+  end
+
+  context 'risk filter' do
+    it 'displays in CRM7 search' do
+      visit nsm_root_path
+      click_on 'Search'
+      expect(page).to have_content 'Risk'
     end
   end
 end

--- a/spec/system/prior_authority/search_spec.rb
+++ b/spec/system/prior_authority/search_spec.rb
@@ -213,4 +213,12 @@ RSpec.describe 'Search', :stub_oauth_token do
       expect(stub).to have_been_requested
     end
   end
+
+  context 'risk filter' do
+    it 'does not display in CRM4 search' do
+      visit prior_authority_root_path
+      click_on 'Search'
+      expect(page).not_to have_content 'Risk'
+    end
+  end
 end


### PR DESCRIPTION
## Description of change

DO NOT MERGE refers to: https://dsdmoj.atlassian.net/browse/CRM457-2086

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1945)

relates to https://github.com/ministryofjustice/laa-crime-application-store/pull/281

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:
CW/Supervisor unable to filter using `risk` in search
![Screenshot 2024-09-20 at 10 01 53](https://github.com/user-attachments/assets/b6f673d7-c1f5-44f9-8b40-ae7c7f806b32)


### After changes:
CW can search using `risk` as a filter on `CMR7` crm7 search
SUPERVISOR can search using `risk` on `CRM7` via analytics dashboard search
![Screenshot 2024-09-20 at 10 02 14](https://github.com/user-attachments/assets/1c4c231a-6c72-4963-ad66-721e5bc611bf)


## How to manually test the feature
