### PR TITLE
[CRM457-2054] only show delete adjustments for open claims

### DIFF
--- a/app/services/nsm/adjustment_deleter.rb
+++ b/app/services/nsm/adjustment_deleter.rb
@@ -3,6 +3,8 @@ module Nsm
     attr_reader :params, :adjustment_type, :current_user, :submission
 
     def call
+      return false if submission.assessed?
+
       case adjustment_type
       when :work_item
         delete_work_item_adjustment

--- a/app/services/nsm/all_adjustments_deleter.rb
+++ b/app/services/nsm/all_adjustments_deleter.rb
@@ -8,6 +8,8 @@ module Nsm
     end
 
     def call
+      return false if submission.assessed?
+
       raise StandardError, "no adjustments to delete for id:#{submission.id}" unless submission.any_adjustments?
 
       app_store_record = AppStoreClient.new.get_submission(submission)

--- a/app/views/nsm/adjustments/show.html.erb
+++ b/app/views/nsm/adjustments/show.html.erb
@@ -9,7 +9,9 @@
         <%= t('.adjusted_costs') %>
       </h2>
 
-      <%= govuk_button_link_to( t('.delete_all_adjustments'), confirm_deletion_nsm_claim_adjustments_path(claim), secondary: true,  data: { turbo: "false" }) %>
+      <% unless claim.assessed? %>
+        <%= govuk_button_link_to( t('.delete_all_adjustments'), confirm_deletion_nsm_claim_adjustments_path(claim), secondary: true,  data: { turbo: "false" }) %>
+      <% end %>
 
       <ul class="govuk-tabs__list" id="tabs">
         <li class="govuk-tabs__list-item <%= 'govuk-tabs__list-item--selected' if scope == :work_items %>">

--- a/app/views/nsm/disbursements/_adjusted.html.erb
+++ b/app/views/nsm/disbursements/_adjusted.html.erb
@@ -18,7 +18,9 @@
                                         additional_classes:) %>
           <% end %>
         <% end %>
-        <th class="govuk-table__header" scope="col"><%= t(".action") %></th>
+        <% unless claim.assessed? %>
+          <th class="govuk-table__header" scope="col"><%= t(".action") %></th>
+        <% end %>
       </tr>
     </thead>
     <tbody class="govuk-table__body app-task-list__items">
@@ -46,11 +48,13 @@
           <td class="govuk-table__cell govuk-table__cell--numeric">
             <%= disbursement.allowed_gross %>
           </td>
-          <td class="govuk-table__cell">
-            <%= link_to t(".delete"),
-              confirm_deletion_nsm_claim_disbursement_path(claim, disbursement.id),
-              class: "govuk-link govuk-link--no-visited-state" %>
-          </td>
+          <% unless claim.assessed? %>
+            <td class="govuk-table__cell">
+              <%= link_to t(".delete"),
+                confirm_deletion_nsm_claim_disbursement_path(claim, disbursement.id),
+                class: "govuk-link govuk-link--no-visited-state" %>
+            </td>
+         <% end %>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/nsm/work_items/_adjusted.html.erb
+++ b/app/views/nsm/work_items/_adjusted.html.erb
@@ -18,7 +18,9 @@
                                         additional_classes: ) %>
           <% end %>
         <% end %>
-        <th class="govuk-table__header" scope="col"><%= t(".action") %></th>
+        <% unless claim.assessed? %>
+          <th class="govuk-table__header" scope="col"><%= t(".action") %></th>
+        <% end %>
       </tr>
     </thead>
 
@@ -55,11 +57,13 @@
           <td class="govuk-table__cell govuk-table__cell--numeric">
             <%= work_item.formatted_allowed_amount %>
           </td>
-          <td class="govuk-table__cell">
-            <%= link_to t(".delete"),
-              confirm_deletion_nsm_claim_work_item_path(claim, work_item.id),
-              class: "govuk-link govuk-link--no-visited-state" %>
-          </td>
+          <% unless claim.assessed? %>
+            <td class="govuk-table__cell">
+              <%= link_to t(".delete"),
+                confirm_deletion_nsm_claim_work_item_path(claim, work_item.id),
+                class: "govuk-link govuk-link--no-visited-state" %>
+            </td>
+          <% end %>
         </tr>
       <% end %>
     </tbody>

--- a/spec/services/nsm/adjustment_deleter_spec.rb
+++ b/spec/services/nsm/adjustment_deleter_spec.rb
@@ -13,6 +13,15 @@ RSpec.describe Nsm::AdjustmentDeleter do
       create(:assignment, submission: claim, user: user)
     end
 
+    describe '#call' do
+      let(:adjustment_type) { :disbursement }
+
+      it 'returns false if submission already assessed' do
+        allow(service.submission).to receive(:assessed?).and_return true
+        expect(service.call).to be false
+      end
+    end
+
     context 'when adjustment type is unknown' do
       let(:adjustment_type) { :some_new_adjustment }
 

--- a/spec/services/nsm/all_adjustments_deleter_spec.rb
+++ b/spec/services/nsm/all_adjustments_deleter_spec.rb
@@ -26,6 +26,13 @@ RSpec.describe Nsm::AllAdjustmentsDeleter do
       claim.data.merge('adjusted' => true)
     end
 
+    describe '#call' do
+      it 'returns false if submission already assessed' do
+        allow(service.submission).to receive(:assessed?).and_return true
+        expect(service.call).to be false
+      end
+    end
+
     context 'when deleting disbursement adjustments' do
       before { service.call }
 


### PR DESCRIPTION
## Description of change

remove delete links and delete all button for assesses claims 

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2054)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
