### PR TITLE
CRM457-2002: Expire claims and show expired claims

### DIFF
--- a/app/forms/nsm/search_form.rb
+++ b/app/forms/nsm/search_form.rb
@@ -1,14 +1,22 @@
 module Nsm
   class SearchForm < ::SearchForm
     def statuses
-      [show_all] + %i[
-        not_assigned
-        in_progress
-        sent_back
-        granted
-        part_grant
-        rejected
-      ].map { Option.new(_1, I18n.t("search.statuses.#{_1}")) }
+      status_list = %i[not_assigned
+                       in_progress
+                       sent_back
+                       provider_updated
+                       granted
+                       part_grant
+                       rejected
+                       expired]
+
+      relevant_statuses = if FeatureFlags.nsm_rfi_loop.enabled?
+                            status_list
+                          else
+                            status_list - %i[provider_updated expired]
+                          end
+
+      [show_all] + relevant_statuses.map { Option.new(_1, I18n.t("search.statuses.#{_1}")) }
     end
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -73,7 +73,7 @@ module ApplicationHelper
     return unless claim_id
 
     current_claim = Claim.find(claim_id)
-    if current_claim.assessed?
+    if current_claim.closed?
       :closed
     elsif current_claim.assigned_to?(current_user)
       :your

--- a/app/jobs/expire_sendbacks.rb
+++ b/app/jobs/expire_sendbacks.rb
@@ -5,6 +5,11 @@ class ExpireSendbacks < ApplicationJob
                              .find_each do |expirable|
                                expire(expirable)
                              end
+    Claim.sent_back
+         .where("(data->>'resubmission_deadline')::timestamp < NOW()")
+         .find_each do |expirable|
+           expire(expirable)
+         end
   end
 
   private

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -17,7 +17,7 @@ class Claim < Submission
   }
 
   scope :auto_assignable, lambda { |user|
-    submitted
+    where(state: [SUBMITTED, PROVIDER_UPDATED])
       .where.not(risk: :high)
       .where.missing(:assignments)
       .where.not(id: Event::Unassignment.where(primary_user_id: user.id).select(:submission_id))

--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -4,10 +4,10 @@ class Claim < Submission
   default_scope -> { where(application_type: APPLICATION_TYPES[:nsm]) }
 
   # open
-  scope :pending_decision, -> { where.not(state: ASSESSED_STATES) }
+  scope :pending_decision, -> { where.not(state: CLOSED_STATES) }
 
   # closed
-  scope :decision_made, -> { where(state: ASSESSED_STATES) }
+  scope :decision_made, -> { where(state: CLOSED_STATES) }
 
   # your
   scope :pending_and_assigned_to, lambda { |user|
@@ -26,19 +26,23 @@ class Claim < Submission
   STATES = (
     [
       SUBMITTED = 'submitted'.freeze,
-      SENT_BACK = 'sent_back'.freeze
+      SENT_BACK = 'sent_back'.freeze,
+      PROVIDER_UPDATED = 'provider_updated'.freeze,
     ] +
-      (ASSESSED_STATES = [
-        GRANTED = 'granted'.freeze,
-        PART_GRANT = 'part_grant'.freeze,
-        REJECTED = 'rejected'.freeze
-      ].freeze)
+      CLOSED_STATES = (
+        (ASSESSED_STATES = [
+          GRANTED = 'granted'.freeze,
+          PART_GRANT = 'part_grant'.freeze,
+          REJECTED = 'rejected'.freeze
+        ].freeze) +
+        [EXPIRED = 'expired'.freeze]
+      ).freeze
   ).freeze
 
   enum :state, STATES.to_h { [_1, _1] }
 
   def editable_by?(user)
-    !assessed? && assigned_to?(user) && !user.viewer?
+    !closed? && assigned_to?(user) && !user.viewer?
   end
 
   def assigned_to?(user)
@@ -49,12 +53,16 @@ class Claim < Submission
     ASSESSED_STATES.include?(state)
   end
 
+  def closed?
+    CLOSED_STATES.include?(state)
+  end
+
   def assignment_removable_by?(user)
-    !assessed? && assignments.any? && !user.viewer?
+    !closed? && assignments.any? && !user.viewer?
   end
 
   def self_assignable_by?(user)
-    !assessed? && assignments.none? && !user.viewer?
+    !closed? && assignments.none? && !user.viewer?
   end
 
   def formatted_claimed_total

--- a/app/view_models/nsm/v1/claim_summary.rb
+++ b/app/view_models/nsm/v1/claim_summary.rb
@@ -29,6 +29,14 @@ module Nsm
       def display_allowed_total?
         claimed_total != allowed_total || submission.assessed?
       end
+
+      def sent_back_on
+        if submission.data['further_information']
+          submission.data['further_information'].map { _1['requested_at'].to_datetime }.max
+        else
+          last_updated_at
+        end
+      end
     end
   end
 end

--- a/app/views/nsm/claim_details/show.html.erb
+++ b/app/views/nsm/claim_details/show.html.erb
@@ -7,9 +7,9 @@
   <div class="govuk-grid-column-full">
     <h2 class="govuk-heading-l"><%= t('.overview') %></h2>
 
-    <% if claim.sent_back? %>
+    <% if claim.sent_back? || claim.expired? %>
       <div class="govuk-inset-text">
-        <p><strong><%= t(".sent_back", date: claim_summary.last_updated_at.to_fs(:stamp)) %></strong></p>
+        <p><strong><%= t(".sent_back", date: claim_summary.sent_back_on.to_fs(:stamp)) %></strong></p>
         <%= simple_format claim_summary.assessment_comment %>
       </div>
     <% elsif claim_summary.assessment_comment.present? %>

--- a/app/views/nsm/histories/show.html.erb
+++ b/app/views/nsm/histories/show.html.erb
@@ -12,15 +12,15 @@
 
     <%=
       govuk_table do |table|
-        history_events.each do |event|
-          table.with_head do |head|
-            head.with_row do |row|
-              row.with_cell(text: t('.when'))
-              row.with_cell(text: t('.caseworker'))
-              row.with_cell(text: t('.what'))
-            end
+        table.with_head do |head|
+          head.with_row do |row|
+            row.with_cell(text: t('.when'))
+            row.with_cell(text: t('.caseworker'))
+            row.with_cell(text: t('.what'))
           end
-          table.with_body do |body|
+        end
+        table.with_body do |body|
+          history_events.each do |event|
             body.with_row do |row|
               row.with_cell(text: format_in_zone(event.created_at, format: '%A<br>%d %b %Y<br>%I:%M%P').html_safe)
               row.with_cell(text: event.primary_user&.display_name || '')

--- a/config/locales/en/events.yml
+++ b/config/locales/en/events.yml
@@ -23,5 +23,7 @@ en:
     title:
       self: Caseworker removed self from claim
       secondary: Caseworker removed from claim by %{display_name}
+  event/delete_adjustments:
+    title: Caseworker deleted all adjustments
   event/expiry:
     title: Claim expired

--- a/config/locales/en/events.yml
+++ b/config/locales/en/events.yml
@@ -23,5 +23,5 @@ en:
     title:
       self: Caseworker removed self from claim
       secondary: Caseworker removed from claim by %{display_name}
-  event/delete_adjustments:
-    title: Caseworker deleted all adjustments
+  event/expiry:
+    title: Claim expired

--- a/spec/forms/nsm/search_form_spec.rb
+++ b/spec/forms/nsm/search_form_spec.rb
@@ -7,7 +7,22 @@ RSpec.describe Nsm::SearchForm do
     it 'does not contain auto_grant, provider_updated, expired status' do
       statuses = subject.statuses.map(&:value)
       %i[auto_grant provider_updated expired].each do |status|
-        refute(statuses.include?(status))
+        expect(statuses).not_to include(status)
+      end
+    end
+
+    context 'when feature flag is enabled' do
+      before do
+        allow(FeatureFlags).to receive(:nsm_rfi_loop).and_return(
+          instance_double(FeatureFlags::EnabledFeature, enabled?: true)
+        )
+      end
+
+      it 'does contain provider_updated and expired' do
+        statuses = subject.statuses.map(&:value)
+        %i[provider_updated expired].each do |status|
+          expect(statuses).to include(status)
+        end
       end
     end
   end

--- a/spec/jobs/expire_sendbacks_spec.rb
+++ b/spec/jobs/expire_sendbacks_spec.rb
@@ -2,46 +2,102 @@ require 'rails_helper'
 
 RSpec.describe ExpireSendbacks do
   describe '#perform' do
-    let(:application) { create(:prior_authority_application, state:, updated_at:) }
+    context 'when the submission is a prior authority application' do
+      let(:application) { create(:prior_authority_application, state:, updated_at:) }
+
+      before do
+        application
+        allow(NotifyAppStore).to receive(:perform_later)
+        described_class.new.perform
+      end
+
+      context 'when an application is overdue expiry' do
+        let(:state) { 'sent_back' }
+        let(:updated_at) { 15.days.ago }
+
+        it 'marks as expired' do
+          expect(application.reload).to be_expired
+        end
+
+        it 'creates an event' do
+          expect(application.events.first).to be_a(Event::Expiry)
+        end
+
+        it 'updates the app store without an email' do
+          expect(NotifyAppStore).to have_received(:perform_later).with(submission: application, trigger_email: false)
+        end
+      end
+
+      context 'when an application is not sent back' do
+        let(:state) { 'submitted' }
+        let(:updated_at) { 15.days.ago }
+
+        it 'does not mark as expired' do
+          expect(application.reload).not_to be_expired
+        end
+      end
+
+      context 'when an application is only recently sent back' do
+        let(:state) { 'sent_back' }
+        let(:updated_at) { 10.days.ago }
+
+        it 'does not mark as expired' do
+          expect(application.reload).not_to be_expired
+        end
+      end
+    end
+  end
+
+  context 'when the submission is a claim' do
+    let(:claim) { create(:claim, state:, data:) }
 
     before do
-      application
+      claim
       allow(NotifyAppStore).to receive(:perform_later)
       described_class.new.perform
     end
 
-    context 'when an application is overdue expiry' do
+    context 'when a claim is overdue expiry' do
       let(:state) { 'sent_back' }
-      let(:updated_at) { 15.days.ago }
+      let(:data) { { 'resubmission_deadline' => 1.hour.ago.to_datetime } }
 
       it 'marks as expired' do
-        expect(application.reload).to be_expired
+        expect(claim.reload).to be_expired
       end
 
       it 'creates an event' do
-        expect(application.events.first).to be_a(Event::Expiry)
+        expect(claim.events.first).to be_a(Event::Expiry)
       end
 
       it 'updates the app store without an email' do
-        expect(NotifyAppStore).to have_received(:perform_later).with(submission: application, trigger_email: false)
+        expect(NotifyAppStore).to have_received(:perform_later).with(submission: claim, trigger_email: false)
       end
     end
 
-    context 'when an application is not sent back' do
-      let(:state) { 'submitted' }
-      let(:updated_at) { 15.days.ago }
+    context 'when a claim is not sent back' do
+      let(:state) { 'provider_updated' }
+      let(:data) { { 'resubmission_deadline' => 1.hour.ago.to_datetime } }
 
       it 'does not mark as expired' do
-        expect(application.reload).not_to be_expired
+        expect(claim.reload).not_to be_expired
       end
     end
 
-    context 'when an application is only recently sent back' do
+    context 'when a claim is not ready to be expired' do
       let(:state) { 'sent_back' }
-      let(:updated_at) { 10.days.ago }
+      let(:data) { { 'resubmission_deadline' => 2.hours.from_now.to_datetime } }
 
       it 'does not mark as expired' do
-        expect(application.reload).not_to be_expired
+        expect(claim.reload).not_to be_expired
+      end
+    end
+
+    context 'when a claim does not have a resubmission deadline' do
+      let(:state) { 'sent_back' }
+      let(:data) { {} }
+
+      it 'does not mark as expired' do
+        expect(claim.reload).not_to be_expired
       end
     end
   end

--- a/spec/system/nsm/overview_spec.rb
+++ b/spec/system/nsm/overview_spec.rb
@@ -63,4 +63,26 @@ RSpec.describe 'Overview', type: :system do
         .and have_link('Review quote adjustments')
     end
   end
+
+  context 'when claim has been sent back and expired' do
+    let(:claim) { create(:claim, state: 'expired') }
+
+    before do
+      claim.data['assessment_comment'] = 'Send back reason'
+      claim.data['further_information'] = [
+        {
+          requested_at: DateTime.new(2024, 9, 1, 10, 10, 10),
+          information_requested: 'Send back reason'
+        }
+      ]
+      claim.save!
+      visit nsm_claim_claim_details_path(claim)
+    end
+
+    it 'shows me the status and comment' do
+      expect(page)
+        .to have_content('Expired')
+        .and have_content('Send back reason')
+    end
+  end
 end


### PR DESCRIPTION
## Description of change
- Add logic to expire claims once the deadline has passed
- Show expired claims with appropriate UI
- The above meant adding a new status, and tidging how we group statuses, because 'expired' claims haven't been assessed but we want to treat them the same as assessed claims in some ways.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2002)
