### PR TITLE
CRM457-2067: Sync risk changes back to app store

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -23,7 +23,6 @@ class Event < ApplicationRecord
   ].freeze
 
   LOCAL_EVENTS = [
-    'Event::ChangeRisk',
     'Event::DraftDecision',
     'Event::Edit',
     'Event::Note',

--- a/app/services/app_store_client.rb
+++ b/app/services/app_store_client.rb
@@ -41,6 +41,17 @@ class AppStoreClient
     end
   end
 
+  def update_submission_metadata(submission, payload)
+    response = self.class.patch("#{host}/v1/submissions/#{submission.id}/metadata", **options(payload))
+
+    case response.code
+    when 200
+      :success
+    else
+      raise "Unexpected response from AppStore - status #{response.code} for metadata update to'#{submission.id}'"
+    end
+  end
+
   def trigger_subscription(payload, action: :create)
     method = action == :create ? :post : :delete
     response = self.class.send(method, "#{host}/v1/subscriber", **options(payload))

--- a/config/locales/en/nsm/change_risks.yml
+++ b/config/locales/en/nsm/change_risks.yml
@@ -24,6 +24,8 @@ en:
       models:
         nsm/change_risk_form:
           attributes:
+            base:
+              sync_error: There was a problem saving the change. Please try again.
             risk_level:
               blank: Select what you want to change the risk to
               inclusion: Select what you want to change the risk to

--- a/spec/system/nsm/risk_spec.rb
+++ b/spec/system/nsm/risk_spec.rb
@@ -1,12 +1,17 @@
 require 'rails_helper'
 
-RSpec.describe 'Risk' do
+RSpec.describe 'Risk', :stub_oauth_token do
   let(:user) { create(:caseworker) }
   let(:claim) { create(:claim) }
+  let(:stub) do
+    stub_request(:patch, "https://appstore.example.com/v1/submissions/#{claim.id}/metadata").to_return(status:)
+  end
+  let(:status) { 200 }
 
   before do
     sign_in user
     create(:assignment, submission: claim, user: user)
+    stub
     visit open_nsm_claims_path
     click_on claim.data['laa_reference']
     expect(page).to have_content 'Low risk'
@@ -18,6 +23,7 @@ RSpec.describe 'Risk' do
     fill_in 'Explain your decision', with: 'Looks shifty to me'
     click_on 'Change risk'
     expect(page).to have_content 'You changed the claim risk to medium'
+    expect(stub).to have_been_requested
   end
 
   it 'prevents me changing the risk without a reason' do
@@ -30,5 +36,16 @@ RSpec.describe 'Risk' do
     click_on 'Cancel'
     expect(page).to have_current_path nsm_claim_claim_details_path(claim)
     expect(page).to have_content 'Low risk'
+  end
+
+  context 'when app store errors out' do
+    let(:status) { 500 }
+
+    it 'errors out' do
+      choose 'Medium risk'
+      fill_in 'Explain your decision', with: 'Looks shifty to me'
+      click_on 'Change risk'
+      expect(page).to have_content 'There was a problem saving the change. Please try again.'
+    end
   end
 end


### PR DESCRIPTION
## Description of change
Let the app store know immediately if the risk has changed.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2067)

## Notes for reviewer
I opted to make the app store call synchronous. As we move towards the app store as our single source of truth we need to get comfortable with the idea of it being a direct dependency that we interact with as part of our request/response interaction with end users. A synchronous request means we guarantee things stay in sync, get immediate feedback if there is a problem, and start to validate that our architecture can handle using the app store as the single source of truth.
