### PR TITLE
CRM457-2063: Use 10 working day window for prior authority application send-backs

### DIFF
--- a/app/forms/nsm/send_back_form.rb
+++ b/app/forms/nsm/send_back_form.rb
@@ -56,7 +56,7 @@ module Nsm
     end
 
     def working_days_allowed
-      Rails.application.config.x.rfi.nsm_working_day_window
+      Rails.application.config.x.rfi.working_day_window
     end
   end
 end

--- a/app/forms/prior_authority/send_back_form.rb
+++ b/app/forms/prior_authority/send_back_form.rb
@@ -75,7 +75,7 @@ module PriorAuthority
     end
 
     def resubmission_deadline
-      Rails.application.config.x.rfi.resubmission_window.from_now
+      WorkingDayService.call(Rails.application.config.x.rfi.working_day_window)
     end
 
     def append_explanation(type, explanation)

--- a/app/jobs/expire_sendbacks.rb
+++ b/app/jobs/expire_sendbacks.rb
@@ -1,15 +1,10 @@
 class ExpireSendbacks < ApplicationJob
   def perform
-    PriorAuthorityApplication.sent_back
-                             .where(updated_at: ...Rails.application.config.x.rfi.resubmission_window.ago)
-                             .find_each do |expirable|
-                               expire(expirable)
-                             end
-    Claim.sent_back
-         .where("(data->>'resubmission_deadline')::timestamp < NOW()")
-         .find_each do |expirable|
-           expire(expirable)
-         end
+    [PriorAuthorityApplication, Claim].each do |klass|
+      klass.sent_back
+           .where("(data->>'resubmission_deadline')::timestamp < NOW()")
+           .find_each { expire(_1) }
+    end
   end
 
   private

--- a/app/mailers/nsm/feedback_messages/further_information_request_feedback.rb
+++ b/app/mailers/nsm/feedback_messages/further_information_request_feedback.rb
@@ -26,7 +26,7 @@ module Nsm
 
       def date_to_respond_by
         if FeatureFlags.nsm_rfi_loop.enabled?
-          @submission.data['resubmission_deadline']
+          DateTime.parse(@submission.data['resubmission_deadline']).to_fs(:stamp)
         else
           7.days.from_now.to_fs(:stamp)
         end

--- a/app/mailers/prior_authority/feedback_messages/further_information_request_feedback.rb
+++ b/app/mailers/prior_authority/feedback_messages/further_information_request_feedback.rb
@@ -13,7 +13,7 @@ module PriorAuthority
           ufn: ufn,
           defendant_name: defendant_name,
           application_total: application_total,
-          date_to_respond_by: Rails.configuration.x.rfi.resubmission_window.from_now.to_fs(:stamp),
+          date_to_respond_by: date_to_respond_by,
           caseworker_information_requested: comments,
           date: DateTime.now.to_fs(:stamp),
         }
@@ -43,6 +43,10 @@ module PriorAuthority
 
       def further_information_explanation
         @submission.data['further_information_explanation']
+      end
+
+      def date_to_respond_by
+        DateTime.parse(@submission.data['resubmission_deadline']).to_fs(:stamp)
       end
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -70,8 +70,7 @@ module LaaAssessNonStandardMagistrateFee
     config.x.analytics.cookies_consent_expiration = 1.year
     config.x.analytics.analytics_consent_name = 'analytics_preferences_set'
     config.x.analytics.analytics_consent_expiration = 1.year
-    config.x.rfi.resubmission_window = 14.days
-    config.x.rfi.nsm_working_day_window = 10
+    config.x.rfi.working_day_window = 10
     config.x.redis_url = if ENV['REDIS_HOST'].present? && ENV['REDIS_PASSWORD'].present?
       protocol = ENV.fetch("REDIS_PROTOCOL", "rediss")
       password = ENV.fetch('REDIS_PASSWORD')

--- a/spec/forms/prior_authority/send_back_form_spec.rb
+++ b/spec/forms/prior_authority/send_back_form_spec.rb
@@ -6,6 +6,9 @@ RSpec.describe PriorAuthority::SendBackForm do
   let(:submission) { create(:prior_authority_application) }
   let(:further_information_explanation) { 'foo' }
   let(:incorrect_information_explanation) { 'bar' }
+  let(:deadline) { DateTime.new(2024, 9, 1, 6, 46, 34) }
+
+  before { allow(WorkingDayService).to receive(:call).with(10).and_return(deadline) }
 
   describe '#comments' do
     context 'when further information is requested' do
@@ -114,7 +117,7 @@ RSpec.describe PriorAuthority::SendBackForm do
         end
 
         it 'sets a resubmission deadline' do
-          expect(DateTime.parse(submission.data['resubmission_deadline'])).to eq 14.days.from_now
+          expect(DateTime.parse(submission.data['resubmission_deadline'])).to eq deadline
         end
 
         it 'updates the state' do
@@ -164,7 +167,7 @@ RSpec.describe PriorAuthority::SendBackForm do
         end
 
         it 'sets a resubmission deadline' do
-          expect(DateTime.parse(submission.data['resubmission_deadline'])).to eq 14.days.from_now
+          expect(DateTime.parse(submission.data['resubmission_deadline'])).to eq deadline
         end
 
         it 'updates the state' do

--- a/spec/jobs/expire_sendbacks_spec.rb
+++ b/spec/jobs/expire_sendbacks_spec.rb
@@ -3,7 +3,11 @@ require 'rails_helper'
 RSpec.describe ExpireSendbacks do
   describe '#perform' do
     context 'when the submission is a prior authority application' do
-      let(:application) { create(:prior_authority_application, state:, updated_at:) }
+      let(:application) do
+        create(:prior_authority_application,
+               state: state,
+               data: build(:prior_authority_data, resubmission_deadline: deadline))
+      end
 
       before do
         application
@@ -13,7 +17,7 @@ RSpec.describe ExpireSendbacks do
 
       context 'when an application is overdue expiry' do
         let(:state) { 'sent_back' }
-        let(:updated_at) { 15.days.ago }
+        let(:deadline) { 1.day.ago }
 
         it 'marks as expired' do
           expect(application.reload).to be_expired
@@ -30,7 +34,7 @@ RSpec.describe ExpireSendbacks do
 
       context 'when an application is not sent back' do
         let(:state) { 'submitted' }
-        let(:updated_at) { 15.days.ago }
+        let(:deadline) { 1.day.ago }
 
         it 'does not mark as expired' do
           expect(application.reload).not_to be_expired
@@ -39,7 +43,7 @@ RSpec.describe ExpireSendbacks do
 
       context 'when an application is only recently sent back' do
         let(:state) { 'sent_back' }
-        let(:updated_at) { 10.days.ago }
+        let(:deadline) { 1.day.from_now }
 
         it 'does not mark as expired' do
           expect(application.reload).not_to be_expired

--- a/spec/jobs/prior_authority/fake_assess_spec.rb
+++ b/spec/jobs/prior_authority/fake_assess_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe PriorAuthority::FakeAssess do
       allow(NotifyAppStore).to receive(:perform_later)
       allow(AppStoreClient).to receive(:new).and_return(client)
       allow(SecureRandom).to receive(:rand).and_return random_choice
+      allow(WorkingDayService).to receive(:call).and_return 3.days.from_now
       subject.perform([application.id])
     end
 

--- a/spec/mailers/nsm/feedback_messages/further_information_request_feeback_spec.rb
+++ b/spec/mailers/nsm/feedback_messages/further_information_request_feeback_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Nsm::FeedbackMessages::FurtherInformationRequestFeedback do
       allow(FeatureFlags).to receive(:nsm_rfi_loop).and_return(
         instance_double(FeatureFlags::EnabledFeature, enabled?: true)
       )
-      claim.data['resubmission_deadline'] = 'DEADLINE'
+      claim.data['resubmission_deadline'] = '2024-11-7T16:35:34.00'
     end
 
     let(:feedback_template) { '632fc896-8019-4308-a091-67f593700f32' }
@@ -63,7 +63,7 @@ RSpec.describe Nsm::FeedbackMessages::FurtherInformationRequestFeedback do
     describe '#contents' do
       it 'has correct deadline' do
         expect(subject.contents).to include(
-          date_to_respond_by: 'DEADLINE',
+          date_to_respond_by: '7 November 2024',
         )
       end
     end

--- a/spec/mailers/prior_authority/feedback_messages/further_information_request_feeback_spec.rb
+++ b/spec/mailers/prior_authority/feedback_messages/further_information_request_feeback_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe PriorAuthority::FeedbackMessages::FurtherInformationRequestFeedba
         defendant: { 'last_name' => 'Abrahams', 'first_name' => 'Abe' },
         incorrect_information_explanation: incorrect_information_explanation,
         further_information_explanation: further_information_explanation,
+        resubmission_deadline: '2023-4-07T12:49:58.00'
       )
     ).tap do |app|
       create(
@@ -54,7 +55,7 @@ RSpec.describe PriorAuthority::FeedbackMessages::FurtherInformationRequestFeedba
         ufn: '111111/111',
         defendant_name: 'Abe Abrahams',
         application_total: '£324.50',
-        date_to_respond_by: 14.days.from_now.to_fs(:stamp),
+        date_to_respond_by: '7 April 2023',
         date: DateTime.now.to_fs(:stamp),
       )
     end

--- a/spec/mailers/prior_authority/submission_feedback_mailer_spec.rb
+++ b/spec/mailers/prior_authority/submission_feedback_mailer_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe PriorAuthority::SubmissionFeedbackMailer, type: :mailer do
 
   context 'with further information state' do
     let(:feedback_template) { 'c8abf9ee-5cfe-44ab-9253-72111b7a35ba' }
-    let(:date_to_respond_by) { 14.days.from_now.to_fs(:stamp) }
+    let(:date_to_respond_by) { '4 January 2025' }
 
     let(:caseworker_information_requested) do
       "## Further information request\n\n" \
@@ -127,6 +127,7 @@ RSpec.describe PriorAuthority::SubmissionFeedbackMailer, type: :mailer do
           incorrect_information_explanation: 'Please correct this information...',
           further_information_explanation: 'Please provide this further info...',
           assessment_comment: 'This message is set but not used by the mailer',
+          resubmission_deadline: '2025-1-4T04:04:04.00',
         )
       )
     end

--- a/spec/system/prior_authority/send_back_spec.rb
+++ b/spec/system/prior_authority/send_back_spec.rb
@@ -3,11 +3,26 @@ require 'rails_helper'
 RSpec.describe 'Send an application back', :stub_oauth_token do
   let(:caseworker) { create(:caseworker) }
   let(:application) { create(:prior_authority_application, state: 'submitted') }
+  let(:bank_holiday_list) do
+    {
+      'england-and-wales': {
+        events: [
+          { date: '2024-01-01' }
+        ]
+      }
+    }
+  end
 
   before do
     stub_request(:get, "https://appstore.example.com/v1/submissions/#{application.id}").to_return(
       status: 200,
       body: { 'application' => application.data }.to_json,
+    )
+
+    stub_request(:get, 'https://www.gov.uk/bank-holidays.json').to_return(
+      status: 200,
+      body: bank_holiday_list.to_json,
+      headers: { 'Content-type' => 'application/json' }
     )
 
     sign_in caseworker


### PR DESCRIPTION
## Description of change
Reuse the NSM "10 working day" logic for PA send-backs

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2063)
