### PR TITLE
CRM457-1996: access logs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,7 @@ class ApplicationController < ActionController::Base
   before_action :set_security_headers
   before_action :set_default_cookies
   before_action :set_referrer
+  before_action :log_access
 
   private
 
@@ -32,5 +33,25 @@ class ApplicationController < ActionController::Base
   def set_referrer
     referrer = request.env['HTTP_REFERER']
     @referrer = referrer if referrer && URI(referrer).scheme != 'javascript'
+  end
+
+  def log_access
+    return unless signed_in? && submission_id.present?
+
+    current_user.access_logs.create!(
+      path: request.path,
+      controller: controller_name,
+      action: action_name,
+      submission_id: submission_id,
+      secondary_id: secondary_id,
+    )
+  end
+
+  def submission_id
+    nil
+  end
+
+  def secondary_id
+    params[:id]
   end
 end

--- a/app/controllers/nsm/base_controller.rb
+++ b/app/controllers/nsm/base_controller.rb
@@ -1,5 +1,11 @@
 module Nsm
   class BaseController < ApplicationController
     layout 'nsm'
+
+    private
+
+    def submission_id
+      params[:claim_id]
+    end
   end
 end

--- a/app/controllers/nsm/claims_controller.rb
+++ b/app/controllers/nsm/claims_controller.rb
@@ -50,5 +50,13 @@ module Nsm
       @sort_by = params.fetch(:sort_by, default)
       @sort_direction = params.fetch(:sort_direction, 'descending')
     end
+
+    def submission_id
+      params[:id]
+    end
+
+    def secondary_id
+      nil
+    end
   end
 end

--- a/app/controllers/prior_authority/applications_controller.rb
+++ b/app/controllers/prior_authority/applications_controller.rb
@@ -31,6 +31,8 @@ module PriorAuthority
       @details = BaseViewModel.build(:application_details, application)
     end
 
+    private
+
     def order_and_paginate(query)
       pagy(Sorter.call(query, @sort_by, @sort_direction))
     end
@@ -39,6 +41,14 @@ module PriorAuthority
       default = 'date_updated'
       @sort_by = params.fetch(:sort_by, default)
       @sort_direction = params.fetch(:sort_direction, 'descending')
+    end
+
+    def submission_id
+      params[:id]
+    end
+
+    def secondary_id
+      nil
     end
   end
 end

--- a/app/controllers/prior_authority/base_controller.rb
+++ b/app/controllers/prior_authority/base_controller.rb
@@ -1,5 +1,11 @@
 module PriorAuthority
   class BaseController < ApplicationController
     layout 'prior_authority'
+
+    private
+
+    def submission_id
+      params[:application_id]
+    end
   end
 end

--- a/app/models/access_log.rb
+++ b/app/models/access_log.rb
@@ -1,0 +1,3 @@
+class AccessLog < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  has_many :access_logs, dependent: :destroy
+
   ROLES = [
     CASEWORKER = 'caseworker'.freeze,
     SUPERVISOR = 'supervisor'.freeze,

--- a/db/migrate/20240930083741_create_access_logs.rb
+++ b/db/migrate/20240930083741_create_access_logs.rb
@@ -1,0 +1,14 @@
+class CreateAccessLogs < ActiveRecord::Migration[7.1]
+  def change
+    create_table :access_logs do |t|
+      t.references :user, null: false, foreign_key: true, type: :uuid
+      t.string :path
+      t.string :controller
+      t.string :action
+      t.string :submission_id
+      t.string :secondary_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_25_081532) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_30_083741) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
   enable_extension "postgis"
+
+  create_table "access_logs", force: :cascade do |t|
+    t.uuid "user_id", null: false
+    t.string "path"
+    t.string "controller"
+    t.string "action"
+    t.string "submission_id"
+    t.string "secondary_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_access_logs_on_user_id"
+  end
 
   create_table "assignments", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "submission_id", null: false
@@ -105,6 +117,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_25_081532) do
     t.index ["email"], name: "index_users_on_email"
   end
 
+  add_foreign_key "access_logs", "users"
   add_foreign_key "assignments", "submissions"
   add_foreign_key "assignments", "users"
   add_foreign_key "events", "submissions"

--- a/lib/tasks/audit.rake
+++ b/lib/tasks/audit.rake
@@ -1,0 +1,19 @@
+namespace :audit do
+  desc 'Audit user activity'
+  task :user, [:user_id, :from, :to] => [:environment] do |_, args|
+    AccessLog.where(user_id: args[:user_id], created_at: Date.parse(args[:from])..Date.parse(args[:to]))
+             .order(:created_at)
+             .find_each do |log|
+      puts "#{log.created_at},#{log.controller},#{log.action},#{log.submission_id},#{log.secondary_id},#{log.path}"
+    end
+  end
+
+  desc 'Audit submission activity'
+  task :submission, [:submission_id, :from, :to] => [:environment] do |_, args|
+    AccessLog.where(submission_id: args[:submission_id], created_at: Date.parse(args[:from])..Date.parse(args[:to]))
+             .order(:created_at)
+             .find_each do |log|
+      puts "#{log.created_at},#{log.user_id},#{log.controller},#{log.action},#{log.secondary_id},#{log.path}"
+    end
+  end
+end

--- a/spec/controllers/nsm/change_risks_controller_spec.rb
+++ b/spec/controllers/nsm/change_risks_controller_spec.rb
@@ -25,7 +25,8 @@ RSpec.describe Nsm::ChangeRisksController, type: :controller do
     let(:claim) { instance_double(Claim, id: claim_id) }
     let(:claim_id) { SecureRandom.uuid }
     let(:risk) { instance_double(Nsm::ChangeRiskForm, save:, risk_level:) }
-    let(:user) { instance_double(User) }
+    let(:user) { instance_double(User, access_logs:) }
+    let(:access_logs) { double(AccessLog, create!: true) }
     let(:risk_level) { 'high' }
     let(:save) { true }
 

--- a/spec/controllers/nsm/histories_controller_spec.rb
+++ b/spec/controllers/nsm/histories_controller_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe Nsm::HistoriesController do
   end
 
   context 'create' do
-    let(:user) { instance_double(User) }
+    let(:user) { instance_double(User, access_logs:) }
+    let(:access_logs) { double(AccessLog, create!: true) }
     let(:risk_level) { 'high' }
 
     it 'builds a note object' do

--- a/spec/controllers/nsm/make_decisions_controller_spec.rb
+++ b/spec/controllers/nsm/make_decisions_controller_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe Nsm::MakeDecisionsController do
 
   context 'update' do
     let(:decision) { instance_double(Nsm::MakeDecisionForm, save: save, state: 'granted') }
-    let(:user) { instance_double(User) }
+    let(:user) { instance_double(User, access_logs:) }
+    let(:access_logs) { double(AccessLog, create!: true) }
     let(:claim) { instance_double(Claim, id: SecureRandom.uuid) }
     let(:laa_reference_class) do
       instance_double(Nsm::V1::LaaReference, laa_reference: 'AAA111')

--- a/spec/controllers/nsm/send_backs_controller_spec.rb
+++ b/spec/controllers/nsm/send_backs_controller_spec.rb
@@ -23,7 +23,8 @@ RSpec.describe Nsm::SendBacksController do
 
   context 'update' do
     let(:send_back) { instance_double(Nsm::SendBackForm, save:) }
-    let(:user) { instance_double(User) }
+    let(:user) { instance_double(User, access_logs:) }
+    let(:access_logs) { double(AccessLog, create!: true) }
     let(:claim) { build(:claim, id: SecureRandom.uuid) }
     let(:laa_reference_class) do
       instance_double(Nsm::V1::LaaReference, laa_reference: 'AAA111')

--- a/spec/controllers/nsm/unassignments_controller_spec.rb
+++ b/spec/controllers/nsm/unassignments_controller_spec.rb
@@ -36,7 +36,8 @@ RSpec.describe Nsm::UnassignmentsController do
       instance_double(Nsm::UnassignmentForm, save:, unassignment_user:, user:)
     end
     let(:unassignment_user) { 'other' }
-    let(:user) { instance_double(User, display_name: 'Jim Bob') }
+    let(:user) { instance_double(User, display_name: 'Jim Bob', access_logs: access_logs) }
+    let(:access_logs) { double(AccessLog, create!: true) }
     let(:claim) { create(:claim, :with_assignment) }
     let(:laa_reference_class) do
       instance_double(Nsm::V1::LaaReference, laa_reference: 'AAA111')

--- a/spec/factories/access_log.rb
+++ b/spec/factories/access_log.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :access_log do
+    user factory: %i[caseworker]
+    submission_id { '123123123' }
+    action { 'show' }
+    controller { 'claim' }
+    path { '/nsm/claims/show/123123123' }
+    secondary_id { nil }
+  end
+end

--- a/spec/lib/tasks/audit_spec.rb
+++ b/spec/lib/tasks/audit_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+describe 'audit:', type: :task do
+  let(:fixed_arbitrary_date) { DateTime.new(2023, 12, 3, 12, 3, 12) }
+  let(:user) { create(:caseworker) }
+  let(:submission) { create(:claim) }
+
+  before do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+    create :access_log,
+           user: user,
+           submission_id: submission.id,
+           created_at: fixed_arbitrary_date,
+           path: '/foo',
+           controller: 'claims',
+           action: 'show'
+  end
+
+  describe 'user' do
+    subject { Rake::Task['audit:user'].invoke(user.id, '2023-12-3', '2023-12-4') }
+
+    after { Rake::Task['audit:user'].reenable }
+
+    let(:expected_output) { "2023-12-03 12:03:12 UTC,claims,show,#{submission.id},,/foo\n" }
+
+    it 'calls the service' do
+      expect { subject }.to output(expected_output).to_stdout
+    end
+  end
+
+  describe 'submission' do
+    subject { Rake::Task['audit:submission'].invoke(submission.id, '2023-12-3', '2023-12-4') }
+
+    after { Rake::Task['audit:submission'].reenable }
+
+    let(:expected_output) { "2023-12-03 12:03:12 UTC,#{user.id},claims,show,,/foo\n" }
+
+    it 'calls the service' do
+      expect { subject }.to output(expected_output).to_stdout
+    end
+  end
+end

--- a/spec/system/nsm/assessment_spec.rb
+++ b/spec/system/nsm/assessment_spec.rb
@@ -42,6 +42,12 @@ Rails.describe 'Assessment', :stub_oauth_token, :stub_update_claim do
         visit nsm_claim_history_path(claim)
         expect(page).to have_content 'Test Data'
       end
+
+      it 'records a paper trail in the access logs' do
+        expect(user.access_logs.where(submission_id: claim.id).order(:created_at).pluck(:controller, :action)).to eq(
+          [%w[claim_details show], %w[make_decisions edit], %w[make_decisions update]]
+        )
+      end
     end
   end
 

--- a/spec/system/prior_authority/make_decision_spec.rb
+++ b/spec/system/prior_authority/make_decision_spec.rb
@@ -44,6 +44,12 @@ RSpec.describe 'Decide an application', :stub_oauth_token do
         click_on 'Submit decision'
         expect(page).to have_content 'This application has already been assessed'
       end
+
+      it 'records a paper trail in the access logs' do
+        expect(caseworker.access_logs.where(submission_id: application.id).order(:created_at).pluck(:controller, :action)).to eq(
+          [%w[applications show], %w[decisions new], %w[decisions create], %w[decisions show]]
+        )
+      end
     end
   end
 


### PR DESCRIPTION
## Description of change
Add access logs that are populated on every page view that involves looking at a submission

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1996)

## Notes for reviewer
- I've built in some redundancy in the log format, with both the full path and a breakdown of controller/action/id, to give us some protections against e.g. routes changing in future
- The rake task to spit out logs is very simple, in the absence of specific requirements I thought best to go with the easiest thing for now.
