### PR TITLE
HOTFIX for RFI nil documents 

### DIFF
--- a/app/view_models/nsm/v1/further_information.rb
+++ b/app/view_models/nsm/v1/further_information.rb
@@ -56,6 +56,8 @@ module Nsm
       end
 
       def uploaded_documents
+        return [] if documents.nil?
+
         @uploaded_documents ||= documents.map { Document.new(_1) }
       end
 

--- a/spec/view_models/nsm/v1/further_information_spec.rb
+++ b/spec/view_models/nsm/v1/further_information_spec.rb
@@ -3,40 +3,66 @@ require 'rails_helper'
 RSpec.describe Nsm::V1::FurtherInformation do
   subject { described_class.new(params) }
 
+  let(:submission) { double('Submission', id: 1) }
+  let(:user) { create(:caseworker, id: SecureRandom.uuid, first_name: 'Fred', last_name: 'Falke') }
+
   let(:params) do
     {
       'information_supplied' => 'Please find...',
       'caseworker_id' => user.id,
       'requested_at' => DateTime.now,
       'information_requested' => 'Please send...',
-      'documents' => []
+      'documents' => [{
+        'file_name' => 'Some_Info.pdf',
+        'file_path' => '421727bc53d347ea81edd6a00833671d',
+        'file_size' => 690_389,
+        'file_type' => 'application/pdf',
+        'document_type' => 'supporting_document'
+      }]
     }
   end
 
-  let(:user) { create(:caseworker, id: SecureRandom.uuid, first_name: 'Fred', last_name: 'Falke') }
-
   describe '#data' do
     it 'shows correct table data' do
+      allow(subject).to receive(:submission).and_return(submission)
+      response_with_doc = '<p>Please find...</p><br>' \
+                          '<a href="/nsm/claims/1/supporting_evidences/' \
+                          'downloads/421727bc53d347ea81edd6a00833671d">Some_Info.pdf</a>'
       expect(subject.data).to eq([{ title: 'Caseworker', value: 'Fred Falke' },
                                   { title: 'Information request', value: 'Please send...' },
-                                  { title: 'Provider response', value: '<p>Please find...</p>' }])
+                                  { title: 'Provider response', value: response_with_doc }])
     end
   end
 
   describe '#caseworker' do
-    it 'shows caseworker display name' do
-      expect(subject.caseworker).to eq 'Fred Falke'
+    let(:params) do
+      { 'information_supplied' => 'Please find...',
+        'caseworker_id' => 1234,
+        'requested_at' => DateTime.now,
+        'information_requested' => 'Please send...',
+        'documents' => [] }
     end
 
     it 'falls back to nil if CW not found' do
-      params = { 'information_supplied' => 'Please find...',
-                 'caseworker_id' => 1234,
-                 'requested_at' => DateTime.now,
-                 'information_requested' => 'Please send...',
-                 'documents' => [] }
-      subject = described_class.new(params)
+      subject { described_class.new(params) }
 
       expect(subject.caseworker).to be_nil
+    end
+  end
+
+  describe '#uploaded_documents' do
+    subject { described_class.new(params) }
+
+    let(:params) do
+      { 'information_supplied' => 'Please find...',
+        'caseworker_id' => 1234,
+        'requested_at' => DateTime.now,
+        'information_requested' => 'Please send...',
+        'documents' => nil }
+    end
+
+    it 'returns nil if no documents' do
+      expect(subject.uploaded_documents).to be_empty
     end
   end
 end


### PR DESCRIPTION
## Description of change

hotfix for when we might not have documents for further information - though this might actually just have been stray data in dev - an RFI send_back should always have an empty documents array that is populated by the provider on response if documents are added

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
