### PR TITLE
[CRM457-2104] add service types to granted and part granted emails

### DIFF
--- a/app/mailers/prior_authority/feedback_messages/feedback_base.rb
+++ b/app/mailers/prior_authority/feedback_messages/feedback_base.rb
@@ -3,6 +3,8 @@
 module PriorAuthority
   module FeedbackMessages
     class FeedbackBase
+      include ActionView::Helpers::OutputSafetyHelper
+
       def initialize(submission)
         @submission = submission
       end
@@ -45,10 +47,23 @@ module PriorAuthority
         decision.comments
       end
 
+      def service_required
+        application_summary.service_name
+      end
+
+      def service_provider_details
+        quote = application_details.primary_quote
+        [quote.contact_full_name, quote.organisation, quote.town, quote.postcode].compact.join(', ')
+      end
+
       private
 
       def application_summary
         @application_summary ||= BaseViewModel.build(:application_summary, @submission)
+      end
+
+      def application_details
+        @application_details ||= BaseViewModel.build(:application_details, @submission)
       end
 
       def decision

--- a/app/mailers/prior_authority/feedback_messages/granted_feedback.rb
+++ b/app/mailers/prior_authority/feedback_messages/granted_feedback.rb
@@ -12,6 +12,8 @@ module PriorAuthority
           laa_case_reference: case_reference,
           ufn: ufn,
           defendant_name: defendant_name,
+          service_required: service_required,
+          service_provider_details: service_provider_details,
           application_total: application_total,
           date: DateTime.now.to_fs(:stamp),
         }

--- a/app/mailers/prior_authority/feedback_messages/part_granted_feedback.rb
+++ b/app/mailers/prior_authority/feedback_messages/part_granted_feedback.rb
@@ -12,6 +12,8 @@ module PriorAuthority
           laa_case_reference: case_reference,
           ufn: ufn,
           defendant_name: defendant_name,
+          service_required: service_required,
+          service_provider_details: service_provider_details,
           application_total: application_total,
           part_grant_total: adjusted_total,
           caseworker_decision_explanation: comments,

--- a/spec/mailers/prior_authority/feedback_messages/granted_feedback_spec.rb
+++ b/spec/mailers/prior_authority/feedback_messages/granted_feedback_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe PriorAuthority::FeedbackMessages::GrantedFeedback do
       expect(feedback.contents).to include(
         laa_case_reference: 'LAA-FHaMVK',
         ufn: '111111/111',
+        service_required: 'Pathologist report',
+        service_provider_details: 'ABC DEF, ABC, HIJ, SW1 1AA',
         defendant_name: 'Abe Abrahams',
         application_total: '£324.50',
         date: DateTime.now.to_fs(:stamp),

--- a/spec/mailers/prior_authority/feedback_messages/part_granted_feedback_spec.rb
+++ b/spec/mailers/prior_authority/feedback_messages/part_granted_feedback_spec.rb
@@ -45,6 +45,8 @@ RSpec.describe PriorAuthority::FeedbackMessages::PartGrantedFeedback do
         defendant_name: 'Abe Abrahams',
         application_total: '£300.00',
         part_grant_total: '£150.00',
+        service_required: 'Pathologist report',
+        service_provider_details: 'ABC DEF, ABC, HIJ, SW1 1AA',
         caseworker_decision_explanation: 'Caseworker part granted coz...',
         date: DateTime.now.to_fs(:stamp),
       )


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2104)

Update Prior Authority Notify granted and part-granted emails to provider to include the Service required and the Service provider details.

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
