### PR TITLE
CRM457-2049: Fix RFI/'delete all adjustments' edge case

### DIFF
--- a/app/services/nsm/all_adjustments_deleter.rb
+++ b/app/services/nsm/all_adjustments_deleter.rb
@@ -32,8 +32,8 @@ module Nsm
       letters_and_calls.each do |letter_or_call|
         revert_fields.each do |field|
           revert(letter_or_call, field, letter_or_call['type']['value'])
-          letter_or_call.delete('adjustment_comment')
         end
+        letter_or_call.delete('adjustment_comment')
       end
     end
 

--- a/app/services/nsm/all_adjustments_deleter.rb
+++ b/app/services/nsm/all_adjustments_deleter.rb
@@ -31,7 +31,7 @@ module Nsm
       revert_fields = %w[uplift count]
       letters_and_calls.each do |letter_or_call|
         revert_fields.each do |field|
-          revert(letter_or_call, field, letter_or_call['type']['value'])
+          revert(letter_or_call, field, letter_or_call['type'])
         end
         letter_or_call.delete('adjustment_comment')
       end

--- a/app/services/nsm/all_adjustments_deleter.rb
+++ b/app/services/nsm/all_adjustments_deleter.rb
@@ -10,12 +10,53 @@ module Nsm
     def call
       return false unless submission.editable_by?(current_user)
 
-      raise StandardError, "no adjustments to delete for id:#{submission.id}" unless submission.any_adjustments?
-
-      app_store_record = AppStoreClient.new.get_submission(submission)
-      submission.update!(data: app_store_record['application'])
-
+      delete_work_item_adjustments if work_items
+      delete_letters_and_calls_adjustments if letters_and_calls
+      delete_disbursement_adjustments if disbursements
       ::Event::DeleteAdjustments.build(submission:, comment:, current_user:)
+      submission.save!
+    end
+
+    def delete_work_item_adjustments
+      revert_fields = %w[uplift pricing work_type time_spent]
+      work_items.each do |work_item|
+        revert_fields.each do |field|
+          revert(work_item, field, 'work_items')
+        end
+        work_item.delete('adjustment_comment')
+      end
+    end
+
+    def delete_letters_and_calls_adjustments
+      revert_fields = %w[uplift count]
+      letters_and_calls.each do |letter_or_call|
+        revert_fields.each do |field|
+          revert(letter_or_call, field, letter_or_call['type']['value'])
+          letter_or_call.delete('adjustment_comment')
+        end
+      end
+    end
+
+    def delete_disbursement_adjustments
+      revert_fields = %w[total_cost vat_amount total_cost_without_vat]
+      disbursements.each do |disbursement|
+        revert_fields.each do |field|
+          revert(disbursement, field, 'disbursements')
+        end
+        disbursement.delete('adjustment_comment')
+      end
+    end
+
+    def letters_and_calls
+      @letters_and_calls ||= submission.data['letters_and_calls'].filter { _1['adjustment_comment'] }
+    end
+
+    def disbursements
+      @disbursements ||= submission.data['disbursements'].filter { _1['adjustment_comment'] }
+    end
+
+    def work_items
+      @work_items ||= submission.data['work_items'].filter { _1['adjustment_comment'] }
     end
 
     def submission_scope

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -187,10 +187,7 @@ FactoryBot.define do
             'total_cost_without_vat_original' => 100.0,
             'prior_authority' => 'yes',
             'disbursement_date' => '2022-12-23',
-            'disbursement_type' => {
-              'en' => 'Other',
-              'value' => 'other'
-            },
+            'disbursement_type' => 'other',
             'adjustment_comment' => 'adjusted up'
           },
           {
@@ -205,38 +202,29 @@ FactoryBot.define do
             'total_cost_without_vat' => 130.0,
             'prior_authority' => 'yes',
             'disbursement_date' => '2022-12-23',
-            'disbursement_type' => {
-              'en' => 'Other',
-              'value' => 'other'
-            }
+            'disbursement_type' => 'other'
           }
         ]
       end
       letters_and_calls do
         [
           {
-            'type' => {
-              'en' => 'Letters',
-              'value' => 'letters'
-            },
-              'count' => 12,
-              'count_original' => 5,
-              'uplift' => 95,
-              'uplift_original' => 50,
-              'pricing' => 3.56,
-              'adjustment_comment' => 'adj'
+            'type' => 'letters',
+            'count' => 12,
+            'count_original' => 5,
+            'uplift' => 95,
+            'uplift_original' => 50,
+            'pricing' => 3.56,
+            'adjustment_comment' => 'adj'
           },
           {
-            'type' => {
-              'en' => 'Calls',
-              'value' => 'calls'
-            },
-              'count' => 4,
-              'count_original' => 5,
-              'uplift' => 20,
-              'uplift_original' => 50,
-              'pricing' => 3.56,
-              'adjustment_comment' => 'adj'
+            'type' => 'calls',
+            'count' => 4,
+            'count_original' => 5,
+            'uplift' => 20,
+            'uplift_original' => 50,
+            'pricing' => 3.56,
+            'adjustment_comment' => 'adj'
           },
         ]
       end
@@ -248,14 +236,8 @@ FactoryBot.define do
             'uplift_original' => 50,
             'pricing' => 24.0,
             'pricing_original' => 44.0,
-            'work_type' => {
-              'en' => 'Waiting',
-              'value' => 'waiting'
-            },
-            'work_type_original' => {
-              'en' => 'Attendance without counsel',
-              'value' => 'attendance_without_counsel'
-            },
+            'work_type' => 'waiting',
+            'work_type_original' => 'attendance_without_counsel',
             'fee_earner' => 'aaa',
             'time_spent' => 161,
             'time_spent_original' => 181,
@@ -284,10 +266,7 @@ FactoryBot.define do
             'total_cost_without_vat' => 130.0,
             'prior_authority' => 'yes',
             'disbursement_date' => '2022-12-23',
-            'disbursement_type' => {
-              'en' => 'Other',
-              'value' => 'other'
-            },
+            'disbursement_type' => 'other',
             'adjustment_comment' => 'adjusted up'
           }
         ]
@@ -321,10 +300,7 @@ FactoryBot.define do
             'total_cost_without_vat' => 80.0,
             'prior_authority' => 'yes',
             'disbursement_date' => '2022-12-12',
-            'disbursement_type' => {
-              'en' => 'Other',
-              'value' => 'other'
-            }
+            'disbursement_type' => 'other'
           }
         ]
       end

--- a/spec/services/nsm/adjustment_deleter_spec.rb
+++ b/spec/services/nsm/adjustment_deleter_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Nsm::AdjustmentDeleter do
       it 'reverts changes' do
         expect(claim.reload.data.dig('work_items', 0, 'uplift')).to eq 50
         expect(claim.data.dig('work_items', 0, 'pricing')).to eq 44
-        expect(claim.data.dig('work_items', 0, 'work_type', 'value')).to eq 'attendance_without_counsel'
+        expect(claim.data.dig('work_items', 0, 'work_type')).to eq 'attendance_without_counsel'
         expect(claim.data.dig('work_items', 0, 'time_spent')).to eq 181
         expect(claim.data.dig('work_items', 0, 'uplift_original')).to be_nil
         expect(claim.data.dig('work_items', 0, 'pricing_original')).to be_nil

--- a/spec/services/nsm/all_adjustments_deleter_spec.rb
+++ b/spec/services/nsm/all_adjustments_deleter_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Nsm::AllAdjustmentsDeleter do
       it 'reverts changes' do
         expect(claim.reload.data.dig('work_items', 0, 'uplift')).to eq 50
         expect(claim.data.dig('work_items', 0, 'pricing')).to eq 44
-        expect(claim.data.dig('work_items', 0, 'work_type', 'value')).to eq 'attendance_without_counsel'
+        expect(claim.data.dig('work_items', 0, 'work_type')).to eq 'attendance_without_counsel'
         expect(claim.data.dig('work_items', 0, 'time_spent')).to eq 181
         expect(claim.data.dig('work_items', 0, 'uplift_original')).to be_nil
         expect(claim.data.dig('work_items', 0, 'pricing_original')).to be_nil

--- a/spec/services/nsm/all_adjustments_deleter_spec.rb
+++ b/spec/services/nsm/all_adjustments_deleter_spec.rb
@@ -4,26 +4,13 @@ RSpec.describe Nsm::AllAdjustmentsDeleter do
   describe '.call' do
     subject(:service) { described_class.new(params, nil, user) }
 
-    let(:params) { { claim_id: claim.id, nsm_delete_adjustments_form: { comment: 'some comment' } } }
+    let(:params) { { claim_id: claim.id, id: item_id, nsm_delete_adjustments_form: { comment: 'test' } } }
+    let(:item_id) { '1234-adj' }
     let(:user) { create(:caseworker) }
     let(:claim) { create(:claim, :with_adjustments) }
-    let(:client) { instance_double(AppStoreClient, get_submission: app_store_record) }
-    let(:app_store_record) do
-      {
-        'version' => 1,
-        'json_schema_version' => 1,
-        'application_state' => 'submitted',
-        'application_type' => 'crm7',
-        'application' => claim.data.merge('adjusted' => false),
-        'events' => [],
-        'application_id' => claim.id,
-      }
-    end
 
     before do
-      allow(AppStoreClient).to receive(:new).and_return(client)
       create(:assignment, submission: claim, user: user)
-      claim.data.merge('adjusted' => true)
     end
 
     describe '#call' do
@@ -37,21 +24,131 @@ RSpec.describe Nsm::AllAdjustmentsDeleter do
       before { service.call }
 
       it 'reverts changes' do
-        expect(claim.reload.data['adjusted']).to be false
+        expect(claim.reload.data.dig('disbursements', 0, 'total_cost')).to eq 130
+        expect(claim.data.dig('disbursements', 0, 'vat_amount')).to eq 1.0
+        expect(claim.data.dig('disbursements', 0, 'total_cost_without_vat')).to eq 100
+        expect(claim.data.dig('disbursements', 0, 'total_cost_original')).to be_nil
+        expect(claim.data.dig('disbursements', 0, 'vat_amount_original')).to be_nil
+        expect(claim.data.dig('disbursements', 0, 'total_cost_without_vat_original')).to be_nil
+        expect(claim.data.dig('disbursements', 0, 'adjustment_comment')).to be_nil
       end
 
-      it 'creates and event' do
-        expect(claim.events.last.details['comment']).to eq('some comment')
+      it 'creates relevant events' do
+        event = claim.events.find { _1.details['field'] == 'total_cost_without_vat' }
+        expect(event).to be_a Event::UndoEdit
+        expect(event).to have_attributes(
+          linked_id: item_id,
+          linked_type: 'disbursements',
+          details: {
+            'field' => 'total_cost_without_vat',
+            'from' => 130.0,
+            'to' => 100.0,
+          }
+        )
+      end
+    end
+
+    context 'when deleting work_item adjustments' do
+      before { service.call }
+
+      # rubocop:disable RSpec/MultipleExpectations
+      it 'reverts changes' do
+        expect(claim.reload.data.dig('work_items', 0, 'uplift')).to eq 50
+        expect(claim.data.dig('work_items', 0, 'pricing')).to eq 44
+        expect(claim.data.dig('work_items', 0, 'work_type', 'value')).to eq 'attendance_without_counsel'
+        expect(claim.data.dig('work_items', 0, 'time_spent')).to eq 181
+        expect(claim.data.dig('work_items', 0, 'uplift_original')).to be_nil
+        expect(claim.data.dig('work_items', 0, 'pricing_original')).to be_nil
+        expect(claim.data.dig('work_items', 0, 'work_type_original')).to be_nil
+        expect(claim.data.dig('work_items', 0, 'time_spent_original')).to be_nil
+        expect(claim.data.dig('work_items', 0, 'adjustment_comment')).to be_nil
+      end
+      # rubocop:enable RSpec/MultipleExpectations
+
+      it 'creates relevant events' do
+        event = claim.events.find { _1.details['field'] == 'time_spent' }
+        expect(event).to be_a Event::UndoEdit
+        expect(event).to have_attributes(
+          linked_id: item_id,
+          linked_type: 'work_items',
+          details: {
+            'field' => 'time_spent',
+            'from' => 161,
+            'to' => 181,
+          }
+        )
+      end
+    end
+
+    context 'when deleting calls adjustments' do
+      before { service.call }
+
+      it 'reverts call changes' do
+        expect(claim.reload.data.dig('letters_and_calls', 1, 'uplift')).to eq 50
+        expect(claim.data.dig('letters_and_calls', 1, 'count')).to eq 5
+        expect(claim.data.dig('letters_and_calls', 1, 'uplift_original')).to be_nil
+        expect(claim.data.dig('letters_and_calls', 1, 'count_original')).to be_nil
+        expect(claim.data.dig('letters_and_calls', 1, 'adjustment_comment')).to be_nil
+      end
+
+      it 'creates relevant events' do
+        event = claim.events.find { _1['linked_type'] == 'calls' && _1.details['field'] == 'count' }
+        expect(event).to be_a Event::UndoEdit
+        expect(event).to have_attributes(
+          linked_id: nil,
+          linked_type: 'calls',
+          details: {
+            'field' => 'count',
+            'from' => 4,
+            'to' => 5,
+          }
+        )
+      end
+    end
+
+    context 'when deleting letters adjustments' do
+      before { service.call }
+
+      it 'reverts letter changes' do
+        expect(claim.reload.data.dig('letters_and_calls', 0, 'uplift')).to eq 50
+        expect(claim.data.dig('letters_and_calls', 0, 'count')).to eq 5
+        expect(claim.data.dig('letters_and_calls', 0, 'uplift_original')).to be_nil
+        expect(claim.data.dig('letters_and_calls', 0, 'count_original')).to be_nil
+        expect(claim.data.dig('letters_and_calls', 0, 'adjustment_comment')).to be_nil
+      end
+
+      it 'creates relevant events' do
+        event = claim.events.find { _1['linked_type'] == 'letters' && _1.details['field'] == 'count' }
+        expect(event).to be_a Event::UndoEdit
+        expect(event).to have_attributes(
+          linked_id: nil,
+          linked_type: 'letters',
+          details: {
+            'field' => 'count',
+            'from' => 12,
+            'to' => 5,
+          }
+        )
       end
     end
 
     context 'no adjustments' do
-      before do
-        allow(subject.submission).to receive(:any_adjustments?).and_return(false)
+      it 'wont try to disbursement adjustments if none' do
+        allow(subject).to receive(:work_items).and_return nil
+        expect(subject).not_to receive(:delete_work_item_adjustments)
+        subject.call
       end
 
-      it 'raises an error if no adjustments' do
-        expect { service.call }.to raise_error(StandardError, "no adjustments to delete for id:#{claim.id}")
+      it 'wont try to work_item adjustments if none' do
+        allow(subject).to receive(:letters_and_calls).and_return nil
+        expect(subject).not_to receive(:delete_letters_and_calls_adjustments)
+        subject.call
+      end
+
+      it 'wont try to letter and call adjustments if none' do
+        allow(subject).to receive(:disbursements).and_return nil
+        expect(subject).not_to receive(:delete_disbursement_adjustments)
+        subject.call
       end
     end
   end

--- a/spec/system/nsm/adjustments_spec.rb
+++ b/spec/system/nsm/adjustments_spec.rb
@@ -3,19 +3,6 @@ require 'rails_helper'
 RSpec.describe 'Adjustments' do
   let(:user) { create(:caseworker) }
   let(:claim) { create(:claim, :with_adjustments) }
-  let(:no_adjustments) { create(:claim) }
-  let(:client) { instance_double(AppStoreClient, get_submission: app_store_record) }
-  let(:app_store_record) do
-    {
-      'version' => 1,
-      'json_schema_version' => 1,
-      'application_state' => 'submitted',
-      'application_type' => 'crm7',
-      'application' => no_adjustments.data,
-      'events' => [],
-      'application_id' => claim.id,
-    }
-  end
 
   before do
     sign_in user
@@ -145,10 +132,6 @@ RSpec.describe 'Adjustments' do
     end
 
     describe 'delete all adjustments' do
-      before do
-        allow(AppStoreClient).to receive(:new).and_return(client)
-      end
-
       it 'asks to confirm delete all adjustments' do
         visit adjusted_nsm_claim_work_items_path(claim)
         click_on 'Delete all adjustments'


### PR DESCRIPTION
This reverts commit 892d599b033366fe755961c33916c9c4b211838d.

Now when we click 'delete all adjustments' we manually remove every adjustment from the payload instead of pulling a 'fresh copy' from the app store. This is because the app store version may contain adjustments if we have completed an RFI loop and adjustments were made before the claim was sent back.

Robin had written code to do it this way initially, and I (wrongly!) said it was much simpler to take the 'fresh copy' approach.