### PR TITLE
CRM457-2149: Don't override adjustment comments when removing all uplifts

### DIFF
--- a/app/forms/base_adjustment_form.rb
+++ b/app/forms/base_adjustment_form.rb
@@ -11,8 +11,10 @@ class BaseAdjustmentForm
 
   private
 
-  def process_field(value:, field:, comment_field: 'adjustment_comment')
-    selected_record[comment_field] = explanation
+  COMMENT_FIELD = 'adjustment_comment'.freeze
+
+  def process_field(value:, field:)
+    selected_record[self.class::COMMENT_FIELD] = explanation
 
     return if selected_record[field] == value
 
@@ -72,9 +74,9 @@ class BaseAdjustmentForm
   end
 
   def explanation_has_changed?
-    return false if selected_record['adjustment_comment'].blank?
+    return false if selected_record[self.class::COMMENT_FIELD].blank?
 
-    explanation != selected_record['adjustment_comment']
+    explanation != selected_record[self.class::COMMENT_FIELD]
   end
 
   # :nocov:

--- a/app/forms/base_adjustment_form.rb
+++ b/app/forms/base_adjustment_form.rb
@@ -12,6 +12,8 @@ class BaseAdjustmentForm
   private
 
   def process_field(value:, field:, comment_field: 'adjustment_comment')
+    selected_record[comment_field] = explanation
+
     return if selected_record[field] == value
 
     # does this belong in the Event object as that is where it is
@@ -25,7 +27,7 @@ class BaseAdjustmentForm
     }.merge(changed_value(value, selected_record[field]))
 
     ensure_original_field_value_set(field)
-    assign_new_attributes(field, value, comment_field)
+    assign_new_attributes(field, value)
 
     Event::Edit.build(submission:, details:, linked:, current_user:)
   end
@@ -34,9 +36,8 @@ class BaseAdjustmentForm
     selected_record["#{field}_original"] ||= selected_record[field]
   end
 
-  def assign_new_attributes(field, value, comment_field)
+  def assign_new_attributes(field, value)
     selected_record[field] = value
-    selected_record[comment_field] = explanation
   end
 
   def changed_value(val1, val2)
@@ -57,7 +58,7 @@ class BaseAdjustmentForm
   end
 
   def data_changed
-    return if data_has_changed?
+    return if data_has_changed? || explanation_has_changed?
 
     errors.add(no_change_field, :no_change)
   end
@@ -68,6 +69,12 @@ class BaseAdjustmentForm
 
   def explanation_required?
     data_has_changed?
+  end
+
+  def explanation_has_changed?
+    return false if selected_record['adjustment_comment'].blank?
+
+    explanation != selected_record['adjustment_comment']
   end
 
   # :nocov:

--- a/app/forms/nsm/uplift/base_form.rb
+++ b/app/forms/nsm/uplift/base_form.rb
@@ -21,7 +21,10 @@ module Nsm
 
         Claim.transaction do
           claim.data[self.class::SCOPE].each do |selected_record|
-            row = self.class::Remover.new(claim:, explanation:, current_user:, selected_record:)
+            row = self.class::Remover.new(claim: claim,
+                                          explanation: explanation_for(selected_record),
+                                          current_user: current_user,
+                                          selected_record: selected_record)
             next unless row.valid?
 
             row.save
@@ -33,6 +36,10 @@ module Nsm
         true
       rescue StandardError
         false
+      end
+
+      def explanation_for(record)
+        [record['adjustment_comment'].presence, explanation].compact.join("\n\n")
       end
     end
   end

--- a/app/forms/prior_authority/travel_cost_form.rb
+++ b/app/forms/prior_authority/travel_cost_form.rb
@@ -24,11 +24,11 @@ module PriorAuthority
 
     private
 
-    def process_fields
-      comment_field = 'travel_adjustment_comment'
+    COMMENT_FIELD = 'travel_adjustment_comment'.freeze
 
-      process_field(value: travel_time.to_i, field: 'travel_time', comment_field: comment_field)
-      process_field(value: travel_cost_per_hour.to_s, field: 'travel_cost_per_hour', comment_field: comment_field)
+    def process_fields
+      process_field(value: travel_time.to_i, field: 'travel_time')
+      process_field(value: travel_cost_per_hour.to_s, field: 'travel_cost_per_hour')
     end
 
     def selected_record

--- a/spec/forms/nsm/uplift/base_form_spec.rb
+++ b/spec/forms/nsm/uplift/base_form_spec.rb
@@ -51,6 +51,23 @@ RSpec.describe Nsm::Uplift::BaseForm do
       end
     end
 
+    context 'when the record has already been adjusted' do
+      before do
+        claim.data['letters_and_calls'][0]['adjustment_comment'] = 'Previous comment'
+      end
+
+      it 'preserves the previous comment' do
+        subject.save
+        expect(implementation_class::Remover).to have_received(:new)
+          .with(
+            claim: claim,
+            explanation: "Previous comment\n\n#{explanation}",
+            current_user: current_user,
+            selected_record: claim.data['letters_and_calls'][0]
+          )
+      end
+    end
+
     context 'when invalid' do
       let(:explanation) { nil }
 

--- a/spec/forms/nsm/work_item_form_spec.rb
+++ b/spec/forms/nsm/work_item_form_spec.rb
@@ -78,12 +78,23 @@ RSpec.describe Nsm::WorkItemForm do
         end
       end
 
-      context 'and explanation does not have an error' do
+      context 'and explanation would otherwise have an error' do
         let(:explanation) { '' }
 
-        it 'is not valid' do
+        it 'ignores the explanation error' do
           expect(subject).not_to be_valid
           expect(subject.errors.of_kind?(:explanation, :blank)).to be(false)
+        end
+      end
+
+      context 'but the explanation has' do
+        before do
+          work_item = claim.data['work_items'].detect { _1['id'] == id }
+          work_item['adjustment_comment'] = 'Previous explanation'
+        end
+
+        it 'is valid' do
+          expect(subject).to be_valid
         end
       end
     end
@@ -200,6 +211,34 @@ RSpec.describe Nsm::WorkItemForm do
         it 'saves without error' do
           expect { subject.save }.to change(Event, :count).by(1)
         end
+      end
+    end
+
+    context 'when only explanation has changed' do
+      let(:uplift) { 'no' }
+      let(:time_spent) { 161 }
+
+      before do
+        work_item = claim.data['work_items'].detect { _1['id'] == id }
+        work_item['adjustment_comment'] = 'Previous explanation'
+        claim.save!
+      end
+
+      it 'updates the JSON data' do
+        subject.save
+        work_item = claim.reload
+                         .data['work_items']
+                         .detect { |row| row['work_type'] == 'waiting' }
+        expect(work_item).to eq(
+          'id' => 'cf5e303e-98dd-4b0f-97ea-3560c4c5f137',
+          'time_spent' => 161,
+          'pricing' => 24.0,
+          'work_type' => 'waiting',
+          'uplift' => 95,
+          'fee_earner' => 'aaa',
+          'completed_on' => '2022-12-12',
+          'adjustment_comment' => 'change to work items',
+        )
       end
     end
 


### PR DESCRIPTION
## Description of change
Keep previous comments on individual records when removing all uplifts.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2149)
