### PR TITLE
CRM457-2095: Add flags indicating async job status

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -104,7 +104,7 @@ class Event < ApplicationRecord
 
   def as_json(*)
     super
-      .except('submission_id')
+      .except('submission_id', 'notify_app_store_completed')
       .merge(
         public: PUBLIC_EVENTS.include?(event_type),
         event_type: event_type.demodulize.underscore

--- a/app/services/notify_app_store.rb
+++ b/app/services/notify_app_store.rb
@@ -1,17 +1,27 @@
 class NotifyAppStore < ApplicationJob
   queue_as :default
 
+  def self.perform_later(submission:, trigger_email: true)
+    submission.update!(notify_app_store_completed: false)
+    super
+  end
+
   def perform(submission:, trigger_email: true)
     notify(MessageBuilder.new(submission:))
 
-    return unless trigger_email
-
-    klass = "#{submission.namespace}::SubmissionFeedbackMailer".constantize
-    klass.notify(submission).deliver_later! if ENV.fetch('SEND_EMAILS', 'false') == 'true'
+    send_email(submission:, trigger_email:)
+    submission.update!(notify_app_store_completed: true)
   end
 
   def notify(message_builder)
     client = AppStoreClient.new
     client.update_submission(message_builder.message)
+  end
+
+  def send_email(submission:, trigger_email:)
+    return unless trigger_email && ENV.fetch('SEND_EMAILS', 'false') == 'true'
+
+    klass = "#{submission.namespace}::SubmissionFeedbackMailer".constantize
+    klass.notify(submission).deliver_later!
   end
 end

--- a/app/services/notify_event_app_store.rb
+++ b/app/services/notify_event_app_store.rb
@@ -1,9 +1,16 @@
 class NotifyEventAppStore < ApplicationJob
   queue_as :default
 
+  def self.perform_later(event:)
+    event.update!(notify_app_store_completed: false)
+    super
+  end
+
   def perform(event:)
     result = client.create_events(event.submission_id, events: [event.as_json])
     handle_forbidden_response(event) if result == :forbidden
+
+    event.update!(notify_app_store_completed: true)
   end
 
   private

--- a/db/migrate/20241015091931_add_notify_app_store_complete_to_submission.rb
+++ b/db/migrate/20241015091931_add_notify_app_store_complete_to_submission.rb
@@ -1,0 +1,6 @@
+class AddNotifyAppStoreCompleteToSubmission < ActiveRecord::Migration[7.1]
+  def change
+    add_column :submissions, :notify_app_store_completed, :boolean
+    add_column :events, :notify_app_store_completed, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_30_083741) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_15_091931) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"
@@ -63,6 +63,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_30_083741) do
     t.jsonb "details", default: {}
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "notify_app_store_completed"
     t.index ["linked_type", "linked_id"], name: "index_events_on_linked_type_and_linked_id"
     t.index ["primary_user_id"], name: "index_events_on_primary_user_id"
     t.index ["secondary_user_id"], name: "index_events_on_secondary_user_id"
@@ -91,6 +92,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_30_083741) do
     t.jsonb "data"
     t.datetime "app_store_updated_at"
     t.string "application_type"
+    t.boolean "notify_app_store_completed"
     t.index "(((data -> 'defendant'::text) ->> 'first_name'::text)), (((data -> 'defendant'::text) ->> 'last_name'::text))", name: "index_submissions_on_client_name"
     t.index "(((data -> 'firm_office'::text) ->> 'account_number'::text))", name: "index_submissions_on_firm_account_number"
     t.index "(((data -> 'firm_office'::text) ->> 'name'::text))", name: "index_submissions_on_firm_name"

--- a/spec/services/notify_event_app_store_spec.rb
+++ b/spec/services/notify_event_app_store_spec.rb
@@ -3,9 +3,18 @@ require 'rails_helper'
 RSpec.describe NotifyEventAppStore do
   subject { described_class.new }
 
-  let(:event) { instance_double(Event, submission_id:, as_json:) }
+  let(:event) { instance_double(Event, submission_id: submission_id, as_json: as_json, update!: true) }
   let(:submission_id) { SecureRandom.uuid }
   let(:as_json) { { event: :json } }
+
+  describe '.perform_later' do
+    let(:event) { create :event, notify_app_store_completed: nil }
+
+    it 'sets a flag' do
+      described_class.perform_later(event:)
+      expect(event.reload.notify_app_store_completed).to be false
+    end
+  end
 
   describe '#perform' do
     let(:http_notifier) { instance_double(AppStoreClient, create_events: true) }
@@ -34,6 +43,11 @@ RSpec.describe NotifyEventAppStore do
       it 'allows the error to be raised - should reset the sidekiq job' do
         expect { subject.perform(event:) }.to raise_error('annoying_error')
       end
+    end
+
+    it 'updates the record' do
+      expect(event).to receive(:update!).with(notify_app_store_completed: true)
+      subject.perform(event:)
     end
   end
 


### PR DESCRIPTION
## Description of change

Set a flag before running an async job, change the flag after running it, that way if we lose access to Redis (both the job queue and the logs of dead jobs), we know what needs to be re-synced.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2095)