### PR TITLE
CRM457-2094: Make critical job enqueueings atomic

### DIFF
--- a/app/forms/nsm/make_decision_form.rb
+++ b/app/forms/nsm/make_decision_form.rb
@@ -22,13 +22,13 @@ module Nsm
       return false unless valid?
 
       claim.with_lock do
-        change_data_and_notify_app_store
+        change_data_and_notify_app_store!
       end
 
       true
     end
 
-    def change_data_and_notify_app_store
+    def change_data_and_notify_app_store!
       previous_state = claim.state
 
       claim.data.merge!('status' => state, 'updated_at' => Time.current, 'assessment_comment' => comment)

--- a/app/forms/nsm/send_back_form.rb
+++ b/app/forms/nsm/send_back_form.rb
@@ -21,11 +21,11 @@ module Nsm
     def save
       return false unless valid?
 
-      Claim.transaction do
+      claim.with_lock do
         update_local_data
-      end
 
-      NotifyAppStore.perform_later(submission: claim)
+        NotifyAppStore.perform_later(submission: claim)
+      end
 
       true
     end

--- a/app/forms/prior_authority/decision_form.rb
+++ b/app/forms/prior_authority/decision_form.rb
@@ -30,13 +30,13 @@ module PriorAuthority
       return false unless valid?
 
       submission.with_lock do
-        change_data_and_notify_app_store
+        change_data_and_notify_app_store!
       end
 
       true
     end
 
-    def change_data_and_notify_app_store
+    def change_data_and_notify_app_store!
       stash(add_draft_decision_event: false)
       previous_state = submission.state
 

--- a/app/forms/prior_authority/decision_form.rb
+++ b/app/forms/prior_authority/decision_form.rb
@@ -29,21 +29,25 @@ module PriorAuthority
     def save
       return false unless valid?
 
-      PriorAuthorityApplication.transaction do
-        stash(add_draft_decision_event: false)
-        previous_state = submission.state
-
-        submission.data.merge!('status' => pending_decision, 'updated_at' => Time.current)
-        submission.update!(state: pending_decision)
-        ::Event::Decision.build(submission: submission,
-                                comment: explanation,
-                                previous_state: previous_state,
-                                current_user: current_user)
+      submission.with_lock do
+        change_data_and_notify_app_store
       end
 
-      NotifyAppStore.perform_later(submission:)
-
       true
+    end
+
+    def change_data_and_notify_app_store
+      stash(add_draft_decision_event: false)
+      previous_state = submission.state
+
+      submission.data.merge!('status' => pending_decision, 'updated_at' => Time.current)
+      submission.update!(state: pending_decision)
+      ::Event::Decision.build(submission: submission,
+                              comment: explanation,
+                              previous_state: previous_state,
+                              current_user: current_user)
+
+      NotifyAppStore.perform_later(submission:)
     end
 
     def stash(add_draft_decision_event: true)

--- a/app/forms/prior_authority/send_back_form.rb
+++ b/app/forms/prior_authority/send_back_form.rb
@@ -29,13 +29,13 @@ module PriorAuthority
     def save
       return false unless valid?
 
-      PriorAuthorityApplication.transaction do
+      submission.with_lock do
         discard_all_adjustments
         stash(add_draft_send_back_event: false)
         update_local_records
-      end
 
-      NotifyAppStore.perform_later(submission:)
+        NotifyAppStore.perform_later(submission:)
+      end
 
       true
     end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -24,6 +24,7 @@ class Event < ApplicationRecord
 
   LOCAL_EVENTS = [
     'Event::DraftDecision',
+    'Event::NewVersion',
     'Event::Edit',
     'Event::Note',
     'Event::UndoEdit',

--- a/app/models/event/new_version.rb
+++ b/app/models/event/new_version.rb
@@ -2,7 +2,6 @@ class Event
   class NewVersion < Event
     def self.build(submission:)
       create(submission: submission, submission_version: submission.current_version)
-        .tap(&:notify)
     end
 
     def body

--- a/spec/models/event/new_version_spec.rb
+++ b/spec/models/event/new_version_spec.rb
@@ -13,14 +13,6 @@ RSpec.describe Event::NewVersion do
     )
   end
 
-  it 'notifies the app store' do
-    event = Event.send(:new)
-    expect(described_class).to receive(:create).and_return(event)
-    expect(NotifyEventAppStore).to receive(:perform_later).with(event:)
-
-    subject
-  end
-
   it 'has a valid title' do
     expect(subject.title).to eq('Received')
   end

--- a/spec/services/notify_app_store_spec.rb
+++ b/spec/services/notify_app_store_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe NotifyAppStore do
   before do
     allow(described_class::MessageBuilder).to receive(:new)
       .and_return(message_builder)
+
+    allow(submission).to receive(:with_lock).and_yield
   end
 
   describe '.perform_later' do


### PR DESCRIPTION
## Description of change
This means if Redis fails we won't end up in an inconsistent state.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2094)
