### PR TITLE
CRM457-2076: Go back to telling app store about new versions immediately

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -24,7 +24,6 @@ class Event < ApplicationRecord
 
   LOCAL_EVENTS = [
     'Event::DraftDecision',
-    'Event::NewVersion',
     'Event::Edit',
     'Event::Note',
     'Event::UndoEdit',

--- a/app/models/event/new_version.rb
+++ b/app/models/event/new_version.rb
@@ -1,7 +1,7 @@
 class Event
   class NewVersion < Event
     def self.build(submission:)
-      create(submission: submission, submission_version: submission.current_version)
+      create(submission: submission, submission_version: submission.current_version).tap(&:notify)
     end
 
     def body

--- a/db/migrate/20241018110747_back_fill_new_version_notifications.rb
+++ b/db/migrate/20241018110747_back_fill_new_version_notifications.rb
@@ -1,0 +1,12 @@
+class BackFillNewVersionNotifications < ActiveRecord::Migration[7.1]
+  def change
+    # Unassessed submissions haven't been pushing their new version events to the app
+    # store recently. Once they are assessed or sent back those events get synced,
+    # so it's only the ones that are still awaiting assessment that could be out
+    # of sync
+    Submission.where(state: %w[submitted provider_updated]).find_each do |submission|
+      last_new_version_event = submission.events.where(event_type: 'Event::NewVersion').order(:created_at).last
+      last_new_version_event&.notify
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_15_110647) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_18_110747) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"


### PR DESCRIPTION
## Description of change
Go back to telling app store about new versions, and sync any unsynced new versions via a migration
[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2076)
