### PR TITLE
Replace Snyk orb with Snyk executable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,6 @@ version: 2.1
 # ------------------
 orbs:
   browser-tools: circleci/browser-tools@1.4.7
-  snyk: snyk/snyk@2.1.0
   aws-cli: circleci/aws-cli@4.1.3
   aws-ecr: circleci/aws-ecr@9.0.2
   crime-forms-end-to-end-tests: ministryofjustice/crime-forms-end-to-end-tests@volatile
@@ -95,6 +94,14 @@ references:
         sudo apt update
         sudo apt install -y python3-pip
         pip install yamllint
+
+  _install-snyk: &install-snyk
+    run:
+      name: Install snyk CLI
+      command: |
+        curl --compressed https://downloads.snyk.io/cli/stable/snyk-linux -o snyk
+        chmod +x ./snyk
+        sudo mv ./snyk /usr/local/bin/
 
 # ------------------
 # COMMANDS
@@ -295,8 +302,7 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
       - build-docker-image-for-scan
-      - snyk/install:
-          token-variable: SNYK_TOKEN
+      - *install-snyk
       - run:
           name: Run static code analysis
           command: snyk code test --severity-threshold=high


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-1911)

## Notes for reviewer
Note that authentication for Snyk comes from the SNYK_TOKEN environment variable that is stored in Circle CI