### PR TITLE
CRM457-2183: Allow downloading of RFI files

### DIFF
--- a/app/controllers/nsm/further_information_downloads_controller.rb
+++ b/app/controllers/nsm/further_information_downloads_controller.rb
@@ -1,0 +1,9 @@
+module Nsm
+  class FurtherInformationDownloadsController < Nsm::BaseController
+    include FileRedirectable
+
+    def show
+      redirect_to_file_download(params[:id], params[:file_name])
+    end
+  end
+end

--- a/app/view_models/nsm/v1/further_information.rb
+++ b/app/view_models/nsm/v1/further_information.rb
@@ -47,7 +47,10 @@ module Nsm
       def document_link(document)
         link_to(
           document.file_name,
-          url_helpers.nsm_claim_supporting_evidences_download_path(submission.id, document.file_path)
+          url_helpers.nsm_further_information_download_path(
+            document.file_path,
+            file_name: document.file_name,
+          )
         )
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,7 @@ Rails.application.routes.draw do
       resources :assignments, only: %i[new create]
     end
 
+    resources :further_information_downloads, only: :show
     resource :search, only: %i[new show]
     get 'claims/:claim', to: redirect('claims/%{claim}/claim_details')
   end

--- a/spec/system/nsm/overview_spec.rb
+++ b/spec/system/nsm/overview_spec.rb
@@ -144,5 +144,12 @@ RSpec.describe 'Overview', type: :system do
         .and have_link('Some_Info.pdf')
         .and have_link('Some_Info2.pdf')
     end
+
+    it 'lets me download files' do
+      click_on('Some_Info.pdf')
+      expect(page).to have_current_path(
+        %r{/421727bc53d347ea81edd6a00833671d\?response-content-disposition=attachment%3B%20filename%3D%22Some_Info.pdf}
+      )
+    end
   end
 end

--- a/spec/view_models/nsm/v1/further_information_spec.rb
+++ b/spec/view_models/nsm/v1/further_information_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe Nsm::V1::FurtherInformation do
     it 'shows correct table data' do
       allow(subject).to receive(:submission).and_return(submission)
       response_with_doc = '<p>Please find...</p><br>' \
-                          '<a href="/nsm/claims/1/supporting_evidences/' \
-                          'downloads/421727bc53d347ea81edd6a00833671d">Some_Info.pdf</a>'
+                          '<a href="/nsm/further_information_downloads/421727bc53d347ea81edd6a00833671d' \
+                          '?file_name=Some_Info.pdf">Some_Info.pdf</a>'
       expect(subject.data).to eq([{ title: 'Caseworker', value: 'Fred Falke' },
                                   { title: 'Information request', value: 'Please send...' },
                                   { title: 'Provider response', value: response_with_doc }])


### PR DESCRIPTION
## Description of change
We were linking to the supporting evidence download path, but that only worked for documents listed as supporting evidence in the blob.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2183)
