### PR TITLE
CRM457-2155: Exclude high value claims from auto-assignment

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -1,4 +1,8 @@
 class Claim < Submission
+  # This is the value at or above which the vat-inclusive profit costs of a claim
+  # make it "high value" meaning different allocation rules apply
+  HIGH_VALUE_THRESHOLD = 5000
+
   validates :risk, inclusion: { in: %w[low medium high] }
 
   default_scope -> { where(application_type: APPLICATION_TYPES[:nsm]) }
@@ -18,7 +22,9 @@ class Claim < Submission
 
   scope :auto_assignable, lambda { |user|
     where(state: [SUBMITTED, PROVIDER_UPDATED])
-      .where.not(risk: :high)
+      .where("(data->'cost_summary' IS NULL AND risk != 'high') OR " \
+             "(data->'cost_summary'->'profit_costs'->'gross_cost')::decimal < ?",
+             HIGH_VALUE_THRESHOLD)
       .where.missing(:assignments)
       .where.not(id: Event::Unassignment.where(primary_user_id: user.id).select(:submission_id))
   }

--- a/spec/factories/claims.rb
+++ b/spec/factories/claims.rb
@@ -45,7 +45,12 @@ FactoryBot.define do
           'waiting' => 45.5,
           'preparation' => 23.2,
           'attendance_without_counsel' => 10.17,
-        }
+        },
+        'cost_summary' => {
+          'profit_costs' => {
+            'gross_cost' => 120.0,
+          },
+        },
       }
     end
 


### PR DESCRIPTION
## Description of change
Note that there are still 3 open claims that don't have a cost summary in the blob as they precede that. They are all high risk claims that have always in the past been allocated manually, so they should continue to be done that way. I've added in some explicit fallback logic to describe that behaviour. 

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2155)
