### PR TITLE
[CRM457-2220] un-stick expired provider application

### DIFF
--- a/lib/tasks/fixes/CRM457_2220.rake
+++ b/lib/tasks/fixes/CRM457_2220.rake
@@ -1,0 +1,28 @@
+namespace :CRM457_2220 do
+  desc "un-expire app and notify app-store is sent_back"
+  task fix: :environment do
+    # We have all the data we need saved locally for this record - we
+    # need to refresh the resubmission deadline, reset expiry status to sent_back
+    # and delete the associated Expiry Event for consistency (this event was created in error)
+
+    sub_id = '507c6b43-a3c5-4520-b610-b639b88c945c'
+    exp_id = '4e1d61b1-52c2-4a72-bc61-e2ed0d4c5f10'
+
+    resubmission_deadline = WorkingDayService.call(Rails.application.config.x.rfi.working_day_window)
+    puts "resubmission_deadline: #{resubmission_deadline}"
+    submission = PriorAuthorityApplication.find(sub_id)
+    puts "submission_id: #{submission.id}"
+    submission.data.merge!('updated_at' => Time.current,
+                           'status' => PriorAuthorityApplication::SENT_BACK,
+                           'resubmission_deadline' => resubmission_deadline)
+    submission.sent_back!
+    puts "submission_state: #{submission.state}"
+
+    Event.find(exp_id).destroy
+    puts "Expiry Event: #{exp_id} destroyed"
+
+    puts "Attempt NotifyAppStore START"
+    NotifyAppStore.perform_later(submission:)
+    puts "Attempt NotifyAppStore END"
+  end
+end


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2220)

This fix `un-sticks` application id `507c6b43-a3c5-4520-b610-b639b88c945c` for both CW and Provider by

- resetting CW status from expired to `sent_back`
- destroying the erroneous expired event from the application
- updating/resetting clock on resubmission_deadline (2 weeks from now)
- syncing changes with app-store/provider

we can run this fix by running `rake CRM457-2220:fix` 

## Notes for reviewer

Submission events for CW
```
[["Event::NewVersion", Fri, 11 Oct 2024 13:17:29.954099000 UTC +00:00],
 ["PriorAuthority::Event::SendBack", Mon, 14 Oct 2024 14:26:46.738524000 UTC +00:00],
 ["Event::Assignment", Mon, 14 Oct 2024 14:22:14.498403000 UTC +00:00],
 ["Event::ProviderUpdated", Mon, 14 Oct 2024 15:24:53.086000000 UTC +00:00],
 ["Event::Assignment", Tue, 15 Oct 2024 15:47:19.993605000 UTC +00:00],
 ["PriorAuthority::Event::SendBack", Tue, 15 Oct 2024 15:48:20.388451000 UTC +00:00],
 ["Event::Expiry", Tue, 29 Oct 2024 21:16:02.013489000 UTC +00:00]]
 ```
 
this `["PriorAuthority::Event::SendBack", Tue, 15 Oct 2024 15:48:20.388451000 UTC +00:00]` never reached the app-store. No error was logged. It [looks like](https://app-logs.cloud-platform.service.justice.gov.uk/_dashboards/app/data-explorer/discover#?_a=(discover:(columns:!(log),isDirty:!f,sort:!()),metadata:(indexPattern:bb90f230-0d2e-11ef-bf63-53113938c53a,view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2024-10-15T15:00:00.000Z',to:'2024-10-15T16:00:00.000Z'))&_q=(filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:bb90f230-0d2e-11ef-bf63-53113938c53a,key:kubernetes.namespace_name,negate:!f,params:(query:laa-assess-crime-forms-prod),type:phrase),query:(match_phrase:(kubernetes.namespace_name:laa-assess-crime-forms-prod)))),query:(language:kuery,query:%22507c6b43-a3c5-4520-b610-b639b88c945c%22))) this job was enqueued but not [performed](https://app-logs.cloud-platform.service.justice.gov.uk/_dashboards/app/data-explorer/discover#?_a=(discover:(columns:!(log),isDirty:!f,sort:!()),metadata:(indexPattern:bb90f230-0d2e-11ef-bf63-53113938c53a,view:discover))&_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2024-10-15T15:30:00.000Z',to:'2024-10-15T16:00:00.000Z'))&_q=(filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:bb90f230-0d2e-11ef-bf63-53113938c53a,key:kubernetes.namespace_name,negate:!f,params:(query:laa-crime-application-store-production),type:phrase),query:(match_phrase:(kubernetes.namespace_name:laa-crime-application-store-production)))),query:(language:kuery,query:%22507c6b43-a3c5-4520-b610-b639b88c945c%22)))
 
 Submission events in app-store
 ```
 [["new_version", "2024-10-11T13:17:29.954Z"],
 ["assignment", "2024-10-14T14:22:14.498Z"],
 ["send_back", "2024-10-14T14:26:46.738Z"],
 ["provider_updated", "2024-10-14T15:24:53.086Z"],
 ["assignment", "2024-10-15T15:47:19.993Z"]]
 ```





## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
