### PR TITLE
CRM457-2216 part 4: Sync events and adjustments to app store immediately

### DIFF
--- a/app/controllers/nsm/adjustments_controller.rb
+++ b/app/controllers/nsm/adjustments_controller.rb
@@ -13,7 +13,7 @@ module Nsm
       authorize deleter.submission, :update?
 
       if form.valid?
-        deleter.call
+        deleter.call!
         redirect_to nsm_claim_claim_details_path, flash: { success: t('.success') }
       else
         render :confirm_deletion_adjustments, locals: { deletion_path:, form: }

--- a/app/controllers/nsm/disbursements_controller.rb
+++ b/app/controllers/nsm/disbursements_controller.rb
@@ -66,7 +66,7 @@ module Nsm
         model.id == params[:id]
       end
       form = DisbursementsForm.new(claim:, item:, **form_params)
-      if form.save
+      if form.save!
         redirect_to nsm_claim_disbursements_path(claim)
       else
         render :edit, locals: { claim:, item:, form: }

--- a/app/controllers/nsm/letters_and_calls/uplifts_controller.rb
+++ b/app/controllers/nsm/letters_and_calls/uplifts_controller.rb
@@ -14,7 +14,7 @@ module Nsm
         authorize(claim)
         form = Uplift::LettersAndCallsForm.new(claim:, **form_params)
 
-        if form.save
+        if form.save!
           redirect_to nsm_claim_letters_and_calls_path(claim),
                       flash: { success: t('.uplift_removed') }
         else

--- a/app/controllers/nsm/letters_and_calls_controller.rb
+++ b/app/controllers/nsm/letters_and_calls_controller.rb
@@ -67,7 +67,7 @@ module Nsm
       end
       form = form_class.new(claim:, item:, **form_params)
 
-      if form.save
+      if form.save!
         redirect_to nsm_claim_letters_and_calls_path(claim)
       else
         render :edit, locals: { claim:, item:, form: }

--- a/app/controllers/nsm/work_items/uplifts_controller.rb
+++ b/app/controllers/nsm/work_items/uplifts_controller.rb
@@ -14,7 +14,7 @@ module Nsm
         authorize(claim)
         form = Uplift::WorkItemsForm.new(claim:, **form_params)
 
-        if form.save
+        if form.save!
           redirect_to nsm_claim_work_items_path(claim),
                       flash: { success: t('.uplift_removed') }
         else

--- a/app/controllers/nsm/work_items_controller.rb
+++ b/app/controllers/nsm/work_items_controller.rb
@@ -70,7 +70,7 @@ module Nsm
 
       form = WorkItemForm.new(**common_form_attributes(claim, item), **form_params)
 
-      if form.save
+      if form.save!
         redirect_to nsm_claim_work_items_path(claim)
       else
         render :edit, locals: { claim:, item:, form: }

--- a/app/controllers/prior_authority/additional_costs_controller.rb
+++ b/app/controllers/prior_authority/additional_costs_controller.rb
@@ -26,7 +26,7 @@ module PriorAuthority
 
       form = AdditionalCostForm.new(submission:, item:, **form_params)
 
-      if form.save
+      if form.save!
         redirect_to prior_authority_application_adjustments_path(submission)
       else
         render :edit, locals: { submission:, item:, form:, index: }
@@ -47,7 +47,7 @@ module PriorAuthority
     def destroy
       deleter = PriorAuthority::AdjustmentDeleter.new(params, :additional_cost, current_user)
       authorize(deleter.submission, :edit?)
-      deleter.call
+      deleter.call!
       redirect_to prior_authority_application_adjustments_path(params[:application_id])
     end
 

--- a/app/controllers/prior_authority/service_costs_controller.rb
+++ b/app/controllers/prior_authority/service_costs_controller.rb
@@ -25,7 +25,7 @@ module PriorAuthority
 
       form = ServiceCostForm.new(submission:, item:, **form_params(item))
 
-      if form.save
+      if form.save!
         redirect_to prior_authority_application_adjustments_path(submission)
       else
         render :edit, locals: { submission:, item:, form: }
@@ -44,7 +44,7 @@ module PriorAuthority
     def destroy
       deleter = PriorAuthority::AdjustmentDeleter.new(params, :service_cost, current_user)
       authorize(deleter.submission, :update?)
-      deleter.call
+      deleter.call!
       redirect_to prior_authority_application_adjustments_path(params[:application_id])
     end
 

--- a/app/controllers/prior_authority/travel_costs_controller.rb
+++ b/app/controllers/prior_authority/travel_costs_controller.rb
@@ -25,7 +25,7 @@ module PriorAuthority
 
       form = TravelCostForm.new(submission:, item:, **form_params)
 
-      if form.save
+      if form.save!
         redirect_to prior_authority_application_adjustments_path(submission)
       else
         render :edit, locals: { submission:, item:, form: }
@@ -43,7 +43,7 @@ module PriorAuthority
     def destroy
       deleter = PriorAuthority::AdjustmentDeleter.new(params, :travel_cost, current_user)
       authorize(deleter.submission, :update?)
-      deleter.call
+      deleter.call!
       redirect_to prior_authority_application_adjustments_path(params[:application_id])
     end
 

--- a/app/forms/base_adjustment_form.rb
+++ b/app/forms/base_adjustment_form.rb
@@ -9,6 +9,12 @@ class BaseAdjustmentForm
   attribute :item # used to detect changes in data
   validate :data_changed
 
+  def save!
+    submission.with_lock do
+      AppStoreClient.new.adjust(submission) if save
+    end
+  end
+
   private
 
   COMMENT_FIELD = 'adjustment_comment'.freeze

--- a/app/forms/nsm/send_back_form.rb
+++ b/app/forms/nsm/send_back_form.rb
@@ -16,6 +16,7 @@ module Nsm
     def stash
       claim.data['send_back_comment'] = send_back_comment
       claim.save!
+      AppStoreClient.new.adjust(claim)
     end
 
     def save

--- a/app/models/event/assignment.rb
+++ b/app/models/event/assignment.rb
@@ -1,6 +1,6 @@
 class Event
   class Assignment < Event
-    def self.build(submission:, current_user:, comment: nil)
+    def self.construct(submission:, current_user:, comment: nil)
       create(
         submission: submission,
         primary_user: current_user,
@@ -8,7 +8,7 @@ class Event
         details: {
           comment:
         }
-      ).tap(&:notify)
+      )
     end
 
     def title

--- a/app/models/event/auto_decision.rb
+++ b/app/models/event/auto_decision.rb
@@ -1,6 +1,6 @@
 class Event
   class AutoDecision < Event
-    def self.build(submission:, previous_state:)
+    def self.construct(submission:, previous_state:)
       create(
         submission: submission,
         submission_version: submission.current_version,

--- a/app/models/event/change_risk.rb
+++ b/app/models/event/change_risk.rb
@@ -1,6 +1,6 @@
 class Event
   class ChangeRisk < Event
-    def self.build(submission:, explanation:, previous_risk_level:, current_user:)
+    def self.construct(submission:, explanation:, previous_risk_level:, current_user:)
       create(
         submission: submission,
         submission_version: submission.current_version,

--- a/app/models/event/decision.rb
+++ b/app/models/event/decision.rb
@@ -1,6 +1,6 @@
 class Event
   class Decision < Event
-    def self.build(submission:, previous_state:, comment:, current_user:)
+    def self.construct(submission:, previous_state:, comment:, current_user:)
       create(
         submission: submission,
         submission_version: submission.current_version,

--- a/app/models/event/delete_adjustments.rb
+++ b/app/models/event/delete_adjustments.rb
@@ -1,6 +1,6 @@
 class Event
   class DeleteAdjustments < Event
-    def self.build(submission:, comment:, current_user:)
+    def self.construct(submission:, comment:, current_user:)
       create(
         submission: submission,
         submission_version: submission.current_version,

--- a/app/models/event/draft_decision.rb
+++ b/app/models/event/draft_decision.rb
@@ -1,6 +1,6 @@
 class Event
   class DraftDecision < Event
-    def self.build(submission:, next_state:, comment:, current_user:)
+    def self.construct(submission:, next_state:, comment:, current_user:)
       create!(
         submission: submission,
         submission_version: submission.current_version,

--- a/app/models/event/edit.rb
+++ b/app/models/event/edit.rb
@@ -1,6 +1,6 @@
 class Event
   class Edit < Event
-    def self.build(submission:, linked:, details:, current_user:)
+    def self.construct(submission:, linked:, details:, current_user:)
       create(
         submission: submission,
         submission_version: submission.current_version,

--- a/app/models/event/expiry.rb
+++ b/app/models/event/expiry.rb
@@ -1,6 +1,6 @@
 class Event
   class Expiry < Event
-    def self.build(submission:)
+    def self.construct(submission:)
       create(submission: submission, submission_version: submission.current_version)
     end
   end

--- a/app/models/event/new_version.rb
+++ b/app/models/event/new_version.rb
@@ -1,9 +1,9 @@
 class Event
   class NewVersion < Event
-    def self.build(submission:)
+    def self.construct(submission:)
       # We notify the app store immediately of a new version, because its analytics mechanism
       # depends on having new version events available.
-      create(submission: submission, submission_version: submission.current_version).tap(&:notify)
+      create(submission: submission, submission_version: submission.current_version)
     end
 
     def body

--- a/app/models/event/note.rb
+++ b/app/models/event/note.rb
@@ -1,6 +1,6 @@
 class Event
   class Note < Event
-    def self.build(submission:, note:, current_user:)
+    def self.construct(submission:, note:, current_user:)
       create(
         submission: submission,
         submission_version: submission.current_version,

--- a/app/models/event/unassignment.rb
+++ b/app/models/event/unassignment.rb
@@ -2,7 +2,7 @@ class Event
   class Unassignment < Event
     belongs_to :secondary_user, optional: true, class_name: 'User'
 
-    def self.build(submission:, user:, current_user:, comment:)
+    def self.construct(submission:, user:, current_user:, comment:)
       create(
         submission: submission,
         primary_user: user,
@@ -11,7 +11,7 @@ class Event
         details: {
           comment:
         }
-      ).tap(&:notify)
+      )
     end
 
     def title

--- a/app/models/prior_authority/event/send_back.rb
+++ b/app/models/prior_authority/event/send_back.rb
@@ -1,7 +1,7 @@
 module PriorAuthority
   module Event
     class SendBack < ::Event
-      def self.build(submission:, updates_needed:, comments:, current_user:)
+      def self.construct(submission:, updates_needed:, comments:, current_user:)
         create!(
           submission: submission,
           submission_version: submission.current_version,

--- a/app/services/adjustment_deleter_base.rb
+++ b/app/services/adjustment_deleter_base.rb
@@ -8,6 +8,13 @@ class AdjustmentDeleterBase
     @submission = submission_scope
   end
 
+  def call!
+    submission.with_lock do
+      call
+      AppStoreClient.new.adjust(submission)
+    end
+  end
+
   def call
     raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
   end

--- a/app/services/app_store_client.rb
+++ b/app/services/app_store_client.rb
@@ -113,7 +113,7 @@ class AppStoreClient
     response = self.class.post("#{host}/v1/submissions/#{submission.id}/adjustments", **options(application: submission.data))
     process_response(
       response,
-      "Unexpected response from AppStore - status #{response.code} for assignment to :#{submission.id}",
+      "Unexpected response from AppStore - status #{response.code} for adjustment to :#{submission.id}",
       201 => :created,
     )
   end

--- a/app/services/app_store_client.rb
+++ b/app/services/app_store_client.rb
@@ -109,6 +109,15 @@ class AppStoreClient
     )
   end
 
+  def adjust(submission)
+    response = self.class.post("#{host}/v1/submissions/#{submission.id}/adjustments", **options(application: submission.data))
+    process_response(
+      response,
+      "Unexpected response from AppStore - status #{response.code} for assignment to :#{submission.id}",
+      201 => :created,
+    )
+  end
+
   private
 
   def options(payload = nil)

--- a/app/services/update_submission.rb
+++ b/app/services/update_submission.rb
@@ -34,7 +34,8 @@ class UpdateSubmission
 
   def new_version_appropriate?
     # If this is a prior authority submission, only add a new version event on the first new version
-    @record['version'] == 1 || @record['application_type'] != Submission::APPLICATION_TYPES[:prior_authority]
+    @record['version'] == 1 ||
+      (@record['application_type'] == Submission::APPLICATION_TYPES[:nsm] && @record['application_state'] == 'provider_updated')
   end
 
   def assign_attributes

--- a/db/migrate/20241111112720_backfill_local_events_and_adjustments_to_app_store.rb
+++ b/db/migrate/20241111112720_backfill_local_events_and_adjustments_to_app_store.rb
@@ -1,0 +1,16 @@
+class BackfillLocalEventsAndAdjustmentsToAppStore < ActiveRecord::Migration[7.2]
+  def change
+    client = AppStoreClient.new
+    Submission.where(state: %i[submitted provider_updated]).find_each do |submission|
+      client.adjust(submission)
+      client.create_events(submission.id, submission.events)
+    end
+
+    # For old pre-RFI NSMs, caseworkers could still conceivably be adding events and
+    # adjustments
+    Submission.where(application_type: 'crm7', state: :sent_back).find_each do |submission|
+      client.adjust(submission)
+      client.create_events(submission.id, submission.events)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_08_105420) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_11_112720) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "plpgsql"

--- a/spec/controllers/nsm/disbursements_controller_spec.rb
+++ b/spec/controllers/nsm/disbursements_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Nsm::DisbursementsController do
   end
 
   describe 'update' do
-    let(:form) { instance_double(Nsm::DisbursementsForm, save:) }
+    let(:form) { instance_double(Nsm::DisbursementsForm, save!: save) }
 
     before do
       allow(Nsm::DisbursementsForm).to receive(:new).and_return(form)

--- a/spec/controllers/nsm/letters_and_calls/uplifts_controller_spec.rb
+++ b/spec/controllers/nsm/letters_and_calls/uplifts_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Nsm::LettersAndCalls::UpliftsController do
   end
 
   describe 'update' do
-    let(:form) { instance_double(Nsm::Uplift::LettersAndCallsForm, save:) }
+    let(:form) { instance_double(Nsm::Uplift::LettersAndCallsForm, save!: save) }
 
     before do
       allow(Nsm::Uplift::LettersAndCallsForm).to receive(:new).and_return(form)

--- a/spec/controllers/nsm/letters_and_calls_controller_spec.rb
+++ b/spec/controllers/nsm/letters_and_calls_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Nsm::LettersAndCallsController do
   end
 
   describe 'update' do
-    let(:form) { instance_double(Nsm::LettersCallsForm::Letters, save:) }
+    let(:form) { instance_double(Nsm::LettersCallsForm::Letters, save!: save) }
 
     before do
       allow(Nsm::LettersCallsForm::Letters).to receive(:new).and_return(form)

--- a/spec/controllers/nsm/work_items/uplifts_controller_spec.rb
+++ b/spec/controllers/nsm/work_items/uplifts_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Nsm::WorkItems::UpliftsController do
   end
 
   describe 'update' do
-    let(:form) { instance_double(Nsm::Uplift::WorkItemsForm, save:) }
+    let(:form) { instance_double(Nsm::Uplift::WorkItemsForm, save!: save) }
 
     before do
       allow(Nsm::Uplift::WorkItemsForm).to receive(:new).and_return(form)

--- a/spec/controllers/nsm/work_items_controller_spec.rb
+++ b/spec/controllers/nsm/work_items_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Nsm::WorkItemsController do
   end
 
   describe 'update' do
-    let(:form) { instance_double(Nsm::WorkItemForm, save:) }
+    let(:form) { instance_double(Nsm::WorkItemForm, save!: save) }
 
     before do
       allow(Nsm::WorkItemForm).to receive(:new).and_return(form)

--- a/spec/forms/nsm/disbursements_form_spec.rb
+++ b/spec/forms/nsm/disbursements_form_spec.rb
@@ -45,6 +45,9 @@ RSpec.describe Nsm::DisbursementsForm do
   end
   let(:explanation) { 'change to disbursements' }
   let(:current_user) { create(:caseworker) }
+  let(:app_store_client) { instance_double(AppStoreClient, create_events: true) }
+
+  before { allow(AppStoreClient).to receive(:new).and_return(app_store_client) }
 
   describe '#save' do
     context 'when the form is valid' do

--- a/spec/forms/nsm/letters_calls_form_spec.rb
+++ b/spec/forms/nsm/letters_calls_form_spec.rb
@@ -21,6 +21,9 @@ RSpec.describe Nsm::LettersCallsForm do
   let(:original_uplift) { 95 }
   let(:explanation) { 'change to letters' }
   let(:current_user) { instance_double(User) }
+  let(:app_store_client) { instance_double(AppStoreClient, create_events: true) }
+
+  before { allow(AppStoreClient).to receive(:new).and_return(app_store_client) }
 
   describe '#validations' do
     describe '#type' do

--- a/spec/forms/nsm/work_item_form_spec.rb
+++ b/spec/forms/nsm/work_item_form_spec.rb
@@ -28,6 +28,9 @@ RSpec.describe Nsm::WorkItemForm do
   let(:current_user) { instance_double(User) }
   let(:work_type_value) { 'waiting' }
   let(:work_item_pricing) { { 'waiting' => 12.5, 'travel' => 4.7 } }
+  let(:app_store_client) { instance_double(AppStoreClient, create_events: true) }
+
+  before { allow(AppStoreClient).to receive(:new).and_return(app_store_client) }
 
   describe '#validations' do
     context 'uplift' do

--- a/spec/models/event/change_risk_spec.rb
+++ b/spec/models/event/change_risk_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe Event::ChangeRisk do
   let(:current_user) { create(:caseworker) }
   let(:previous_risk_level) { 'high' }
   let(:explanation) { 'risk has been changed' }
+  let(:app_store_client) { instance_double(AppStoreClient, create_events: true) }
+
+  before { allow(AppStoreClient).to receive(:new).and_return(app_store_client) }
 
   it 'can build a new record' do
     expect(subject).to have_attributes(

--- a/spec/models/event/edit_spec.rb
+++ b/spec/models/event/edit_spec.rb
@@ -15,6 +15,9 @@ RSpec.describe Event::Edit do
     }
   end
   let(:linked) { { type: 'letters' } }
+  let(:app_store_client) { instance_double(AppStoreClient, create_events: true) }
+
+  before { allow(AppStoreClient).to receive(:new).and_return(app_store_client) }
 
   it 'can build a new record' do
     expect(subject).to have_attributes(

--- a/spec/models/event/note_spec.rb
+++ b/spec/models/event/note_spec.rb
@@ -6,6 +6,9 @@ RSpec.describe Event::Note do
   let(:submission) { create(:claim) }
   let(:current_user) { create(:caseworker) }
   let(:note) { 'new note' }
+  let(:app_store_client) { instance_double(AppStoreClient, create_events: true) }
+
+  before { allow(AppStoreClient).to receive(:new).and_return(app_store_client) }
 
   it 'can build a new record' do
     expect(subject).to have_attributes(

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Event do
         'updated_at' => an_instance_of(String),
         :event_type => 'new_version',
         :public => false,
+        :does_not_constitute_update => false,
       )
     end
 
@@ -37,6 +38,7 @@ RSpec.describe Event do
           'updated_at' => an_instance_of(String),
           :event_type => 'decision',
           :public => true,
+          :does_not_constitute_update => false,
         )
       end
     end

--- a/spec/services/nsm/adjustment_deleter_spec.rb
+++ b/spec/services/nsm/adjustment_deleter_spec.rb
@@ -8,8 +8,10 @@ RSpec.describe Nsm::AdjustmentDeleter do
     let(:item_id) { '1234-adj' }
     let(:user) { create(:caseworker) }
     let(:claim) { create(:claim, :with_adjustments) }
+    let(:app_store_client) { instance_double(AppStoreClient, create_events: true) }
 
     before do
+      allow(AppStoreClient).to receive(:new).and_return(app_store_client)
       create(:assignment, submission: claim, user: user)
     end
 

--- a/spec/services/nsm/all_adjustments_deleter_spec.rb
+++ b/spec/services/nsm/all_adjustments_deleter_spec.rb
@@ -8,8 +8,10 @@ RSpec.describe Nsm::AllAdjustmentsDeleter do
     let(:item_id) { '1234-adj' }
     let(:user) { create(:caseworker) }
     let(:claim) { create(:claim, :with_adjustments) }
+    let(:app_store_client) { instance_double(AppStoreClient, create_events: true) }
 
     before do
+      allow(AppStoreClient).to receive(:new).and_return(app_store_client)
       create(:assignment, submission: claim, user: user)
     end
 

--- a/spec/services/update_submission_spec.rb
+++ b/spec/services/update_submission_spec.rb
@@ -47,10 +47,6 @@ RSpec.describe UpdateSubmission, :stub_oauth_token do
       expect { described_class.call(record) }.not_to change(Submission, :count)
     end
 
-    it 'adds a new version event' do
-      expect { described_class.call(record) }.to change(Event::NewVersion, :count).from(0).to(1)
-    end
-
     it 'updates the existing submission' do
       described_class.call(record)
       expect(submission.reload).to have_attributes(
@@ -125,7 +121,7 @@ RSpec.describe UpdateSubmission, :stub_oauth_token do
 
         it 'rehydrates the events' do
           described_class.call(record)
-          expect(Event.count).to eq(2)
+          expect(Event.count).to eq(1)
           expect(Event.find(event_id)).to have_attributes(
             submission_id: submission.id,
             submission_version: 1,
@@ -160,7 +156,7 @@ RSpec.describe UpdateSubmission, :stub_oauth_token do
             submission
             expect { described_class.call(record) }.to change(User, :count).by(1)
 
-            expect(Event.count).to eq(2)
+            expect(Event.count).to eq(1)
             expect(Event::Edit.last).to have_attributes(
               submission_id: submission.id,
               submission_version: 1,

--- a/spec/system/nsm/adjustments_spec.rb
+++ b/spec/system/nsm/adjustments_spec.rb
@@ -1,10 +1,12 @@
 require 'rails_helper'
 
-RSpec.describe 'Adjustments' do
+RSpec.describe 'Adjustments', :stub_oauth_token do
   let(:user) { create(:caseworker) }
   let(:claim) { create(:claim, :with_adjustments) }
 
   before do
+    stub_request(:post, "https://appstore.example.com/v1/submissions/#{claim.id}/events").to_return(status: 201)
+    stub_request(:post, "https://appstore.example.com/v1/submissions/#{claim.id}/adjustments").to_return(status: 201)
     sign_in user
     create(:assignment, submission: claim, user: user)
     visit '/'

--- a/spec/system/nsm/assessment_spec.rb
+++ b/spec/system/nsm/assessment_spec.rb
@@ -93,6 +93,7 @@ Rails.describe 'Assessment', :stub_oauth_token do
     end
 
     it 'lets me save and come back later' do
+      stub_request(:post, "https://appstore.example.com/v1/submissions/#{claim.id}/adjustments").to_return(status: 201)
       click_link_or_button 'Save and come back later'
       visit nsm_claim_claim_details_path(claim)
       click_link_or_button 'Send back to provider'

--- a/spec/system/nsm/disbursements_spec.rb
+++ b/spec/system/nsm/disbursements_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Disbursements' do
+RSpec.describe 'Disbursements', :stub_oauth_token do
   let(:user) { create(:caseworker) }
   let(:claim) { create(:claim) }
   let(:disbursement_form_error_message) do
@@ -8,6 +8,8 @@ RSpec.describe 'Disbursements' do
   end
 
   before do
+    stub_request(:post, "https://appstore.example.com/v1/submissions/#{claim.id}/events").to_return(status: 201)
+    stub_request(:post, "https://appstore.example.com/v1/submissions/#{claim.id}/adjustments").to_return(status: 201)
     create(:assignment, submission: claim, user: user)
     sign_in user
   end

--- a/spec/system/nsm/letters_and_calls_spec.rb
+++ b/spec/system/nsm/letters_and_calls_spec.rb
@@ -1,10 +1,12 @@
 require 'rails_helper'
 
-RSpec.describe 'Letters and Calls' do
+RSpec.describe 'Letters and Calls', :stub_oauth_token do
   let(:user) { create(:caseworker) }
   let(:claim) { create(:claim) }
 
   before do
+    stub_request(:post, "https://appstore.example.com/v1/submissions/#{claim.id}/events").to_return(status: 201)
+    stub_request(:post, "https://appstore.example.com/v1/submissions/#{claim.id}/adjustments").to_return(status: 201)
     sign_in user
     create(:assignment, submission: claim, user: user)
     visit '/'

--- a/spec/system/nsm/overview_spec.rb
+++ b/spec/system/nsm/overview_spec.rb
@@ -1,10 +1,12 @@
 require 'rails_helper'
 
-RSpec.describe 'Overview', type: :system do
+RSpec.describe 'Overview', :stub_oauth_token, type: :system do
   let(:user) { create(:caseworker) }
   let(:claim) { create(:claim) }
 
   before do
+    stub_request(:post, "https://appstore.example.com/v1/submissions/#{claim.id}/events").to_return(status: 201)
+    stub_request(:post, "https://appstore.example.com/v1/submissions/#{claim.id}/adjustments").to_return(status: 201)
     sign_in user
     create(:assignment, submission: claim, user: user)
   end

--- a/spec/system/nsm/work_items_spec.rb
+++ b/spec/system/nsm/work_items_spec.rb
@@ -1,10 +1,12 @@
 require 'rails_helper'
 
-RSpec.describe 'Work items' do
+RSpec.describe 'Work items', :stub_oauth_token do
   let(:user) { create(:caseworker) }
   let(:claim) { create(:claim) }
 
   before do
+    stub_request(:post, "https://appstore.example.com/v1/submissions/#{claim.id}/events").to_return(status: 201)
+    stub_request(:post, "https://appstore.example.com/v1/submissions/#{claim.id}/adjustments").to_return(status: 201)
     sign_in user
     create(:assignment, submission: claim, user: user)
     visit '/'

--- a/spec/system/prior_authority/adjust_additional_costs_spec.rb
+++ b/spec/system/prior_authority/adjust_additional_costs_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
 
-RSpec.describe 'Adjust additional costs' do
+RSpec.describe 'Adjust additional costs', :stub_oauth_token do
   before do
+    stub_request(:post, "https://appstore.example.com/v1/submissions/#{application.id}/events").to_return(status: 201)
+    stub_request(:post, "https://appstore.example.com/v1/submissions/#{application.id}/adjustments").to_return(status: 201)
     sign_in caseworker
     visit '/'
     click_on 'Accept analytics cookies'

--- a/spec/system/prior_authority/adjust_service_costs_spec.rb
+++ b/spec/system/prior_authority/adjust_service_costs_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
 
-RSpec.describe 'Adjust service costs' do
+RSpec.describe 'Adjust service costs', :stub_oauth_token do
   before do
+    stub_request(:post, "https://appstore.example.com/v1/submissions/#{application.id}/events").to_return(status: 201)
+    stub_request(:post, "https://appstore.example.com/v1/submissions/#{application.id}/adjustments").to_return(status: 201)
     sign_in caseworker
     visit '/'
     click_on 'Accept analytics cookies'

--- a/spec/system/prior_authority/adjust_travel_costs_spec.rb
+++ b/spec/system/prior_authority/adjust_travel_costs_spec.rb
@@ -1,7 +1,9 @@
 require 'rails_helper'
 
-RSpec.describe 'Adjust travel costs' do
+RSpec.describe 'Adjust travel costs', :stub_oauth_token do
   before do
+    stub_request(:post, "https://appstore.example.com/v1/submissions/#{application.id}/events").to_return(status: 201)
+    stub_request(:post, "https://appstore.example.com/v1/submissions/#{application.id}/adjustments").to_return(status: 201)
     sign_in caseworker
     visit '/'
     click_on 'Accept analytics cookies'

--- a/spec/system/prior_authority/adjustments_spec.rb
+++ b/spec/system/prior_authority/adjustments_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'View applications' do
+RSpec.describe 'Adjustments', :stub_oauth_token do
   let(:caseworker) { create(:caseworker) }
   let(:application) do
     create(:prior_authority_application,
@@ -12,6 +12,8 @@ RSpec.describe 'View applications' do
   let(:cost_adjustment_button_label) { 'Adjust additional cost' }
 
   before do
+    stub_request(:post, "https://appstore.example.com/v1/submissions/#{application.id}/events").to_return(status: 201)
+    stub_request(:post, "https://appstore.example.com/v1/submissions/#{application.id}/adjustments").to_return(status: 201)
     sign_in caseworker
     visit '/'
     click_on 'Accept analytics cookies'

--- a/spec/system/prior_authority/delete_adjustments_spec.rb
+++ b/spec/system/prior_authority/delete_adjustments_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Delete adjustments' do
+RSpec.describe 'Delete adjustments', :stub_oauth_token do
   let(:caseworker) { create(:caseworker) }
   let(:application) do
     create(
@@ -28,6 +28,8 @@ RSpec.describe 'Delete adjustments' do
   end
 
   before do
+    stub_request(:post, "https://appstore.example.com/v1/submissions/#{application.id}/events").to_return(status: 201)
+    stub_request(:post, "https://appstore.example.com/v1/submissions/#{application.id}/adjustments").to_return(status: 201)
     sign_in caseworker
     visit '/'
     click_on 'Accept analytics cookies'

--- a/spec/system/prior_authority/make_decision_spec.rb
+++ b/spec/system/prior_authority/make_decision_spec.rb
@@ -87,6 +87,7 @@ RSpec.describe 'Decide an application', :stub_oauth_token do
 
   it 'lets me save my answers and return later' do
     stub_request(:post, "https://appstore.example.com/v1/submissions/#{application.id}/events").to_return(status: 201)
+    stub_request(:post, "https://appstore.example.com/v1/submissions/#{application.id}/adjustments").to_return(status: 201)
     choose 'Rejected'
     fill_in 'Provide detailed reasons for rejecting this application', with: 'The wrong form was used'
     click_on 'Save and come back later'

--- a/spec/system/prior_authority/make_decision_spec.rb
+++ b/spec/system/prior_authority/make_decision_spec.rb
@@ -86,6 +86,7 @@ RSpec.describe 'Decide an application', :stub_oauth_token do
   end
 
   it 'lets me save my answers and return later' do
+    stub_request(:post, "https://appstore.example.com/v1/submissions/#{application.id}/events").to_return(status: 201)
     choose 'Rejected'
     fill_in 'Provide detailed reasons for rejecting this application', with: 'The wrong form was used'
     click_on 'Save and come back later'

--- a/spec/system/prior_authority/notes_spec.rb
+++ b/spec/system/prior_authority/notes_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'Notes', :stub_oauth_token do
   let(:application) { create(:prior_authority_application, state: 'submitted') }
 
   before do
+    stub_request(:post, "https://appstore.example.com/v1/submissions/#{application.id}/events").to_return(status: 201)
     sign_in caseworker
     application.assignments.create(user: caseworker)
     visit prior_authority_application_events_path(application)

--- a/spec/system/prior_authority/send_back_spec.rb
+++ b/spec/system/prior_authority/send_back_spec.rb
@@ -99,6 +99,7 @@ RSpec.describe 'Send an application back', :stub_oauth_token do
 
   it 'lets me save my answers and return later' do
     stub_request(:post, "https://appstore.example.com/v1/submissions/#{application.id}/events").to_return(status: 201)
+    stub_request(:post, "https://appstore.example.com/v1/submissions/#{application.id}/adjustments").to_return(status: 201)
     check 'Further information'
     fill_in 'Tell the provider what information they need to add', with: 'You forgot to say please'
     click_on 'Save and come back later'

--- a/spec/system/prior_authority/send_back_spec.rb
+++ b/spec/system/prior_authority/send_back_spec.rb
@@ -98,6 +98,7 @@ RSpec.describe 'Send an application back', :stub_oauth_token do
   end
 
   it 'lets me save my answers and return later' do
+    stub_request(:post, "https://appstore.example.com/v1/submissions/#{application.id}/events").to_return(status: 201)
     check 'Further information'
     fill_in 'Tell the provider what information they need to add', with: 'You forgot to say please'
     click_on 'Save and come back later'


### PR DESCRIPTION
## Description of change
So that the app store is never out of date, and can be relied on as the single source of truth

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2216)
