### PR TITLE
Typo meaning we are not syncing adjustment deletions to app store

### DIFF
--- a/app/controllers/concerns/nsm/adjustment_concern.rb
+++ b/app/controllers/concerns/nsm/adjustment_concern.rb
@@ -10,7 +10,7 @@ module Nsm
     def destroy
       deleter = Nsm::AdjustmentDeleter.new(params, resource_klass, current_user)
       authorize(deleter.submission, :update?)
-      deleter.call
+      deleter.call!
       redirect_to destroy_redirect, flash: { success: t('.success') }
     end
 


### PR DESCRIPTION
`call` just does the local stuff. `call!` calls `call` then syncs to the app store.
