### PR TITLE
Fix disbursement change edge case

### DIFF
--- a/app/view_models/nsm/v1/disbursement.rb
+++ b/app/view_models/nsm/v1/disbursement.rb
@@ -163,15 +163,7 @@ module Nsm
       end
 
       def changed?
-        vat_changed? || cost_changed?
-      end
-
-      def vat_changed?
-        apply_vat != original_apply_vat
-      end
-
-      def cost_changed?
-        original_total_cost_without_vat != total_cost_without_vat
+        provider_requested_total_cost != caseworker_total_cost
       end
 
       def backlink_path(claim)


### PR DESCRIPTION
## Description of change
If a mileage-based disbursement has had the number of miles changed, then `total_cost_without_vat` will not change, as now that is only used to represent lump-sum disbursements, and we don't put a calculated total for miles * rate in there any more. So the only way to be confident that there has been a chance is to compare the total, vat-inclusive calculated result.