### PR TITLE
CRM457-2322: No UAT devauth, and improve UX when unknown caseworker ID

### DIFF
--- a/app/forms/prior_authority/unassignment_form.rb
+++ b/app/forms/prior_authority/unassignment_form.rb
@@ -10,7 +10,7 @@ module PriorAuthority
     validates :comment, presence: true
 
     def caseworker_name
-      @caseworker_name ||= User.find_by(id: application.assigned_user_id)&.display_name
+      @caseworker_name ||= application.assigned_user&.display_name
     end
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -99,7 +99,7 @@ class Event
   end
 
   def primary_user
-    @primary_user ||= User.find_by(id: primary_user_id)
+    @primary_user ||= User.load(primary_user_id)
   end
 
   def as_json(*)

--- a/app/models/event/unassignment.rb
+++ b/app/models/event/unassignment.rb
@@ -12,12 +12,12 @@ class Event
     end
 
     def secondary_user
-      User.find_by(id: secondary_user_id)
+      User.load(secondary_user_id)
     end
 
     def title
       if secondary_user_id
-        t('title.secondary', display_name: secondary_user&.display_name)
+        t('title.secondary', display_name: secondary_user.display_name)
       else
         t('title.self')
       end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -28,7 +28,7 @@ class Submission
   end
 
   def assigned_user
-    @assigned_user ||= User.find_by(id: assigned_user_id)
+    @assigned_user ||= User.load(assigned_user_id)
   end
 
   def to_param

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  DummyUser = Struct.new(:display_name)
+
   has_many :access_logs, dependent: :destroy
   has_many :roles, dependent: :destroy
 
@@ -24,5 +26,11 @@ class User < ApplicationRecord
 
   def pending_activation?
     auth_subject_id.nil? && first_auth_at.nil?
+  end
+
+  def self.load(user_id)
+    return unless user_id
+
+    find_by(id: user_id) || DummyUser.new(I18n.t('helpers.non_local_caseworker'))
   end
 end

--- a/app/view_models/nsm/v1/further_information.rb
+++ b/app/view_models/nsm/v1/further_information.rb
@@ -65,7 +65,7 @@ module Nsm
       end
 
       def caseworker
-        User.find_by(id: caseworker_id)&.display_name
+        User.load(caseworker_id)&.display_name
       end
 
       private

--- a/app/view_models/prior_authority/v1/application_details/further_information_card.rb
+++ b/app/view_models/prior_authority/v1/application_details/further_information_card.rb
@@ -14,7 +14,7 @@ module PriorAuthority
         end
 
         def caseworker
-          User.find(@further_information['caseworker_id']).display_name
+          User.load(@further_information['caseworker_id']).display_name
         end
 
         def information_request

--- a/app/view_models/prior_authority/v1/application_details/incorrect_information_card.rb
+++ b/app/view_models/prior_authority/v1/application_details/incorrect_information_card.rb
@@ -14,7 +14,7 @@ module PriorAuthority
         end
 
         def caseworker
-          User.find(@incorrect_information['caseworker_id']).display_name
+          User.load(@incorrect_information['caseworker_id']).display_name
         end
 
         def information_request

--- a/app/view_models/prior_authority/v1/application_summary.rb
+++ b/app/view_models/prior_authority/v1/application_summary.rb
@@ -106,7 +106,7 @@ module PriorAuthority
       delegate :sent_back?, :expired?, :provider_updated?, to: :submission
 
       def caseworker
-        User.find_by(id: submission.assigned_user_id)&.display_name
+        submission.assigned_user&.display_name
       end
     end
   end

--- a/app/view_models/search_result.rb
+++ b/app/view_models/search_result.rb
@@ -24,7 +24,7 @@ class SearchResult
   end
 
   def caseworker
-    User.find_by(id: submission.assigned_user_id)&.display_name || I18n.t('search.unassigned')
+    submission.assigned_user&.display_name || I18n.t('search.unassigned')
   end
 
   def date_updated

--- a/config/feature_flags.yml
+++ b/config/feature_flags.yml
@@ -2,7 +2,7 @@ feature_flags:
   dev_auth:
     local: <%= ENV.fetch("DEV_AUTH_ENABLED", false) %>
     development: true
-    uat: true
+    uat: false
     production: false # must never be enabled in the live service
   postal_evidence:
     local: <%= ENV.fetch("POSTAL_EVIDENCE", false) %>

--- a/config/locales/en/helpers.yml
+++ b/config/locales/en/helpers.yml
@@ -29,3 +29,4 @@ en:
         minimal_html:
           one: '%{minutes}<span class="govuk-visually-hidden"> minute</span>'
           other: '%{minutes}<span class="govuk-visually-hidden"> minutes</span>'
+    non_local_caseworker: Unknown caseworker

--- a/spec/models/event/unassignment_spec.rb
+++ b/spec/models/event/unassignment_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Event::Unassignment do
     let(:current_user) { build(:supervisor, id: SecureRandom.uuid) }
 
     it 'at least does not explode' do
-      expect(subject.title).to eq('Caseworker removed from claim by ')
+      expect(subject.title).to eq('Caseworker removed from claim by Unknown caseworker')
     end
   end
 end

--- a/spec/view_models/nsm/v1/further_information_spec.rb
+++ b/spec/view_models/nsm/v1/further_information_spec.rb
@@ -43,10 +43,10 @@ RSpec.describe Nsm::V1::FurtherInformation do
         'documents' => [] }
     end
 
-    it 'falls back to nil if CW not found' do
+    it 'falls back to sensible default if CW not found' do
       subject { described_class.new(params) }
 
-      expect(subject.caseworker).to be_nil
+      expect(subject.caseworker).to eq 'Unknown caseworker'
     end
   end
 


### PR DESCRIPTION
## Description of change
- Switch off DevAuth on UAT to make it more secure
- Handle records imported from another env (where there will be unrecognised user IDs) better

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2322)
