### PR TITLE
Memoize data_for_calculation

### DIFF
--- a/app/models/claim.rb
+++ b/app/models/claim.rb
@@ -82,7 +82,7 @@ class Claim < Submission
   end
 
   def data_for_calculation
-    {
+    @data_for_calculation ||= {
       claim_type: BaseViewModel.build(:details_of_claim, self).claim_type.value,
       rep_order_date: data['rep_order_date'],
       cntp_date: data['cntp_date'],


### PR DESCRIPTION
CoreCostSummary.show_allowed? calls `changed?` on a view model for every single work item and disbursement (can be hundreds), and each of those calls a calculator method with `submission.data_for_calculation` as an argument. This is a slow method when there are hundreds of work items and disbursements, so we can get a quick win by memoizing it so it only runs once per page load.