### PR TITLE
CRM457-2147: add rake task to deactivate user

### DIFF
--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -1,6 +1,5 @@
 namespace :user do
   desc 'add user to database'
-
   task :add, [:email, :first_name, :last_name, :role] => [:environment] do |t, args|
     user = User.find_or_initialize_by(email: args[:email])
     user.update!(
@@ -9,5 +8,25 @@ namespace :user do
       auth_oid: SecureRandom.uuid
     )
     user.roles.create! role_type: args[:role]
+  end
+
+  desc 'deactivate user (disable login)'
+  task :deactivate, [:email] => [:environment] do |t, args|
+    abort("Usage: Run task with email as argument ie 'rake user:deactivate[test@test.com]'") unless args[:email]
+
+    user = User.find_by(email: args[:email]) || abort('User not found')
+    user.update(deactivated_at: Time.now)
+
+    puts "User email: #{user.email} deactivated at #{user.deactivated_at}"
+  end
+
+  desc 'reactivate user (re-enable disabled login)'
+  task :reactivate, [:email] => [:environment] do |t, args|
+    abort("Usage: Run task with email as argument ie 'rake user:reactivate[test@test.com]'") unless args[:email]
+
+    user = User.find_by(email: args[:email]) || abort('User not found')
+    user.update(deactivated_at: nil)
+
+    puts "User email: #{user.email} reactivated"
   end
 end

--- a/spec/lib/tasks/user_spec.rb
+++ b/spec/lib/tasks/user_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+describe 'user:', type: :task do
+  before do
+    Rails.application.load_tasks if Rake::Task.tasks.empty?
+  end
+
+  describe 'deactivate' do
+    subject(:run) do
+      Rake::Task['user:deactivate'].execute(arguments)
+    end
+
+    let(:user) { create(:caseworker, email: 'active-cw@test.com') }
+    let(:arguments) { Rake::TaskArguments.new [:email], [user.email] }
+    let(:expected_output) { "User email: #{user.email} deactivated at 2024-12-19 12:00:00 UTC\n" }
+
+    after { Rake::Task['user:deactivate'].reenable }
+
+    it 'calls the service' do
+      travel_to Time.zone.local(2024, 12, 19, 12) do
+        expect { run }.to output(expected_output).to_stdout
+      end
+    end
+
+    it 'sets activated_at to time' do
+      travel_to Time.zone.local(2024, 12, 19, 12) do
+        expect { run }.to change { user.reload.deactivated_at }
+          .from(nil).to(Time.zone.local(2024, 12, 19, 12))
+      end
+    end
+  end
+
+  describe 'reactivate' do
+    subject(:run) do
+      Rake::Task['user:reactivate'].execute(arguments)
+    end
+
+    let(:user) { create(:caseworker, :deactivated, email: 'deactivate-cw@test.com') }
+    let(:arguments) { Rake::TaskArguments.new [:email], [user.email] }
+    let(:expected_output) { "User email: #{user.email} reactivated\n" }
+
+    after { Rake::Task['user:reactivate'].reenable }
+
+    it 'calls the service' do
+      expect { run }.to output(expected_output).to_stdout
+    end
+
+    it 'sets activated_at to nil' do
+      travel_to Time.zone.local(2024, 12, 19, 12) do
+        expect { run }.to change { user.reload.deactivated_at }
+          .from(Time.zone.local(2024, 12, 19, 12)).to(nil)
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -80,6 +80,7 @@ RSpec.configure do |config|
   end
 
   # swallow sdtdout to keep output from rspec clean
+  # ...also swallows/hangs debug output sessions
   config.before(:each, type: :task) do
     allow($stdout).to receive(:write)
   end


### PR DESCRIPTION
## Description of change

add a task to deactivate/reactivate users
 
deactivate a user`rake user:deactivate[email: test@test.com]`

reactivate a user `rake user:reactivate[email: test@test.com]`

confluence doc https://dsdmoj.atlassian.net/wiki/spaces/CRM457/pages/5354160130/Off-boarding+caseworkers+in+Users+in+Production+Environment

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2147)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
