### PR TITLE
CRM457-2416: Add GDPR delete documents event to claim history

### DIFF
--- a/app/models/event/gdpr_documents_deleted.rb
+++ b/app/models/event/gdpr_documents_deleted.rb
@@ -1,0 +1,13 @@
+class Event
+  class GdprDocumentsDeleted < Event
+    def self.construct(submission:)
+      new(
+        submission_version: submission.current_version,
+      )
+    end
+
+    def body
+      t('body')
+    end
+  end
+end

--- a/config/locales/en/events.yml
+++ b/config/locales/en/events.yml
@@ -31,3 +31,6 @@ en:
     title: Caseworker deleted all adjustments
   event/expiry:
     title: Claim expired
+  event/gdpr_documents_deleted:
+    title: Uploads deleted
+    body: Uploads are deleted after 6 months to keep provider data safe

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -98,5 +98,14 @@ FactoryBot.define do
         }
       end
     end
+
+    trait :gdpr_documents_deleted do
+      initialize_with { Event::GdprDocumentsDeleted.new(attributes) }
+      details do
+        {
+          comment: 'Docs deleted',
+        }
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2416)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

![Screenshot 2025-02-04 at 10 43 12](https://github.com/user-attachments/assets/fd406e5f-6d8c-427f-992a-01963d06eaf1)


## How to manually test the feature
