### PR TITLE
CRM457-2422 Incorrect display of disbursement VAT rate

### DIFF
--- a/app/view_models/nsm/v1/disbursement.rb
+++ b/app/view_models/nsm/v1/disbursement.rb
@@ -66,7 +66,7 @@ module Nsm
         table_fields[:item_rate] = NumberTo.pounds(pricing) if miles.present?
         table_fields[:miles] = (miles_original || miles).to_s if miles_original.present? || miles.present?
         table_fields[:prior_authority] = prior_authority.capitalize if prior_authority
-        table_fields[:vat] = format_vat_rate
+        table_fields[:vat] = format_vat_rate(original: true)
         table_fields[:net_cost] = NumberTo.pounds(calculation[:claimed_total_exc_vat])
         table_fields[:vat_amount] = NumberTo.pounds(original_vat_amount)
         table_fields[:total] = NumberTo.pounds(provider_requested_total_cost)
@@ -93,8 +93,14 @@ module Nsm
         submission.rates.disbursements[disbursement_type.value.to_sym]
       end
 
-      def format_vat_rate
+      def format_vat_rate(original: false)
+        return '0%' unless applicable_vat(original:) == 'true'
+
         "#{(vat_rate * 100).to_i}%"
+      end
+
+      def applicable_vat(original: false)
+        original ? (apply_vat_original.presence || apply_vat) : apply_vat
       end
 
       def vat_rate

--- a/spec/system/nsm/disbursements_spec.rb
+++ b/spec/system/nsm/disbursements_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe 'Disbursements', :stub_oauth_token, type: :system do
         .and have_content("#{t('nsm.disbursements.show.summary_table.date')}12 December 2022")
         .and have_content("#{t('nsm.disbursements.show.summary_table.details')}Details")
         .and have_content("#{t('nsm.disbursements.show.summary_table.prior_authority')}Yes")
-        .and have_content("#{t('nsm.disbursements.show.summary_table.vat')}20%")
+        .and have_content("#{t('nsm.disbursements.show.summary_table.vat')}0%")
         .and have_content("#{t('nsm.disbursements.show.summary_table.total')}£100.00")
     end
   end

--- a/spec/view_models/nsm/v1/disbursement_spec.rb
+++ b/spec/view_models/nsm/v1/disbursement_spec.rb
@@ -409,83 +409,83 @@ RSpec.describe Nsm::V1::Disbursement do
   end
 
   describe '#format_vat_rate' do
-  let(:args) do
-    {
-      'apply_vat' => apply_vat,
-      'apply_vat_original' => apply_vat_original,
-      :submission => build(:claim)
-    }
-  end
-
-  context 'with current VAT settings' do
-    let(:apply_vat) { 'true' }
-    let(:apply_vat_original) { nil }
-
-    it 'returns formatted VAT rate when VAT is applicable' do
-      expect(disbursement.format_vat_rate).to eq('20%')
+    let(:args) do
+      {
+        'apply_vat' => apply_vat,
+        'apply_vat_original' => apply_vat_original,
+        :submission => build(:claim)
+      }
     end
 
-    context 'when VAT is not applicable' do
-      let(:apply_vat) { 'false' }
-
-      it 'returns 0% when VAT is not applicable' do
-        expect(disbursement.format_vat_rate).to eq('0%')
-      end
-    end
-  end
-
-  context 'with original VAT settings' do
-    let(:apply_vat) { 'false' }
-    let(:apply_vat_original) { 'true' }
-
-    it 'returns original VAT rate when original VAT was applicable' do
-      expect(disbursement.format_vat_rate(original: true)).to eq('20%')
-    end
-
-    context 'when original VAT is not applicable' do
-      let(:apply_vat_original) { 'false' }
-
-      it 'returns 0% when original VAT was not applicable' do
-        expect(disbursement.format_vat_rate(original: true)).to eq('0%')
-      end
-    end
-
-    context 'when original VAT setting is missing' do
+    context 'with current VAT settings' do
       let(:apply_vat) { 'true' }
       let(:apply_vat_original) { nil }
 
-      it 'falls back to current VAT setting' do
+      it 'returns formatted VAT rate when VAT is applicable' do
+        expect(disbursement.format_vat_rate).to eq('20%')
+      end
+
+      context 'when VAT is not applicable' do
+        let(:apply_vat) { 'false' }
+
+        it 'returns 0% when VAT is not applicable' do
+          expect(disbursement.format_vat_rate).to eq('0%')
+        end
+      end
+    end
+
+    context 'with original VAT settings' do
+      let(:apply_vat) { 'false' }
+      let(:apply_vat_original) { 'true' }
+
+      it 'returns original VAT rate when original VAT was applicable' do
         expect(disbursement.format_vat_rate(original: true)).to eq('20%')
+      end
+
+      context 'when original VAT is not applicable' do
+        let(:apply_vat_original) { 'false' }
+
+        it 'returns 0% when original VAT was not applicable' do
+          expect(disbursement.format_vat_rate(original: true)).to eq('0%')
+        end
+      end
+
+      context 'when original VAT setting is missing' do
+        let(:apply_vat) { 'true' }
+        let(:apply_vat_original) { nil }
+
+        it 'falls back to current VAT setting' do
+          expect(disbursement.format_vat_rate(original: true)).to eq('20%')
+        end
       end
     end
   end
-end
 
-describe '#applicable_vat' do
-  let(:args) do
-    {
-      'apply_vat' => apply_vat,
-      'apply_vat_original' => apply_vat_original
-    }
-  end
+  describe '#applicable_vat' do
+    let(:args) do
+      {
+        'apply_vat' => apply_vat,
+        'apply_vat_original' => apply_vat_original
+      }
+    end
 
-  let(:apply_vat) { 'true' }
-  let(:apply_vat_original) { 'false' }
+    let(:apply_vat) { 'true' }
+    let(:apply_vat_original) { 'false' }
 
-  it 'returns current VAT setting when original flag is false' do
-    expect(disbursement.applicable_vat).to eq('true')
-  end
+    it 'returns current VAT setting when original flag is false' do
+      expect(disbursement.applicable_vat).to eq('true')
+    end
 
-  it 'returns original VAT setting when original flag is true' do
-    expect(disbursement.applicable_vat(original: true)).to eq('false')
-  end
+    it 'returns original VAT setting when original flag is true' do
+      expect(disbursement.applicable_vat(original: true)).to eq('false')
+    end
 
-  context 'when original VAT setting is missing' do
-    let(:apply_vat_original) { nil }
+    context 'when original VAT setting is missing' do
+      let(:apply_vat_original) { nil }
 
-    it 'falls back to current VAT setting' do
-      expect(disbursement.applicable_vat(original: true)).to eq('true')
+      it 'falls back to current VAT setting' do
+        expect(disbursement.applicable_vat(original: true)).to eq('true')
+      end
     end
   end
-end
 end

--- a/spec/view_models/nsm/v1/disbursement_spec.rb
+++ b/spec/view_models/nsm/v1/disbursement_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Nsm::V1::Disbursement do
           details: 'Details',
           net_cost: '£83.30',
           prior_authority: 'Yes',
-          vat: '20%',
+          vat: '0%',
           vat_amount: '£0.00',
           total: '£83.30'
         }
@@ -244,7 +244,7 @@ RSpec.describe Nsm::V1::Disbursement do
 
       it 'returns a hash with zero VAT amount' do
         expected_fields = {
-          vat: '20%',
+          vat: '0%',
           vat_amount: '£0.00',
           net_cost: '£83.30',
           total: '£83.30'
@@ -407,4 +407,85 @@ RSpec.describe Nsm::V1::Disbursement do
       it { is_expected.to be false }
     end
   end
+
+  describe '#format_vat_rate' do
+  let(:args) do
+    {
+      'apply_vat' => apply_vat,
+      'apply_vat_original' => apply_vat_original,
+      :submission => build(:claim)
+    }
+  end
+
+  context 'with current VAT settings' do
+    let(:apply_vat) { 'true' }
+    let(:apply_vat_original) { nil }
+
+    it 'returns formatted VAT rate when VAT is applicable' do
+      expect(disbursement.format_vat_rate).to eq('20%')
+    end
+
+    context 'when VAT is not applicable' do
+      let(:apply_vat) { 'false' }
+
+      it 'returns 0% when VAT is not applicable' do
+        expect(disbursement.format_vat_rate).to eq('0%')
+      end
+    end
+  end
+
+  context 'with original VAT settings' do
+    let(:apply_vat) { 'false' }
+    let(:apply_vat_original) { 'true' }
+
+    it 'returns original VAT rate when original VAT was applicable' do
+      expect(disbursement.format_vat_rate(original: true)).to eq('20%')
+    end
+
+    context 'when original VAT is not applicable' do
+      let(:apply_vat_original) { 'false' }
+
+      it 'returns 0% when original VAT was not applicable' do
+        expect(disbursement.format_vat_rate(original: true)).to eq('0%')
+      end
+    end
+
+    context 'when original VAT setting is missing' do
+      let(:apply_vat) { 'true' }
+      let(:apply_vat_original) { nil }
+
+      it 'falls back to current VAT setting' do
+        expect(disbursement.format_vat_rate(original: true)).to eq('20%')
+      end
+    end
+  end
+end
+
+describe '#applicable_vat' do
+  let(:args) do
+    {
+      'apply_vat' => apply_vat,
+      'apply_vat_original' => apply_vat_original
+    }
+  end
+
+  let(:apply_vat) { 'true' }
+  let(:apply_vat_original) { 'false' }
+
+  it 'returns current VAT setting when original flag is false' do
+    expect(disbursement.applicable_vat).to eq('true')
+  end
+
+  it 'returns original VAT setting when original flag is true' do
+    expect(disbursement.applicable_vat(original: true)).to eq('false')
+  end
+
+  context 'when original VAT setting is missing' do
+    let(:apply_vat_original) { nil }
+
+    it 'falls back to current VAT setting' do
+      expect(disbursement.applicable_vat(original: true)).to eq('true')
+    end
+  end
+end
 end


### PR DESCRIPTION
## Description of change
This pull request introduces changes to the `app/view_models/nsm/v1/disbursement.rb` file to improve the handling of VAT rates, as well as updates to the corresponding test files to ensure proper validation of the new functionality.

### Improvements to VAT rate handling:

* [`app/view_models/nsm/v1/disbursement.rb`](diffhunk://#diff-620a1b52b7cf76cb0a718be014d360b5e323004dd3e9dff0097e33c5fa98aab4L69-R69): Modified the `format_vat_rate` method to accept an `original` parameter and added the `applicable_vat` method to determine the applicable VAT rate based on the `original` flag. [[1]](diffhunk://#diff-620a1b52b7cf76cb0a718be014d360b5e323004dd3e9dff0097e33c5fa98aab4L69-R69) [[2]](diffhunk://#diff-620a1b52b7cf76cb0a718be014d360b5e323004dd3e9dff0097e33c5fa98aab4L96-R105)

### Updates to test files:

* [`spec/system/nsm/disbursements_spec.rb`](diffhunk://#diff-9fb29355c9383523fabd3718c958e3472101f532a94b80c2da568211f80c1083L92-R92): Updated the test to reflect the new VAT rate formatting, changing the expected VAT rate from `20%` to `0%`.
* [`spec/view_models/nsm/v1/disbursement_spec.rb`](diffhunk://#diff-e356627f99c43638d9f06715b3757a78d5895811c6c76777eacdbdcf26627146L129-R129): Updated multiple tests to reflect the new VAT rate formatting, changing the expected VAT rate from `20%` to `0%`. Added new tests for the `format_vat_rate` and `applicable_vat` methods to ensure proper functionality.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2422)