### PR TITLE
Enable logging for failed app store client calls

### DIFF
--- a/app/services/app_store_client.rb
+++ b/app/services/app_store_client.rb
@@ -8,7 +8,7 @@ class AppStoreClient
 
     process_response(
       response,
-      "Unexpected response from AppStore - status #{response.code} for '#{url}'",
+      "Unexpected response from AppStore - status #{response.code} for '#{url}'\n#{response.inspect}",
       200 => ->(body) { JSON.parse(body) },
     )
   end


### PR DESCRIPTION
## Description of change

Temporarily log the failed responses to get an idea of what's failing

[Link to relevant discussion](https://mojdt.slack.com/archives/C05212WRK5J/p1743431573698979)