### PR TITLE
CRM457-2546: Reset Send Back Comment on Make Decision Form Submission

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,7 +288,7 @@ GEM
     msgpack (1.7.2)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
-    net-http (0.6.0)
+    net-http (0.4.1)
       uri
     net-imap (0.5.6)
       date

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,7 +288,7 @@ GEM
     msgpack (1.7.2)
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
-    net-http (0.4.1)
+    net-http (0.6.0)
       uri
     net-imap (0.5.6)
       date
@@ -678,4 +678,4 @@ RUBY VERSION
    ruby 3.4.2
 
 BUNDLED WITH
-   2.5.11
+   2.6.7

--- a/app/forms/nsm/make_decision_form.rb
+++ b/app/forms/nsm/make_decision_form.rb
@@ -43,7 +43,12 @@ module Nsm
       persist_form_values
       previous_state = claim.state
 
-      claim.data.merge!('status' => state, 'updated_at' => Time.current, 'assessment_comment' => comment)
+      claim.data.merge!(
+        'status' => state,
+        'updated_at' => Time.current,
+        'assessment_comment' => comment,
+        'send_back_comment' => nil
+      )
       claim.state = state
       ::Event::Decision.build(submission: claim,
                               comment: comment,

--- a/spec/forms/nsm/make_decision_form_spec.rb
+++ b/spec/forms/nsm/make_decision_form_spec.rb
@@ -228,9 +228,10 @@ RSpec.describe Nsm::MakeDecisionForm do
   describe '#save' do
     let(:user) { instance_double(User) }
     let(:claim) { build(:claim, data:) }
-    let(:data) { build(:nsm_data, send_back_comment: send_back_comment) }
+    let(:data) { build(:nsm_data, send_back_comment:) }
     let(:params) { { claim: claim, state: 'part_grant', partial_comment: 'part comment', current_user: user } }
     let(:send_back_comment) { nil }
+
     before do
       claim.data['work_items'].first['time_spent_original'] = claim.data['work_items'].first['time_spent']
       claim.data['work_items'].first['time_spent'] -= 1
@@ -271,7 +272,7 @@ RSpec.describe Nsm::MakeDecisionForm do
       let(:send_back_comment) { 'garbage' }
 
       it 'resets the send_back_comment field to nil' do
-        expect { form.save }.to change{claim.data['send_back_comment']}.from(send_back_comment).to(nil)
+        expect { form.save }.to change { claim.data['send_back_comment'] }.from(send_back_comment).to(nil)
       end
 
       it { expect(form.save).to be_truthy }

--- a/spec/forms/nsm/make_decision_form_spec.rb
+++ b/spec/forms/nsm/make_decision_form_spec.rb
@@ -228,9 +228,9 @@ RSpec.describe Nsm::MakeDecisionForm do
   describe '#save' do
     let(:user) { instance_double(User) }
     let(:claim) { build(:claim, data:) }
-    let(:data) { build(:nsm_data) }
+    let(:data) { build(:nsm_data, send_back_comment: send_back_comment) }
     let(:params) { { claim: claim, state: 'part_grant', partial_comment: 'part comment', current_user: user } }
-
+    let(:send_back_comment) { nil }
     before do
       claim.data['work_items'].first['time_spent_original'] = claim.data['work_items'].first['time_spent']
       claim.data['work_items'].first['time_spent'] -= 1
@@ -265,6 +265,16 @@ RSpec.describe Nsm::MakeDecisionForm do
       let(:params) { { claim: } }
 
       it { expect(form.save).to be_falsey }
+    end
+
+    context 'when send back form has previously been started' do
+      let(:send_back_comment) { 'garbage' }
+
+      it 'resets the send_back_comment field to nil' do
+        expect { form.save }.to change{claim.data['send_back_comment']}.from(send_back_comment).to(nil)
+      end
+
+      it { expect(form.save).to be_truthy }
     end
   end
 


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2546)

## Notes for reviewer

- Sets send_back_comment to nil before submitting decision to app store (subsequently to provider)
- Fixes invalid app store entry bug that occurs when using "Save and Come Back Later" on Send Back To Provider form and then making a decision

## Screenshots of changes (if applicable)

## How to manually test the feature
See reproduction steps in ticket
