### PR TITLE
Add a user management UI

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,50 @@
+class UsersController < ApplicationController
+  before_action :authorize_supervisor
+  before_action :set_default_table_sort_options, only: %i[show]
+
+  DEFAULT_SORT = 'name'.freeze
+
+  def show
+    pagy, records = pagy_array(users)
+
+    render :index, locals: { pagy: pagy, users: records }
+  end
+
+  private
+
+  def users
+    direction = @sort_direction == 'descending' ? :desc : :asc
+    case @sort_by
+    when 'name'
+      User.order(first_name: direction, last_name: direction)
+    when 'role'
+      User.joins(:roles)
+          .select('users.*, roles.role_type')
+          .distinct
+          .order("roles.role_type #{direction}")
+    else
+      User.order(params[:sort_by] => direction)
+    end
+  end
+
+  def authorize_supervisor
+    authorize :dashboard, :show?
+  end
+
+  def controller_params
+    params.permit(
+      :sort_by,
+      :sort_direction,
+      :page
+    )
+  end
+
+  def param_validator
+    @param_validator ||= UsersParams.new(controller_params)
+  end
+
+  def set_default_table_sort_options
+    @sort_by = controller_params.fetch(:sort_by, DEFAULT_SORT)
+    @sort_direction = controller_params.fetch(:sort_direction, 'descending')
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,41 +1,84 @@
 class UsersController < ApplicationController
   before_action :authorize_supervisor
-  before_action :set_default_table_sort_options, only: %i[show]
+  before_action :set_default_table_sort_options, only: %i[index]
 
   DEFAULT_SORT = 'name'.freeze
 
-  def show
-    pagy, records = pagy_array(users)
+  def index
+    pagy, users = pagy_array(sorted_users)
 
-    render :index, locals: { pagy: pagy, users: records }
+    render :index, locals: { pagy:, users: }
+  end
+
+  def new
+    @form_object = UserForm.new
+  end
+
+  def edit
+    @user = User.find(controller_params['id'])
+    user = @user.attributes.slice('first_name', 'last_name', 'email')
+    role = @user.roles.first
+    @form_object = UserForm.new(user.merge({ role_type: role.role_type,
+                                             caseworker_service: role.service,
+                                             viewer_service: role.service }))
+  end
+
+  def create
+    @form_object = UserForm.new(form_params)
+
+    if @form_object.save
+      redirect_to users_path
+    else
+      render :new
+    end
+  end
+
+  def update
+    user = User.find(controller_params['id'])
+    @form_object = UserForm.new(form_params.merge({ id: user.id, email: user.email }))
+
+    if @form_object.save
+      redirect_to users_path
+    else
+      render :edit
+    end
   end
 
   private
 
-  def users
+  def sorted_users
     direction = @sort_direction == 'descending' ? :desc : :asc
     case @sort_by
     when 'name'
       User.order(first_name: direction, last_name: direction)
     when 'role'
-      User.joins(:roles)
-          .select('users.*, roles.role_type')
-          .distinct
-          .order("roles.role_type #{direction}")
+      User.includes(:roles).order(roles: { role_type: direction })
     else
       User.order(params[:sort_by] => direction)
     end
   end
 
   def authorize_supervisor
-    authorize :dashboard, :show?
+    authorize :user_management, :show?
   end
 
   def controller_params
     params.permit(
+      :id,
       :sort_by,
       :sort_direction,
       :page
+    )
+  end
+
+  def form_params
+    params.expect(
+      user_form: [:first_name,
+                  :last_name,
+                  :email,
+                  :role_type,
+                  :caseworker_service,
+                  :viewer_service],
     )
   end
 
@@ -45,6 +88,6 @@ class UsersController < ApplicationController
 
   def set_default_table_sort_options
     @sort_by = controller_params.fetch(:sort_by, DEFAULT_SORT)
-    @sort_direction = controller_params.fetch(:sort_direction, 'descending')
+    @sort_direction = controller_params.fetch(:sort_direction, 'ascending')
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,7 +18,13 @@ class UsersController < ApplicationController
     @user = User.find(controller_params['id'])
     user = @user.attributes.slice('first_name', 'last_name', 'email')
     role = @user.roles.first
-    @form_object = UserForm.new(user.merge({ role_type: role&.role_type || 'none',
+    role_type = if role.nil? || @user.deactivated_at.present?
+                  'none'
+                else
+                  role.role_type
+                end
+
+    @form_object = UserForm.new(user.merge({ role_type: role_type,
                                              caseworker_service: role&.service,
                                              viewer_service: role&.service }))
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -53,6 +53,8 @@ class UsersController < ApplicationController
       User.order(first_name: direction, last_name: direction)
     when 'role'
       User.includes(:roles).order(roles: { role_type: direction })
+    when 'service'
+      User.includes(:roles).order(roles: { service: direction })
     else
       User.order(params[:sort_by] => direction)
     end
@@ -72,13 +74,16 @@ class UsersController < ApplicationController
   end
 
   def form_params
+    allowed_params = [:first_name,
+                      :last_name,
+                      :role_type,
+                      :caseworker_service,
+                      :viewer_service]
+
+    allowed_params << :email unless action_name == 'update'
+
     params.expect(
-      user_form: [:first_name,
-                  :last_name,
-                  :email,
-                  :role_type,
-                  :caseworker_service,
-                  :viewer_service],
+      user_form: allowed_params,
     )
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,9 +18,9 @@ class UsersController < ApplicationController
     @user = User.find(controller_params['id'])
     user = @user.attributes.slice('first_name', 'last_name', 'email')
     role = @user.roles.first
-    @form_object = UserForm.new(user.merge({ role_type: role.role_type,
-                                             caseworker_service: role.service,
-                                             viewer_service: role.service }))
+    @form_object = UserForm.new(user.merge({ role_type: role&.role_type || 'none',
+                                             caseworker_service: role&.service,
+                                             viewer_service: role&.service }))
   end
 
   def create

--- a/app/forms/user_form.rb
+++ b/app/forms/user_form.rb
@@ -31,13 +31,7 @@ class UserForm
   private
 
   def create_user
-    user = User.create(
-      first_name: first_name,
-      last_name: last_name,
-      email: email,
-      auth_oid: SecureRandom.uuid,
-      roles: [Role.new(role_type:, service:)]
-    )
+    user = User.create(user_params)
 
     return true if user.errors.empty?
 
@@ -47,13 +41,18 @@ class UserForm
   end
 
   def update_user
-    User.find(id).update!(
+    User.find(id).update!(user_params)
+  end
+
+  def user_params
+    {
       first_name: first_name,
       last_name: last_name,
       email: email,
+      auth_oid: SecureRandom.uuid,
       roles: role_type == 'none' ? [] : [Role.new(role_type:, service:)],
       deactivated_at: (DateTime.now if role_type == 'none')
-    )
+    }
   end
 
   def service

--- a/app/forms/user_form.rb
+++ b/app/forms/user_form.rb
@@ -14,7 +14,7 @@ class UserForm
   validates :first_name, presence: true
   validates :last_name, presence: true
   validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
-  validates :role_type, presence: true, inclusion: { in: Role::ROLE_TYPES }
+  validates :role_type, presence: true, inclusion: { in: (Role::ROLE_TYPES + ['none']) }
   validates :caseworker_service, inclusion: { in: Role.services, allow_nil: true }
   validates :viewer_service, inclusion: { in: Role.services, allow_nil: true }
 
@@ -47,10 +47,13 @@ class UserForm
   end
 
   def update_user
-    User.find(id).update!(first_name: first_name,
-                          last_name: last_name,
-                          email: email,
-                          roles: [Role.new(role_type:, service:)])
+    User.find(id).update!(
+      first_name: first_name,
+      last_name: last_name,
+      email: email,
+      roles: role_type == 'none' ? [] : [Role.new(role_type:, service:)],
+      deactivated_at: (DateTime.now if role_type == 'none')
+    )
   end
 
   def service

--- a/app/forms/user_form.rb
+++ b/app/forms/user_form.rb
@@ -1,0 +1,60 @@
+class UserForm
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveRecord::AttributeAssignment
+
+  attribute :id
+  attribute :first_name
+  attribute :last_name
+  attribute :email
+  attribute :role_type
+  attribute :caseworker_service
+  attribute :viewer_service
+
+  validates :first_name, presence: true
+  validates :last_name, presence: true
+  validates :email, presence: true, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :role_type, presence: true, inclusion: { in: Role::ROLE_TYPES }
+  validates :caseworker_service, inclusion: { in: Role.services, allow_nil: true }
+  validates :viewer_service, inclusion: { in: Role.services, allow_nil: true }
+
+  def save
+    return false unless valid?
+
+    if id.nil?
+      create_user
+    else
+      update_user
+    end
+  end
+
+  private
+
+  def create_user
+    User.create!(
+      first_name: first_name,
+      last_name: last_name,
+      email: email,
+      auth_oid: SecureRandom.uuid,
+      roles: [Role.new(role_type:, service:)]
+    )
+  end
+
+  def update_user
+    User.find(id).update!(first_name: first_name,
+                          last_name: last_name,
+                          email: email,
+                          roles: [Role.new(role_type:, service:)])
+  end
+
+  def service
+    case role_type
+    when 'caseworker'
+      caseworker_service
+    when 'viewer'
+      viewer_service
+    else
+      'all'
+    end
+  end
+end

--- a/app/forms/user_form.rb
+++ b/app/forms/user_form.rb
@@ -31,13 +31,19 @@ class UserForm
   private
 
   def create_user
-    User.create!(
+    user = User.create(
       first_name: first_name,
       last_name: last_name,
       email: email,
       auth_oid: SecureRandom.uuid,
       roles: [Role.new(role_type:, service:)]
     )
+
+    return true if user.errors.empty?
+
+    user.errors.map { |error| errors.add(error.attribute.to_sym, error.type.to_sym) }
+
+    false
   end
 
   def update_user

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -12,4 +12,6 @@ class Role < ApplicationRecord
   scope :caseworker, -> { where(role_type: CASEWORKER) }
   scope :supervisor, -> { where(role_type: SUPERVISOR) }
   scope :viewer, -> { where(role_type: VIEWER) }
+
+  enum :service, { pa: 'pa', nsm: 'nsm', all: 'all' }, prefix: true
 end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -14,4 +14,7 @@ class Role < ApplicationRecord
   scope :viewer, -> { where(role_type: VIEWER) }
 
   enum :service, { pa: 'pa', nsm: 'nsm', all: 'all' }, prefix: true
+
+  scope :pa_access, -> { where(service: %w[pa all]) }
+  scope :nsm_access, -> { where(service: %w[nsm all]) }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,7 +13,7 @@ class User < ApplicationRecord
   scope :pending_activation, -> { where(auth_subject_id: nil, deactivated_at: nil) }
 
   def display_name
-    "#{first_name.capitalize} #{last_name.capitalize}"
+    "#{first_name} #{last_name}"
   end
 
   def supervisor?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,6 @@
 class User < ApplicationRecord
   DummyUser = Struct.new(:display_name)
-
+  validates :email, uniqueness: true
   has_many :access_logs, dependent: :destroy
   has_many :roles, dependent: :destroy
 
@@ -13,7 +13,7 @@ class User < ApplicationRecord
   scope :pending_activation, -> { where(auth_subject_id: nil, deactivated_at: nil) }
 
   def display_name
-    "#{first_name} #{last_name}"
+    "#{first_name.capitalize} #{last_name.capitalize}"
   end
 
   def supervisor?

--- a/app/param_validators/users_params.rb
+++ b/app/param_validators/users_params.rb
@@ -1,0 +1,12 @@
+class UsersParams < BaseParamValidator
+  attribute :id, :string
+  attribute :sort_by, :string
+  attribute :sort_direction, :string
+  attribute :page, :integer
+
+  validates :sort_by, inclusion: { in: %w[name email role service] },
+allow_nil: true
+  validates :sort_direction, inclusion: { in: %w[ascending descending] }, allow_nil: true
+  validates :page, numericality: { greater_than: 0 }, allow_nil: true
+  validates :id, is_a_uuid: true, allow_nil: true
+end

--- a/app/policies/claim_policy.rb
+++ b/app/policies/claim_policy.rb
@@ -1,25 +1,31 @@
 class ClaimPolicy < ApplicationPolicy
   def update?
-    !record.closed? && record.assigned_user_id == user.id
+    service_access? && !record.closed? && record.assigned_user_id == user.id
   end
 
   def unassign?
-    !record.closed? && record.assigned_user_id.present? && !user.viewer?
+    service_access? && !record.closed? && record.assigned_user_id.present? && !user.viewer?
   end
 
   def self_assign?
-    assign? && !record.closed? && record.assigned_user_id.nil?
+    service_access? && assign? && !record.closed? && record.assigned_user_id.nil?
   end
 
   def assign?
-    !user.viewer?
+    service_access? && !user.viewer?
   end
 
   def index?
-    true
+    service_access?
   end
 
   def show?
-    true
+    service_access?
+  end
+
+  private
+
+  def service_access?
+    user.roles.nsm_access.any?
   end
 end

--- a/app/policies/prior_authority_application_policy.rb
+++ b/app/policies/prior_authority_application_policy.rb
@@ -1,31 +1,35 @@
 class PriorAuthorityApplicationPolicy < ApplicationPolicy
   def unassign?
-    assessable? && record.assigned_user_id.present? && !user.viewer?
+    service_access? && assessable? && record.assigned_user_id.present? && !user.viewer?
   end
 
   def self_assign?
-    assign? && assessable? && record.assigned_user_id.nil?
+    service_access? && assign? && assessable? && record.assigned_user_id.nil?
   end
 
   def update?
-    assessable? && record.assigned_user_id == user.id && !user.viewer?
+    service_access? && assessable? && record.assigned_user_id == user.id && !user.viewer?
   end
 
   def assign?
-    !user.viewer?
+    service_access? && !user.viewer?
   end
 
   def index?
-    true
+    service_access?
   end
 
   def show?
-    true
+    service_access?
   end
 
   private
 
   def assessable?
     record.state.in?(PriorAuthorityApplication::ASSESSABLE_STATES)
+  end
+
+  def service_access?
+    user.roles.pa_access.any?
   end
 end

--- a/app/policies/user_management_policy.rb
+++ b/app/policies/user_management_policy.rb
@@ -1,0 +1,5 @@
+class UserManagementPolicy < ApplicationPolicy
+  def show?
+    user.supervisor?
+  end
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -19,7 +19,7 @@
         <%= link_to t('.analytics'), new_dashboard_path, class: 'govuk-link--no-visited-state' %>
       </p>
     <% end %>
-    <% if policy(:dashboard).show?  %>
+    <% if policy(:user_management).show?  %>
         <p>
             <%= link_to t('.user_management'), users_path, class: 'govuk-link--no-visited-state' %>
         </p>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,28 +1,32 @@
 <% title t('assess_a_crime_form.service_name') %>
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">
-      <%= t('assess_a_crime_form.service_name') %>
-    </h1>
-  </div>
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">
+            <%= t('assess_a_crime_form.service_name') %>
+        </h1>
+    </div>
 </div>
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
-    <p>
-      <%= link_to(t('.prior_authority'), prior_authority_root_path, class: 'govuk-link--no-visited-state') %>
-    </p>
-    <p>
-      <%= link_to(t('.nsm'), nsm_root_path, class: 'govuk-link--no-visited-state') %>
-    </p>
-    <% if policy(:dashboard).show? && FeatureFlags.insights.enabled? %>
-      <p>
-        <%= link_to t('.analytics'), new_dashboard_path, class: 'govuk-link--no-visited-state' %>
-      </p>
-    <% end %>
-    <% if policy(:user_management).show?  %>
-        <p>
-            <%= link_to t('.user_management'), users_path, class: 'govuk-link--no-visited-state' %>
-        </p>
-    <% end %>
-  </div>
+    <div class="govuk-grid-column-two-thirds">
+        <% if policy(:prior_authority_application).show?  %>
+            <p>
+                <%= link_to(t('.prior_authority'), prior_authority_root_path, class: 'govuk-link--no-visited-state') %>
+            </p>
+        <% end %>
+        <% if policy(:claim).show?  %>
+            <p>
+                <%= link_to(t('.nsm'), nsm_root_path, class: 'govuk-link--no-visited-state') %>
+            </p>
+        <% end %>
+        <% if policy(:dashboard).show? && FeatureFlags.insights.enabled? %>
+            <p>
+                <%= link_to t('.analytics'), new_dashboard_path, class: 'govuk-link--no-visited-state' %>
+            </p>
+        <% end %>
+        <% if policy(:user_management).show?  %>
+            <p>
+                <%= link_to t('.user_management'), users_path, class: 'govuk-link--no-visited-state' %>
+            </p>
+        <% end %>
+    </div>
 </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -19,5 +19,10 @@
         <%= link_to t('.analytics'), new_dashboard_path, class: 'govuk-link--no-visited-state' %>
       </p>
     <% end %>
+    <% if policy(:dashboard).show?  %>
+        <p>
+            <%= link_to t('.user_management'), users_path, class: 'govuk-link--no-visited-state' %>
+        </p>
+    <% end %>
   </div>
 </div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,0 +1,59 @@
+<% url = method == :put ? user_path : users_path %>
+<% content_for(:back_link) do %>
+    <%=# Did we come from a page in the app?
+    has_referrer = @referrer.nil?
+
+    # Did we just reload the same page?
+    came_from_current_path =
+    url_for == url
+
+    link_to t("helpers.back_link"),
+     (
+         if has_referrer || came_from_current_path
+         @form_object.backlink_path(claim)
+         else
+         "#{@referrer}##{@form_object.id}"
+         end
+     ),
+     class: "govuk-back-link" %>
+<% end %>
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <%= govuk_error_summary(@form_object) %>
+        <h1 class="govuk-heading-xl">
+            <%= t('.page_title') %>
+        </h1>
+
+        <%= form_with(url: url, method: method, model: @form_object) do |f| %>
+            <%= f.govuk_text_field :first_name, label: { size: 's', text: t(".field.first_name") }, class: "govuk-input--width-20" %>
+            <%= f.govuk_text_field :last_name, label: { size: 's', text: t(".field.last_name") }, class: "govuk-input--width-20" %>
+            <% if method == :put %>
+                <p>
+                    <strong><%= t(".field.email") %></strong>
+                    <br/>
+                    <%= @user.email %>
+                </p>
+            <% else %>
+                <%= f.govuk_text_field :email, label: { size: 's', text: t(".field.email") }, class: "govuk-input--width-20" %>
+            <% end %>
+            <%= f.govuk_radio_buttons_fieldset :role_type, legend: { size: 's', text: t(".field.permissions") } do %>
+                <% (Role::ROLE_TYPES + ["none"]).each_with_index do |role, index| %>
+                    <%= f.govuk_radio_button :role_type, role.to_s, link_errors: index.zero?, label: { text: t(".field.#{role}.title") } do %>
+                        <% next if ["supervisor", "none"].include?(role) %>
+
+                        <%= f.govuk_radio_buttons_fieldset "#{role.to_s}_service".to_sym, legend: { size: 's', text: t("users.service.title") } do %>
+                            <% Role.services.keys.each_with_index do |service, index| %>
+                                <%= f.govuk_radio_button "#{role.to_s}_service".to_sym, service.to_s, link_errors: index.zero?, label: { text: t("users.service.#{service}") } %>
+                            <% end %>
+                        <% end %>
+                    <% end %>
+                <% end %>
+            <% end %>
+
+
+            <%= f.govuk_submit t('.save') %>
+
+        <% end %>
+    </div>
+</div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -39,7 +39,7 @@
             <% end %>
             <%= f.govuk_radio_buttons_fieldset :role_type, legend: { size: 's', text: t(".field.permissions") } do %>
                 <% (Role::ROLE_TYPES + ["none"]).each_with_index do |role, index| %>
-                    <%= f.govuk_radio_button :role_type, role.to_s, link_errors: index.zero?, label: { text: t(".field.#{role}.title") }, hint: { text: t(".field.#{role}.hint")} do %>
+                    <%= f.govuk_radio_button :role_type, role.to_s, link_errors: index.zero?, label: { text: t(".field.#{role}.title") }, hint: { text: t((".field.#{role}.hint" if role != 'none'))} do %>
                         <% next if ["supervisor", "none"].include?(role) %>
 
                         <%= f.govuk_radio_buttons_fieldset "#{role.to_s}_service".to_sym, legend: { size: 's', text: t("users.service.title") } do %>
@@ -47,6 +47,9 @@
                                 <%= f.govuk_radio_button "#{role.to_s}_service".to_sym, service.to_s, link_errors: index.zero?, label: { text: t("users.service.#{service}") } %>
                             <% end %>
                         <% end %>
+                    <% end %>
+                    <% if role == Role::ROLE_TYPES.last %>
+                        <div class="govuk-radios__divider">or</div>
                     <% end %>
                 <% end %>
             <% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -39,7 +39,7 @@
             <% end %>
             <%= f.govuk_radio_buttons_fieldset :role_type, legend: { size: 's', text: t(".field.permissions") } do %>
                 <% (Role::ROLE_TYPES + ["none"]).each_with_index do |role, index| %>
-                    <%= f.govuk_radio_button :role_type, role.to_s, link_errors: index.zero?, label: { text: t(".field.#{role}.title") } do %>
+                    <%= f.govuk_radio_button :role_type, role.to_s, link_errors: index.zero?, label: { text: t(".field.#{role}.title") }, hint: { text: t(".field.#{role}.hint")} do %>
                         <% next if ["supervisor", "none"].include?(role) %>
 
                         <%= f.govuk_radio_buttons_fieldset "#{role.to_s}_service".to_sym, legend: { size: 's', text: t("users.service.title") } do %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -10,7 +10,7 @@
     link_to t("helpers.back_link"),
      (
          if has_referrer || came_from_current_path
-         @form_object.backlink_path(claim)
+         users_path
          else
          "#{@referrer}##{@form_object.id}"
          end
@@ -32,7 +32,7 @@
                 <p>
                     <strong><%= t(".field.email") %></strong>
                     <br/>
-                    <%= @user.email %>
+                    <%= @form_object.email %>
                 </p>
             <% else %>
                 <%= f.govuk_text_field :email, label: { size: 's', text: t(".field.email") }, class: "govuk-input--width-20" %>

--- a/app/views/users/_service.html.erb
+++ b/app/views/users/_service.html.erb
@@ -1,0 +1,29 @@
+<div class="govuk-radios__conditional" id="conditional-role-<%= role %>">
+    <div class="govuk-form-group">
+        <fieldset class="govuk-fieldset">
+            <legend class="govuk-fieldset__legend">
+                <%= t(".title") %>
+            </legend>
+            <div class="govuk-radios" data-module="govuk-radios" data-govuk-radios-init="">
+                <div class="govuk-radios__item">
+                    <input class="govuk-radios__input" id="service" name="service" type="radio" value="All">
+                    <label class="govuk-label govuk-radios__label" for="service">
+                        <%= t(".all") %>
+                    </label>
+                </div>
+                <div class="govuk-radios__item">
+                    <input class="govuk-radios__input" id="service-2" name="service" type="radio" value="PA">
+                    <label class="govuk-label govuk-radios__label" for="service-2">
+                        <%= t(".pa") %>
+                    </label>
+                </div>
+                <div class="govuk-radios__item">
+                    <input class="govuk-radios__input" id="service-3" name="service" type="radio" value="NSM">
+                    <label class="govuk-label govuk-radios__label" for="service-3">
+                        <%= t(".nsm") %>
+                    </label>
+                </div>
+            </div>
+        </fieldset>
+    </div>
+</div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,3 @@
+<% title t('.page_title') %>
+
+<%= render partial: "form", locals: { method: :put } %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -70,7 +70,7 @@
                 </td>
                 <td class="govuk-table__cell">
                     <% if user.roles.any? %>
-                        <% service = user.roles.first.service %>
+                        <% service = user.roles.first.service || '-' %>
                         <% if service == "all" %>
                             <%= service.capitalize %>
                         <% else %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,62 @@
+<% title t('.page_title') %>
+<div class="moj-page-header-actions">
+  <div class="moj-page-header-actions__title">
+      <h1 class="govuk-heading-xl">
+          <%= t('.page_title') %>
+      </h1>
+  </div>
+
+  <div class="moj-page-header-actions__actions">
+    <div class="moj-button-group moj-button-group--inline">
+        <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+            <%= t('.add_new_user') %>
+        </button>
+    </div>
+  </div>
+</div>
+
+<table class="govuk-table" data-module="moj-sortable-table" aria-describedby="page-title">
+    <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+            <%= table_header_with_form("name",
+                                       "users.index.table",
+                                       0,
+                                       users_path,
+                                       @sort_by,
+                                       @sort_direction) %>
+
+
+            <%= table_header_with_form("email",
+                                       "users.index.table",
+                                       1,
+                                       users_path,
+                                       @sort_by,
+                                       @sort_direction) %>
+
+
+            <%= table_header_with_form("role",
+                                       "users.index.table",
+                                       2,
+                                       users_path,
+                                       @sort_by,
+                                       @sort_direction) %>
+        </tr>
+    </thead>
+
+    <tbody class="govuk-table__body app-task-list__items">
+        <% users.each do |user| %>
+            <tr class="govuk-table__row app-task-list__item">
+                <td class="govuk-table__cell">
+                    <%= user.first_name %> <%= user.last_name %>
+                </td>
+                <td class="govuk-table__cell">
+                    <%= user.email %>
+                </td>
+                <td class="govuk-table__cell">
+                    <%= user.roles.pluck(:role_type).join(',') %>
+                </td>
+            </tr>
+        <% end %>
+    </tbody>
+</table>
+<%= render 'shared/pagination', pagy: pagy, item: t(".users") %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -62,14 +62,22 @@
                     <%= user.email %>
                 </td>
                 <td class="govuk-table__cell">
-                    <%= user.roles.first.role_type.capitalize %>
+                    <% if user.roles.any? %>
+                        <%= user.roles.first.role_type.capitalize %>
+                    <% else %>
+                        <%= t('.no_role') %>
+                    <% end %>
                 </td>
                 <td class="govuk-table__cell">
-                    <% service = user.roles.first.service %>
-                    <% if service == "all" %>
-                        <%= service.capitalize %>
+                    <% if user.roles.any? %>
+                        <% service = user.roles.first.service %>
+                        <% if service == "all" %>
+                            <%= service.capitalize %>
+                        <% else %>
+                            <%= service.upcase %>
+                        <% end %>
                     <% else %>
-                        <%= service.upcase %>
+                        -
                     <% end %>
                 </td>
             </tr>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,18 +1,20 @@
 <% title t('.page_title') %>
 <div class="moj-page-header-actions">
-  <div class="moj-page-header-actions__title">
-      <h1 class="govuk-heading-xl">
-          <%= t('.page_title') %>
-      </h1>
-  </div>
-
-  <div class="moj-page-header-actions__actions">
-    <div class="moj-button-group moj-button-group--inline">
-        <button type="submit" class="govuk-button govuk-button--secondary" data-module="govuk-button">
-            <%= t('.add_new_user') %>
-        </button>
+    <div class="moj-page-header-actions__title">
+        <h1 class="govuk-heading-xl">
+            <%= t('.page_title') %>
+        </h1>
     </div>
-  </div>
+
+    <div class="moj-page-header-actions__actions">
+        <div class="moj-button-group moj-button-group--inline">
+            <%= govuk_button_link_to(
+                t(".add_new_user"),
+                new_user_path,
+                secondary: true
+            ) %>
+        </div>
+    </div>
 </div>
 
 <table class="govuk-table" data-module="moj-sortable-table" aria-describedby="page-title">
@@ -40,6 +42,13 @@
                                        users_path,
                                        @sort_by,
                                        @sort_direction) %>
+
+            <%= table_header_with_form("service",
+                                       "users.index.table",
+                                       3,
+                                       users_path,
+                                       @sort_by,
+                                       @sort_direction) %>
         </tr>
     </thead>
 
@@ -47,13 +56,21 @@
         <% users.each do |user| %>
             <tr class="govuk-table__row app-task-list__item">
                 <td class="govuk-table__cell">
-                    <%= user.first_name %> <%= user.last_name %>
+                    <%= govuk_link_to(user.display_name, edit_user_path(user.id)) %>
                 </td>
                 <td class="govuk-table__cell">
                     <%= user.email %>
                 </td>
                 <td class="govuk-table__cell">
-                    <%= user.roles.pluck(:role_type).join(',') %>
+                    <%= user.roles.first.role_type.capitalize %>
+                </td>
+                <td class="govuk-table__cell">
+                    <% service = user.roles.first.service %>
+                    <% if service == "all" %>
+                        <%= service.capitalize %>
+                    <% else %>
+                        <%= service.upcase %>
+                    <% end %>
                 </td>
             </tr>
         <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -62,14 +62,16 @@
                     <%= user.email %>
                 </td>
                 <td class="govuk-table__cell">
-                    <% if user.roles.any? %>
+                    <% if user.deactivated_at.present? %>
+                        <%= t('.user_disabled') %>
+                    <% elsif user.roles.any? %>
                         <%= user.roles.first.role_type.capitalize %>
                     <% else %>
                         <%= t('.no_role') %>
                     <% end %>
                 </td>
                 <td class="govuk-table__cell">
-                    <% if user.roles.any? %>
+                    <% if user.roles.any? && user.deactivated_at.nil? %>
                         <% service = user.roles.first.service || '-' %>
                         <% if service == "all" %>
                             <%= service.capitalize %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,3 @@
+<% title t('.page_title') %>
+
+<%= render partial: "form", locals: { method: :post } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -97,36 +97,35 @@ en:
 
   users:
     service:
-      title: Which services can they access?
+      title: Select service
       all: All
-      pa: PA (Prior Authority)
-      nsm: NSM (Non-Standard Magistrates' court payment)
+      pa: PA - Prior Authority
+      nsm: NSM - Non-Standard Magistrates' court payment
     form:
       page_title: User details
       field:
         first_name: First name
         last_name: Last name
         email: Email address
-        permissions: Which permissions should they have?
+        permissions: Select role
         supervisor:
           title: Supervisor
-          hint: Gives access to user management, analytics and all services
+          hint: User management, analytics and all services
         caseworker:
           title: Caseworker
-          hint: Allows the user to view and assess claims or applications
+          hint: View and assess claims or applications
         viewer:
           title: Viewer
-          hint: Allows the user to view claims or applications
+          hint: View but not assess claims or applications
         none:
-          title: None - account disabled
-          hint: Removes all user permissions and disable the account
+          title: Remove access
       save: Save and continue
     index:
       page_title: User management
       add_new_user: Add new user
       users: users
       no_role: None
-      user_disabled: Account disabled
+      user_disabled: No access
       table:
         name: Name
         email: Email

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,6 +96,15 @@ en:
     sign_in: Sign in
 
   users:
+    index:
+      page_title: User management
+      add_new_user: Add new user
+      users: users
+      table:
+        name: Name
+        email: Email
+        role: Role
+        service: Service
     dev_auth:
       new:
         page_title: Dev Auth for testing

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -118,7 +118,7 @@ en:
           title: Viewer
           hint: Allows the user to view claims or applications
         none:
-          title: None
+          title: None - account disabled
           hint: Removes all user permissions and disable the account
       save: Save and continue
     index:
@@ -126,6 +126,7 @@ en:
       add_new_user: Add new user
       users: users
       no_role: None
+      user_disabled: Account disabled
       table:
         name: Name
         email: Email

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -125,6 +125,7 @@ en:
       page_title: User management
       add_new_user: Add new user
       users: users
+      no_role: None
       table:
         name: Name
         email: Email

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -96,6 +96,31 @@ en:
     sign_in: Sign in
 
   users:
+    service:
+      title: Which services can they access?
+      all: All
+      pa: PA (Prior Authority)
+      nsm: NSM (Non-Standard Magistrates' court payment)
+    form:
+      page_title: User details
+      field:
+        first_name: First name
+        last_name: Last name
+        email: Email address
+        permissions: Which permissions should they have?
+        supervisor:
+          title: Supervisor
+          hint: Gives access to user management, analytics and all services
+        caseworker:
+          title: Caseworker
+          hint: Allows the user to view and assess claims or applications
+        viewer:
+          title: Viewer
+          hint: Allows the user to view claims or applications
+        none:
+          title: None
+          hint: Removes all user permissions and disable the account
+      save: Save and continue
     index:
       page_title: User management
       add_new_user: Add new user
@@ -105,6 +130,10 @@ en:
         email: Email
         role: Role
         service: Service
+    edit:
+      page_title: User details
+    new:
+      page_title: User details
     dev_auth:
       new:
         page_title: Dev Auth for testing

--- a/config/locales/en/assess_a_crime_form.yml
+++ b/config/locales/en/assess_a_crime_form.yml
@@ -7,3 +7,4 @@ en:
       prior_authority: Assess prior authority to incur disbursements, previously CRM4
       nsm: Assess a non-standard magistrates' court payment, previously CRM7
       analytics: Analytics dashboard
+      user_management: User management

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -124,3 +124,17 @@ en:
               search_error: Something went wrong trying to perform this search
             application_type:
               blank: Select a service to search
+        user_form:
+          attributes:
+            email:
+              taken: A user with this email address already exists
+              invalid: Enter a valid email address
+              blank: Enter the user's email address
+            first_name:
+              blank: Enter the first name of the user
+            last_name:
+              blank: Enter the last name of the user
+            role_type:
+              blank: Select the users permissions
+            service:
+              blank: Select the services the user can access

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -131,10 +131,10 @@ en:
               invalid: Enter a valid email address
               blank: Enter the user's email address
             first_name:
-              blank: Enter the first name of the user
+              blank: Enter the user's first name
             last_name:
-              blank: Enter the last name of the user
+              blank: Enter the user's last name
             role_type:
-              blank: Select the users permissions
+              blank: Select the user's permissions
             service:
               blank: Select the services the user can access

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,5 +145,6 @@ Rails.application.routes.draw do
   get 'robots.txt', to: 'robots#index'
 
   resource :dashboard, only: %i[new show]
+  resource :users
 end
 # rubocop:enable Metrics/BlockLength

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -145,6 +145,6 @@ Rails.application.routes.draw do
   get 'robots.txt', to: 'robots#index'
 
   resource :dashboard, only: %i[new show]
-  resource :users
+  resources :users
 end
 # rubocop:enable Metrics/BlockLength

--- a/db/migrate/20250409140116_add_unique_constraint_to_user_email.rb
+++ b/db/migrate/20250409140116_add_unique_constraint_to_user_email.rb
@@ -1,0 +1,6 @@
+class AddUniqueConstraintToUserEmail < ActiveRecord::Migration[8.0]
+  def change
+    remove_index :users, :email if index_exists?(:users, :email)
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/migrate/20250410083914_add_service_to_role.rb
+++ b/db/migrate/20250410083914_add_service_to_role.rb
@@ -2,12 +2,10 @@ class AddServiceToRole < ActiveRecord::Migration[8.0]
   def up
     add_column :roles, :service, :string
 
-    if Rails.env.local?
-      User.where(email: ['super.visor@test.com', 'case.worker@test.com']).flat_map(&:roles).each do |role|
-        role.update(service: 'all')
-      end
-    elsif Rails.env.production?
-      Rails.logger.info('hello')
+    return unless HostEnv.local? || HostEnv.development?
+
+    User.where(email: ['super.visor@test.com', 'case.worker@test.com']).flat_map(&:roles).each do |role|
+      role.update(service: 'all')
     end
   end
 

--- a/db/migrate/20250410083914_add_service_to_role.rb
+++ b/db/migrate/20250410083914_add_service_to_role.rb
@@ -1,0 +1,17 @@
+class AddServiceToRole < ActiveRecord::Migration[8.0]
+  def up
+    add_column :roles, :service, :string
+
+    if Rails.env.local?
+      User.where(email: ['super.visor@test.com', 'case.worker@test.com']).flat_map(&:roles).each do |role|
+        role.update(service: 'all')
+      end
+    elsif Rails.env.production?
+      Rails.logger.info('hello')
+    end
+  end
+
+  def down
+    remove_column :roles, :service
+  end
+end

--- a/db/migrate/20250410083914_add_service_to_role.rb
+++ b/db/migrate/20250410083914_add_service_to_role.rb
@@ -1,12 +1,6 @@
 class AddServiceToRole < ActiveRecord::Migration[8.0]
   def up
-    add_column :roles, :service, :string
-
-    return unless HostEnv.local? || HostEnv.development?
-
-    User.where(email: ['super.visor@test.com', 'case.worker@test.com']).flat_map(&:roles).each do |role|
-      role.update(service: 'all')
-    end
+    add_column :roles, :service, :string, default: 'all'
   end
 
   def down

--- a/db/pii.yml
+++ b/db/pii.yml
@@ -68,6 +68,7 @@ autogrant_limits:
 roles:
   id: false
   user_id: false
+  service: false
   role_type: false
   created_at: false
   updated_at: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -73,7 +73,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_10_083914) do
     t.string "role_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "service"
+    t.string "service", default: "all"
     t.index ["user_id"], name: "index_roles_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_13_171004) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_10_083914) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
-  enable_extension "plpgsql"
+  enable_extension "pg_catalog.plpgsql"
 
   create_table "access_logs", force: :cascade do |t|
     t.uuid "user_id", null: false
@@ -73,6 +73,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_13_171004) do
     t.string "role_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "service"
     t.index ["user_id"], name: "index_roles_on_user_id"
   end
 
@@ -121,7 +122,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_13_171004) do
     t.datetime "deactivated_at"
     t.datetime "invitation_expires_at"
     t.index ["auth_subject_id"], name: "index_users_on_auth_subject_id"
-    t.index ["email"], name: "index_users_on_email"
+    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
   add_foreign_key "access_logs", "users"

--- a/db/seeds/caseworkers.rb
+++ b/db/seeds/caseworkers.rb
@@ -1,4 +1,4 @@
-return unless ENV.fetch('ENV', 'local').in?(%w[development local])
+return unless HostEnv.local? || HostEnv.development?
 
 User
   .find_or_initialize_by(email: 'case.worker@test.com')

--- a/db/seeds/caseworkers.rb
+++ b/db/seeds/caseworkers.rb
@@ -3,8 +3,8 @@ return unless ENV.fetch('ENV', 'local').in?(%w[development local])
 User
   .find_or_initialize_by(email: 'case.worker@test.com')
   .update(
-    first_name: 'case',
-    last_name: 'worker',
+    first_name: 'Case',
+    last_name: 'Worker',
     auth_oid: SecureRandom.uuid,
     auth_subject_id: SecureRandom.uuid,
     roles: [Role.new(role_type: 'caseworker', service: 'all')]
@@ -13,8 +13,8 @@ User
 User
   .find_or_initialize_by(email: 'super.visor@test.com')
   .update(
-    first_name: 'super',
-    last_name: 'visor',
+    first_name: 'Super',
+    last_name: 'Visor',
     auth_oid: SecureRandom.uuid,
     auth_subject_id: SecureRandom.uuid,
     roles: [Role.new(role_type: 'supervisor', service: 'all')]

--- a/db/seeds/caseworkers.rb
+++ b/db/seeds/caseworkers.rb
@@ -1,27 +1,51 @@
 return unless ENV.fetch('ENV', 'local').in?(%w[development local])
 
-case_worker = User.find_or_initialize_by(email: 'case.worker@test.com')
-case_worker.update(
-  first_name: 'case',
-  last_name: 'worker',
-  auth_oid: SecureRandom.uuid,
-  auth_subject_id: SecureRandom.uuid,
-)
-case_worker.roles.create! role_type: 'caseworker'
+User
+  .find_or_initialize_by(email: 'case.worker@test.com')
+  .update(
+    first_name: 'case',
+    last_name: 'worker',
+    auth_oid: SecureRandom.uuid,
+    auth_subject_id: SecureRandom.uuid,
+    roles: [Role.new(role_type: 'caseworker', service: 'all')]
+  )
 
-super_visor = User.find_or_initialize_by(email: 'super.visor@test.com')
-super_visor.update(
-  first_name: 'super',
-  last_name: 'visor',
-  auth_oid: SecureRandom.uuid,
-  auth_subject_id: SecureRandom.uuid,
-)
-super_visor.roles.create! role_type: 'supervisor'
+User
+  .find_or_initialize_by(email: 'super.visor@test.com')
+  .update(
+    first_name: 'super',
+    last_name: 'visor',
+    auth_oid: SecureRandom.uuid,
+    auth_subject_id: SecureRandom.uuid,
+    roles: [Role.new(role_type: 'supervisor', service: 'all')]
+  )
 
-viewer = User.find_or_initialize_by(email: 'viewer@test.com')
-viewer.update(
-  first_name: 'Reid',
-  last_name: "O'Nly",
-  auth_subject_id: SecureRandom.uuid,
-)
-viewer.roles.create! role_type: 'viewer'
+User
+  .find_or_initialize_by(email: 'viewer@test.com')
+  .update(
+    first_name: 'Reid',
+    last_name: "O'Nly",
+    auth_oid: SecureRandom.uuid,
+    auth_subject_id: SecureRandom.uuid,
+    roles: [Role.new(role_type: 'viewer', service: 'all')]
+  )
+
+User
+  .find_or_initialize_by(email: 'pa@test.com')
+  .update(
+    first_name: 'Crim',
+    last_name: 'Fours',
+    auth_oid: SecureRandom.uuid,
+    auth_subject_id: SecureRandom.uuid,
+    roles: [Role.new(role_type: 'caseworker', service: 'pa')]
+  )
+
+User
+  .find_or_initialize_by(email: 'nsm@test.com')
+  .update(
+    first_name: 'Crim',
+    last_name: 'Sevens',
+    auth_oid: SecureRandom.uuid,
+    auth_subject_id: SecureRandom.uuid,
+    roles: [Role.new(role_type: 'caseworker', service: 'nsm')]
+  )

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -1,31 +1,31 @@
 namespace :user do
   desc 'add user to database'
-  task :add, [:email, :first_name, :last_name, :role] => [:environment] do |t, args|
-    user = User.find_or_initialize_by(email: args[:email])
-    user.update!(
-      first_name: args[:first_name],
-      last_name: args[:last_name],
-      auth_oid: SecureRandom.uuid
-    )
-    user.roles.create! role_type: args[:role]
+  task :add, [:email, :first_name, :last_name, :role, :service] => [:environment] do |_t, args|
+    User.find_or_initialize_by(email: args[:email])
+        .update!(
+          first_name: args[:first_name],
+          last_name: args[:last_name],
+          auth_oid: SecureRandom.uuid,
+          roles: [Role.new(role_type: args[:role_type], service: args[:service])]
+        )
   end
 
   desc 'deactivate user (disable login)'
-  task :deactivate, [:email] => [:environment] do |t, args|
+  task :deactivate, [:email] => [:environment] do |_t, args|
     abort("Usage: Run task with email as argument ie 'rake user:deactivate[test@test.com]'") unless args[:email]
 
     user = User.find_by(email: args[:email]) || abort('User not found')
-    user.update(deactivated_at: Time.now)
+    user.update!(deactivated_at: Time.now)
 
     puts "User email: #{user.email} deactivated at #{user.deactivated_at}"
   end
 
   desc 'reactivate user (re-enable disabled login)'
-  task :reactivate, [:email] => [:environment] do |t, args|
+  task :reactivate, [:email] => [:environment] do |_t, args|
     abort("Usage: Run task with email as argument ie 'rake user:reactivate[test@test.com]'") unless args[:email]
 
     user = User.find_by(email: args[:email]) || abort('User not found')
-    user.update(deactivated_at: nil)
+    user.update!(deactivated_at: nil)
 
     puts "User email: #{user.email} reactivated"
   end

--- a/spec/factories/role.rb
+++ b/spec/factories/role.rb
@@ -4,14 +4,17 @@ FactoryBot.define do
 
     trait :supervisor do
       role_type { 'supervisor' }
+      service { 'all' }
     end
 
     trait :caseworker do
       role_type { 'caseworker' }
+      service { 'all' }
     end
 
     trait :viewer do
       role_type { 'viewer' }
+      service { 'all' }
     end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :caseworker, class: 'User' do
-    email { 'case.worker@test.com' }
+    email { Faker::Internet.email }
     first_name { 'case' }
     last_name { 'worker' }
     auth_oid { SecureRandom.uuid }
@@ -13,7 +13,7 @@ FactoryBot.define do
   end
 
   factory :supervisor, class: 'User' do
-    email { 'super.visor@test.com' }
+    email { Faker::Internet.email }
     first_name { 'super' }
     last_name { 'visor' }
     auth_oid { SecureRandom.uuid }
@@ -22,7 +22,7 @@ FactoryBot.define do
   end
 
   factory :viewer, class: 'User' do
-    email { 'readonly.viewer@test.com' }
+    email { Faker::Internet.email }
     first_name { 'cannot' }
     last_name { 'edit' }
     auth_subject_id { SecureRandom.uuid }

--- a/spec/models/event/unassignment_spec.rb
+++ b/spec/models/event/unassignment_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Event::Unassignment do
     end
 
     it 'has a valid title' do
-      expect(subject.title).to eq('Caseworker removed from claim by super visor')
+      expect(subject.title).to eq("Caseworker removed from claim by #{current_user.display_name}")
     end
   end
 

--- a/spec/system/nsm/history_spec.rb
+++ b/spec/system/nsm/history_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe 'History events', :stub_oauth_token do
   let(:caseworker) { create(:caseworker) }
   let(:claim) { build(:claim) }
   let(:fixed_arbitrary_date) { Time.zone.local(2023, 2, 1, 9, 0) }
+  let(:supervisor) { create(:supervisor) }
 
   before do
     stub_app_store_interactions(claim)
@@ -15,8 +16,6 @@ RSpec.describe 'History events', :stub_oauth_token do
 
   context 'paginated events' do
     before do
-      supervisor = create(:supervisor)
-
       now = DateTime.current
 
       travel_to(now - 10.hours)
@@ -71,15 +70,15 @@ RSpec.describe 'History events', :stub_oauth_token do
         # User, Title, comment
         [
           '', 'Uploads deleted', 'Uploads are deleted after 6 months to keep provider data safe',
-          'case worker', 'Caseworker removed from claim by super visor', 'unassignment 2',
-          'case worker', 'Decision made to grant claim', 'Decision test',
+          caseworker.display_name, "Caseworker removed from claim by #{supervisor.display_name}", 'unassignment 2',
+          caseworker.display_name, 'Decision made to grant claim', 'Decision test',
           '', 'Received', 'Received from Provider with further information',
-          'case worker', 'Sent back', 'Sent back to Provider for further information',
-          'case worker', 'Caseworker note', 'User test note',
-          'case worker', 'Claim risk changed to low risk', 'Risk change test',
-          'case worker', 'Self-assigned by case worker', 'Manual assignment note',
-          'case worker', 'Caseworker removed self from claim', 'unassignment 1',
-          'case worker', 'Claim allocated to caseworker', ''
+          caseworker.display_name, 'Sent back', 'Sent back to Provider for further information',
+          caseworker.display_name, 'Caseworker note', 'User test note',
+          caseworker.display_name, 'Claim risk changed to low risk', 'Risk change test',
+          caseworker.display_name, "Self-assigned by #{caseworker.display_name}", 'Manual assignment note',
+          caseworker.display_name, 'Caseworker removed self from claim', 'unassignment 1',
+          caseworker.display_name, 'Claim allocated to caseworker', ''
         ]
       )
     end
@@ -109,7 +108,7 @@ RSpec.describe 'History events', :stub_oauth_token do
       visit nsm_claim_history_path(claim)
       fill_in 'Add a note to the claim history (optional)', with: 'Here is a note'
       click_on 'Add to claim history'
-      expect(page).to have_content "01 Feb 202309:00amcase worker\nCaseworker note\nHere is a note"
+      expect(page).to have_content "01 Feb 202309:00am#{caseworker.display_name}\nCaseworker note\nHere is a note"
     end
 
     it 'rejects blank content' do

--- a/spec/system/prior_authority/history_spec.rb
+++ b/spec/system/prior_authority/history_spec.rb
@@ -50,16 +50,16 @@ RSpec.describe 'History events', :stub_oauth_token do
     ).map { _1.text.strip.gsub(/\s+/, ' ') }
 
     expect(history).to eq(
-      ['1 February 20238:30am', 'case worker', 'case worker added a note Foo Bar',
+      ['1 February 20238:30am', caseworker.display_name, "#{caseworker.display_name} added a note Foo Bar",
        '1 February 20238:00am', 'N/A', 'Received Received from Provider with changes to data',
        '1 February 20237:00am', 'N/A', 'Received Received from Provider with further information and changes to data',
-       '1 February 20236:00am', 'case worker', 'Sent back Sent back to Provider for further information',
-       '1 February 20235:00am', 'case worker', 'case worker saved a draft',
-       '1 February 20234:00am', 'case worker', 'Granted decision comment',
-       '1 February 20233:00am', 'case worker', 'case worker saved a draft',
-       '1 February 20232:00am', 'super visor', 'Self-assigned by super visor manual assignment comment',
-       '1 February 20231:00am', 'super visor', 'Unassigned by super visor unassignment comment',
-       '1 February 202312:00am', 'case worker', 'Assigned to case worker']
+       '1 February 20236:00am', caseworker.display_name, 'Sent back Sent back to Provider for further information',
+       '1 February 20235:00am', caseworker.display_name, "#{caseworker.display_name} saved a draft",
+       '1 February 20234:00am', caseworker.display_name, 'Granted decision comment',
+       '1 February 20233:00am', caseworker.display_name, "#{caseworker.display_name} saved a draft",
+       '1 February 20232:00am', supervisor.display_name, "Self-assigned by #{supervisor.display_name} manual assignment comment",
+       '1 February 20231:00am', supervisor.display_name, "Unassigned by #{supervisor.display_name} unassignment comment",
+       '1 February 202312:00am', caseworker.display_name, "Assigned to #{caseworker.display_name}"]
     )
   end
 

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -32,13 +32,13 @@ RSpec.describe 'Users', :stub_oauth_token do
         click_on 'Role'
 
         within 'table' do
-          expect(page).to have_content(/John Everyman.*Ad Minh/)
+          expect(page).to have_content(/#{caseworker.display_name}.*#{supervisor.display_name}/)
         end
 
         click_on 'Role'
 
         within 'table' do
-          expect(page).to have_content(/Ad Minh.*John Everyman/)
+          expect(page).to have_content(/#{supervisor.display_name}.*#{caseworker.display_name}/)
         end
       end
 
@@ -46,7 +46,7 @@ RSpec.describe 'Users', :stub_oauth_token do
         click_on 'Service'
 
         within 'table' do
-          expect(page).to have_content(/Ad Minh.*Super Visor/)
+          expect(page).to have_content(/#{supervisor.display_name}.*#{caseworker.display_name}/)
         end
       end
 
@@ -54,7 +54,7 @@ RSpec.describe 'Users', :stub_oauth_token do
         click_on 'Email'
 
         within 'table' do
-          expect(page).to have_content(/Ad Minh.*John Everyman/)
+          expect(page).to have_content(/#{supervisor.display_name}.*#{caseworker.display_name}/)
         end
       end
     end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,0 +1,133 @@
+require 'rails_helper'
+
+RSpec.describe 'Users', :stub_oauth_token do
+  let(:caseworker) { create(:caseworker, first_name: 'John', last_name: 'Everyman', email: 'case@worker.com') }
+  let(:supervisor) { create(:supervisor, first_name: 'Ad', last_name: 'Minh', email: 'ad@minh.com') }
+
+  before do
+    caseworker.save
+    supervisor.save
+    sign_in supervisor
+    visit users_path
+  end
+
+  describe '#index' do
+    context 'for non-admins' do
+      before do
+        sign_in caseworker
+        visit users_path
+      end
+
+      it 'does not allow access' do
+        expect(page).not_to have_content(I18n.t('users.index.page_title'))
+      end
+    end
+
+    context 'for admins' do
+      it 'allows admins' do
+        expect(page).to have_content(I18n.t('users.index.page_title'))
+      end
+
+      it 'allows sorting by role in both directions' do
+        click_on 'Role'
+
+        within 'table' do
+          expect(page).to have_content(/John Everyman.*Ad Minh/)
+        end
+
+        click_on 'Role'
+
+        within 'table' do
+          expect(page).to have_content(/Ad Minh.*John Everyman/)
+        end
+      end
+
+      it 'allows sorting by service' do
+        click_on 'Service'
+
+        within 'table' do
+          expect(page).to have_content(/Ad Minh.*Super Visor/)
+        end
+      end
+
+      it 'allows sorting by email' do
+        click_on 'Email'
+
+        within 'table' do
+          expect(page).to have_content(/Ad Minh.*John Everyman/)
+        end
+      end
+    end
+  end
+
+  describe '#create' do
+    before do
+      sign_in supervisor
+      visit users_path
+      click_on I18n.t('users.index.add_new_user')
+    end
+
+    it 'can create a new user' do
+      fill_in I18n.t('users.form.field.first_name'), with: 'Joe'
+      fill_in I18n.t('users.form.field.last_name'), with: 'Bloggs'
+      fill_in I18n.t('users.form.field.email'), with: Faker::Internet.email
+      choose I18n.t('users.form.field.supervisor.title')
+
+      click_on I18n.t('users.form.save')
+
+      expect(User.count).to eq(8)
+      expect(page).to have_content('Joe Bloggs')
+    end
+
+    it 'cannot create a user with an existing email' do
+      fill_in I18n.t('users.form.field.first_name'), with: 'Joe'
+      fill_in I18n.t('users.form.field.last_name'), with: 'Bloggs'
+      fill_in I18n.t('users.form.field.email'), with: supervisor.email
+      choose I18n.t('users.form.field.supervisor.title')
+
+      click_on I18n.t('users.form.save')
+
+      expect(page).to have_content(I18n.t('activemodel.errors.models.user_form.attributes.email.taken'))
+    end
+  end
+
+  describe '#update' do
+    before do
+      sign_in supervisor
+      visit users_path
+      click_on caseworker.display_name
+      expect(page).to have_content(I18n.t('users.edit.page_title'))
+    end
+
+    it "can update a user's name" do
+      fill_in I18n.t('users.form.field.first_name'), with: 'Joe'
+      fill_in I18n.t('users.form.field.last_name'), with: 'Bloggs'
+      click_on I18n.t('users.form.save')
+
+      expect(page).to have_content('Joe Bloggs')
+      expect(page).not_to have_content('John Everyman')
+    end
+
+    it "can update a user's role" do
+      choose I18n.t('users.form.field.viewer.title')
+      click_on I18n.t('users.form.save')
+
+      expect(find('tr', text: caseworker.display_name).has_text?(I18n.t('users.form.field.viewer.title'))).to be(true)
+    end
+
+    it "can update the service for a user's role" do
+      choose I18n.t('users.service.pa'), match: :first
+      click_on I18n.t('users.form.save')
+
+      expect(find('tr', text: caseworker.display_name).has_text?('PA')).to be(true)
+    end
+
+    it 'cannot update a user without a last name' do
+      fill_in I18n.t('users.form.field.last_name'), with: ''
+
+      click_on I18n.t('users.form.save')
+
+      expect(page).to have_content(I18n.t('activemodel.errors.models.user_form.attributes.last_name.blank'))
+    end
+  end
+end


### PR DESCRIPTION
## Description of change

Add a new UI to allow users to be managed outside of the now-deprecated rake task.

Also restricts which services caseworkers should be able to use.

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2535)

## Notes for reviewer

This will need adjustments to how every other dev has their users
setup locally. If you're using the default seeded users, you won't
have to make any changes other than re-running `bundle exec db:seed`
again.