### PR TITLE
Set cloud-platform-tools image to 2.9.9 to circumvent kubectl issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ executors:
   cloud-platform-executor:
     resource_class: small
     docker:
-      - image: ministryofjustice/cloud-platform-tools
+      - image: ministryofjustice/cloud-platform-tools:2.9.9
 
 # ------------------
 # REFERENCES


### PR DESCRIPTION
More details here: https://mojdt.slack.com/archives/C57UPMZLY/p1746017554921989
