### PR TITLE
Remove N+1 queries when loading user info

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,16 +12,24 @@ class User < ApplicationRecord
   scope :active, -> { where(deactivated_at: nil).where.not(auth_subject_id: nil) }
   scope :pending_activation, -> { where(auth_subject_id: nil, deactivated_at: nil) }
 
+  def nsm_access?
+    @nsm_access ||= roles.nsm_access.exists?
+  end
+
+  def pa_access?
+    @pa_access ||= roles.pa_access.exists?
+  end
+
   def display_name
     "#{first_name} #{last_name}"
   end
 
   def supervisor?
-    roles.supervisor.any?
+    @supervisor ||= roles.supervisor.any?
   end
 
   def viewer?
-    roles.viewer.any?
+    @viewer ||= roles.viewer.any?
   end
 
   def pending_activation?

--- a/app/policies/claim_policy.rb
+++ b/app/policies/claim_policy.rb
@@ -26,6 +26,6 @@ class ClaimPolicy < ApplicationPolicy
   private
 
   def service_access?
-    user.roles.nsm_access.any?
+    user.nsm_access?
   end
 end

--- a/app/policies/prior_authority_application_policy.rb
+++ b/app/policies/prior_authority_application_policy.rb
@@ -30,6 +30,6 @@ class PriorAuthorityApplicationPolicy < ApplicationPolicy
   end
 
   def service_access?
-    user.roles.pa_access.any?
+    user.pa_access?
   end
 end


### PR DESCRIPTION
## Description of change

Policies against users run on every page and always go through a user's roles a few times. It only makes sense to compute this once per object lifetime.

[Link to relevant discussion](https://mojdt.slack.com/archives/C06UR7V28RZ/p1746802375906659)