### PR TITLE
Use correct env name for Delete Dev Release

### DIFF
--- a/.github/workflows/delete-dev-release.yml
+++ b/.github/workflows/delete-dev-release.yml
@@ -1,4 +1,4 @@
-name: Delete UAT release
+name: Delete Dev release
 
 on:
   pull_request:


### PR DESCRIPTION
## Description of change

No Ticket

## Notes for reviewer

The workflow that deletes old dev branches is called Delete UAT release, when it should be Delete Dev release. Updating as it's confusing to people inspecting config