### PR TITLE
 Add public ingress to allow Pingdom to use without whitelist

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -3,7 +3,6 @@
 ENVIRONMENT=$1
 # Convert the branch name into a string that can be turned into a valid URL
 BRANCH_RELEASE_NAME=$(echo "$CIRCLE_BRANCH" | tr '[:upper:]' '[:lower:]' | sed 's:^\w*\/::' | tr -s ' _/[]().' '-' | cut -c1-18 | sed 's/-$//')
-PINGDOM_IPS=$(curl -s https://my.pingdom.com/probes/ipv4 | tr -d ' ' | tr '\n' ',' | sed 's/,/\\,/g' | sed 's/\\,$//')
 SHARED_IPS=$(curl -s https://raw.githubusercontent.com/ministryofjustice/laa-ip-allowlist/main/cidrs.txt | tr -d ' ' | tr '\n' ',' | sed 's/,/\\,/g' | sed 's/\\,$//')
 
 deploy_branch() {
@@ -35,7 +34,6 @@ deploy_main() {
                           --install --wait \
                           --namespace="${K8S_NAMESPACE}" \
                           --values ./helm_deploy/values-"$ENVIRONMENT".yaml \
-                          --set-string pingdomIPs="$PINGDOM_IPS" \
                           --set-string sharedIPs="$SHARED_IPS" \
                           --set image.repository="${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${ECR_REPOSITORY}" \
                           --set image.tag="main-$CIRCLE_SHA1"

--- a/helm_deploy/templates/_helpers.tpl
+++ b/helm_deploy/templates/_helpers.tpl
@@ -95,6 +95,6 @@ Function to return a list of whitelisted IPs allowed to access the service.
 */}}
 {{- define "laa-assess-crime-forms.whitelist" -}}
 {{- if .Values.ingress.whitelist.enabled }}
-    {{- .Values.pingdomIPs }},{{- .Values.sharedIPs }}
+    {{- if .Values.ingress.whitelist.addresses }}{{- join "," .Values.ingress.whitelist.addresses }},{{- end }}{{- .Values.sharedIPs }}
 {{- end -}}
 {{- end -}}

--- a/helm_deploy/templates/public-ingress.yaml
+++ b/helm_deploy/templates/public-ingress.yaml
@@ -1,0 +1,38 @@
+{{- $fullName := include "laa-assess-crime-forms.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: public-{{ $fullName }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "laa-assess-crime-forms.labels" . | nindent 4 }}
+  annotations:
+    nginx.ingress.kubernetes.io/configuration-snippet: |
+      if ($request_method !~ ^GET$) {
+        return 405;
+      }
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
+    external-dns.alpha.kubernetes.io/set-identifier: public-{{- index .Values.ingress.annotations "external-dns.alpha.kubernetes.io/set-identifier" }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          - path: /ping
+            pathType: Exact
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          - path: /ready
+            pathType: Exact
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+      {{- end }}


### PR DESCRIPTION
## Description of change

Remove the need to add Pingdom IPs to the whitelist by allowing the healthcheck endpoints to be public for GET requests only

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2628)