### PR TITLE
CRM457-2635: Use correct class for Log Out link

### DIFF
--- a/app/views/layouts/_header_navigation.html.erb
+++ b/app/views/layouts/_header_navigation.html.erb
@@ -11,7 +11,7 @@
       <li class="moj-header__navigation-item header-navigation-link">
         <%# Signing out will reset the session ID which will reset the CSP nonce token, so turbo-based page replacement
           will fail as inline scripts will no longer have a valid nonce %>
-        <%= govuk_link_to t('.sign_out'), destroy_user_session_path, class: 'moj-header__link govuk-!-font-weight-bold' %>
+        <%= govuk_link_to t('.sign_out'), destroy_user_session_path, class: 'moj-header__navigation-link govuk-!-font-weight-bold' %>
       </li>
     </ul>
   <% end %>


### PR DESCRIPTION
## Description of change

[Change associated with this comment
](https://dsdmoj.atlassian.net/browse/CRM457-2635?focusedCommentId=617895)


