### PR TITLE
CRM457-2532 adjust empty travel cost

### DIFF
--- a/app/controllers/prior_authority/travel_costs_controller.rb
+++ b/app/controllers/prior_authority/travel_costs_controller.rb
@@ -2,7 +2,7 @@ module PriorAuthority
   class TravelCostsController < PriorAuthority::BaseController
     def edit
       authorize(submission, :edit?)
-      all_travel_costs = BaseViewModel.build(:travel_cost, submission, 'quotes')
+      all_travel_costs = BaseViewModel.build(:travel_cost, submission, 'quotes').sort_by { |cost| cost.primary ? 0 : 1 }
 
       item = all_travel_costs.find do |model|
         model.id == controller_params[:id]
@@ -10,12 +10,13 @@ module PriorAuthority
 
       form = TravelCostForm.new(submission:, item:, **item.form_attributes)
 
-      render locals: { submission:, item:, form: }
+      render locals: { submission:, item:, form:, all_travel_costs: }
     end
 
+    # rubocop:disable Metrics/AbcSize
     def update
       authorize(submission, :update?)
-      all_travel_costs = BaseViewModel.build(:travel_cost, submission, 'quotes')
+      all_travel_costs = BaseViewModel.build(:travel_cost, submission, 'quotes').sort_by { |cost| cost.primary ? 0 : 1 }
 
       item = all_travel_costs.find do |model|
         model.id == controller_params[:id]
@@ -26,9 +27,10 @@ module PriorAuthority
       if form.save!
         redirect_to prior_authority_application_adjustments_path(submission)
       else
-        render :edit, locals: { submission:, item:, form: }
+        render :edit, locals: { submission:, item:, form:, all_travel_costs: }
       end
     end
+    # rubocop:enable Metrics/AbcSize
 
     def confirm_deletion
       authorize(submission, :edit?)

--- a/app/forms/prior_authority/travel_cost_form.rb
+++ b/app/forms/prior_authority/travel_cost_form.rb
@@ -21,6 +21,12 @@ module PriorAuthority
 
     private
 
+    def ensure_original_field_value_set(field)
+      return if selected_record.key?("#{field}_original") && selected_record["#{field}_original"].nil?
+
+      selected_record["#{field}_original"] ||= selected_record[field]
+    end
+
     def process_fields
       process_field(value: travel_time.to_i, field: 'travel_time')
       process_field(value: travel_cost_per_hour.to_s, field: 'travel_cost_per_hour')

--- a/app/services/prior_authority/adjustment_deleter.rb
+++ b/app/services/prior_authority/adjustment_deleter.rb
@@ -22,7 +22,8 @@ module PriorAuthority
 
     def delete_travel_cost_adjustment
       %w[travel_time travel_cost_per_hour].each do |field|
-        revert(quote, field)
+        quote[field] = quote["#{field}_original"]
+        quote.delete("#{field}_original")
       end
       quote.delete('travel_adjustment_comment')
     end

--- a/app/view_models/prior_authority/travel_costs_with_adjustments.rb
+++ b/app/view_models/prior_authority/travel_costs_with_adjustments.rb
@@ -5,7 +5,7 @@ module PriorAuthority
     end
 
     def requested_formatted_travel_cost_per_hour
-      return if original_travel_cost_per_hour.to_f.zero?
+      return if original_travel_cost_per_hour.to_f.zero? || original_travel_time.nil?
 
       "#{NumberTo.pounds(original_travel_cost_per_hour)} " \
         "#{I18n.t('prior_authority.application_details.items.per_unit_descriptions.per_hour')}"

--- a/app/view_models/prior_authority/v1/application_summary.rb
+++ b/app/view_models/prior_authority/v1/application_summary.rb
@@ -61,6 +61,10 @@ module PriorAuthority
         @all_quotes ||= Quote.build(:quote, submission, 'quotes')
       end
 
+      def alt_travel_costs
+        all_quotes.find { |q| q.primary == false && q.travel_cost_per_hour.present? }
+      end
+
       def built_primary_quote
         @built_primary_quote ||= all_quotes.find { |q| q.primary == true }
       end

--- a/app/view_models/prior_authority/v1/travel_cost.rb
+++ b/app/view_models/prior_authority/v1/travel_cost.rb
@@ -1,7 +1,10 @@
 module PriorAuthority
   module V1
     class TravelCost < BaseWithAdjustments
+      include TravelCostsWithAdjustments
+
       attribute :id, :string
+      attribute :primary, :boolean
       adjustable_attribute :travel_time, :time_period
       adjustable_attribute :travel_cost_per_hour, :decimal, precision: 10, scale: 2
       attribute :travel_cost_reason, :string

--- a/app/views/prior_authority/adjustments/_travel_costs.erb
+++ b/app/views/prior_authority/adjustments/_travel_costs.erb
@@ -14,35 +14,39 @@
 <% end %>
 
 <%= govuk_table(id: 'travel_costs') do |table|
-      table.with_head do |head|
-        head.with_row do |row|
-          row.with_cell(text: t('.details'))
-          row.with_cell(text: t('.requested'))
-          row.with_cell(text: t('.adjusted'))
-        end
-      end
+  table.with_head do |head|
+    head.with_row do |row|
+      row.with_cell(text: t('.details'))
+      row.with_cell(text: t('.requested'))
+      row.with_cell(text: t('.adjusted'))
+    end
+  end
 
-      table.with_body do |body|
-        body.with_row do |row|
-          row.with_cell(text: t('.time'))
-          row.with_cell(text: quote.requested_travel_units)
-          row.with_cell(text: quote.adjusted_travel_units)
-        end
+  table.with_body do |body|
+    body.with_row do |row|
+      row.with_cell(text: t('.time'))
+      row.with_cell(text: quote.requested_travel_units)
+      row.with_cell(text: quote.adjusted_travel_units)
+    end
 
-        body.with_row do |row|
-          row.with_cell(text: t('.cost'))
-          row.with_cell(text: quote.requested_formatted_travel_cost_per_hour)
-          row.with_cell(text: quote.adjusted_formatted_travel_cost_per_hour)
-        end
+    body.with_row do |row|
+      row.with_cell(text: t('.cost'))
+      row.with_cell(text: quote.requested_formatted_travel_cost_per_hour)
+      row.with_cell(text: quote.adjusted_formatted_travel_cost_per_hour)
+    end
 
-        body.with_row do |row|
-          row.with_cell(text: t('.total'))
-          row.with_cell(text: quote.requested_formatted_travel_cost)
-          row.with_cell(text: quote.adjusted_formatted_travel_cost)
-        end
-      end
-    end %>
+    body.with_row do |row|
+      row.with_cell(text: t('.total'))
+      row.with_cell(text: quote.requested_formatted_travel_cost)
+      row.with_cell(text: quote.adjusted_formatted_travel_cost)
+    end
+  end
+end if quote.travel_costs.positive? %>
 <% if editable %>
+
+  <% unless quote.travel_costs.positive? %>
+    <p><%= t('.no_travel_costs_added') %></p>
+  <% end %>
   <div class="govuk-button-group govuk-button-group-vertically-centred">
     <%= link_to t(".adjust_travel_cost"),
                 edit_prior_authority_application_travel_cost_path(application, quote.id),

--- a/app/views/prior_authority/adjustments/index.html.erb
+++ b/app/views/prior_authority/adjustments/index.html.erb
@@ -13,7 +13,7 @@
     <%= render 'key_information_card', model: @key_information.key_information_card %>
     <%= render 'service_costs', application_summary:, application:, editable: %>
 
-    <% if application_summary.primary_quote.travel_costs(original: true).positive? %>
+    <% if application_summary.alt_travel_costs.present? || application_summary.primary_quote.travel_costs(original: true).positive? %>
       <%= render 'travel_costs', application_summary:, application:, editable: %>
     <% end %>
 

--- a/app/views/prior_authority/travel_costs/edit.html.erb
+++ b/app/views/prior_authority/travel_costs/edit.html.erb
@@ -3,13 +3,37 @@
 <% end %>
 
 <% title t('.page_title') %>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds" id="travel-cost-adjustment-container">
     <%= govuk_error_summary(form) %>
     <h1 class="govuk-heading-xl"><%= t('.page_title') %></h1>
-    <p class="govuk-body"><%= t('.adjustment_blurb', service_type: t(submission.data['service_type'], scope: 'prior_authority.service_types')) %></p>
+    <% if submission.data['no_alternative_quote_reason'].present? %>
+      <p class="govuk-body"><%= t('.adjustment_blurb', service_type: t(submission.data['service_type'], scope: 'prior_authority.service_types')) %></p>
+    <% end %>
+    <%= govuk_table do |table|
+      table.with_caption(html_attributes: { class: "govuk-table__caption--m" }, text: t(".quotes_caption"))
+      table.with_head do |head|
+        head.with_row do |row|
+          row.with_cell(text: t('.quote'))
+          row.with_cell(text: t('.amount'))
+          row.with_cell(text: t('.rate'))
+          row.with_cell(text: t('.total'))
+        end
+      end
 
+      table.with_body do |body|
+        all_travel_costs.each_with_index do |travel_cost, index|
+          body.with_row do |row|
+            row.with_cell(header: true, text: travel_cost.primary ? t('.primary') : t('.alternative', index:))
+            row.with_cell(text: travel_cost.requested_travel_units )
+            row.with_cell(text: travel_cost.requested_formatted_travel_cost_per_hour)
+            row.with_cell(text: travel_cost.requested_formatted_travel_cost)
+          end
+        end
+      end
+    end if submission.data['no_alternative_quote_reason'].blank? %>
+
+    <h2 class="govuk-heading-m">Amount allowed</h2>
     <%= form_with model: form, url: prior_authority_application_travel_cost_path(submission.id, item.id), method: :patch do |f| %>
       <%= f.govuk_period_field :travel_time, legend: { text: t('.travel_time'), size: 's', class: 'govuk-!-font-weight-bold' }, width: 'one-third' %>
 

--- a/config/locales/en/prior_authority/adjustments.yml
+++ b/config/locales/en/prior_authority/adjustments.yml
@@ -33,6 +33,7 @@ en:
         cost: Rate
         cost_description: "Reason for travel cost:"
         details: Details
+        no_travel_costs_added: No travel costs added
         requested: Requested
         time: Amount
         total: Total

--- a/config/locales/en/prior_authority/travel_costs.yml
+++ b/config/locales/en/prior_authority/travel_costs.yml
@@ -4,12 +4,19 @@ en:
       edit:
         adjusted_cost: Adjusted cost
         adjustment_blurb: Adjust the providers' costs by changing the values.
+        alternative: Alternative %{index}
+        amount: Amount
         calculate_button_text: Calculate my changes
         explanation:
           hint: For example, why you made adjustments to the cost or time. We'll share this explanation with the provider.
           label: Explain your decision
         hourly_cost: Cost per hour
         page_title: Adjust travel costs
+        primary: Primary
+        rate: Rate
+        total: Total
         travel_time: Time
+        quote: Quote
+        quotes_caption: Quotes for travel cost
       confirm_deletion:
         travel_cost: "Travel costs"

--- a/spec/factories/prior_authority_applications.rb
+++ b/spec/factories/prior_authority_applications.rb
@@ -151,6 +151,22 @@ FactoryBot.define do
       travel_adjustment_comment { 'caseworker travel cost adjustment explanantion' }
     end
 
+    trait :with_adjusted_nil_travel do
+      travel_time_original { nil }
+      travel_cost_per_hour_original { nil }
+      travel_time { 2 }
+      travel_cost_per_hour { 10 }
+      travel_adjustment_comment { 'caseworker travel cost adjustment explanantion' }
+    end
+
+    trait :with_adjusted_travel do
+      travel_time_original { 1 }
+      travel_cost_per_hour_original { 1 }
+      travel_time { 2 }
+      travel_cost_per_hour { 2 }
+      travel_adjustment_comment { 'caseworker travel cost adjustment explanantion' }
+    end
+
     trait :per_hour do
       cost_type { 'per_hour' }
       cost_per_hour { '80.0' }

--- a/spec/forms/prior_authority/travel_cost_form_spec.rb
+++ b/spec/forms/prior_authority/travel_cost_form_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe PriorAuthority::TravelCostForm do
+  subject { described_class.new(params) }
+
+  let(:primary_quote) { build(:primary_quote, :no_travel, id: 'primary') }
+  let(:alternative_quote) { build(:alternative_quote, id: 'alt-1') }
+  let(:data) do
+    build(:prior_authority_data, quotes: [
+            primary_quote,
+            alternative_quote
+          ])
+  end
+  let(:submission) { build(:prior_authority_application, data:) }
+  let(:all_travel_costs) { BaseViewModel.build(:travel_cost, submission, 'quotes') }
+  let(:item) { all_travel_costs.detect(&:primary) }
+  let(:travel_time) { 1 }
+  let(:travel_cost_per_hour) { 1 }
+
+  describe '#save', :stub_oauth_token do
+    let(:params) do
+      {
+        submission: submission,
+        item: item,
+        travel_time: travel_time,
+        travel_cost_per_hour: travel_cost_per_hour,
+        explanation: 'asdf',
+        id: submission.id,
+      }
+    end
+    let(:current_user) { create(:caseworker) }
+    let(:primary) { submission.data['quotes'].detect { |q| q['id'] == 'primary' } }
+
+    before do
+      stub_request(:put, "https://appstore.example.com/v1/application/#{submission.id}").to_return(status: 201)
+      subject.save
+    end
+
+    context 'adjusted but originally nil' do
+      let(:primary_quote) { build(:primary_quote, :with_adjusted_nil_travel, id: 'primary') }
+
+      it 'travel_time_original does not change' do
+        expect(primary['travel_time_original']).to be_nil
+      end
+
+      it 'travel_time does not change' do
+        expect(primary['travel_time']).to eq(1)
+      end
+    end
+
+    context 'adjust primary travel cost' do
+      let(:primary_quote) { build(:primary_quote, id: 'primary') }
+
+      it 'travel_time_original does not change' do
+        expect(primary['travel_time_original']).to eq(180)
+      end
+
+      it 'travel_time changes' do
+        expect(primary['travel_time']).to eq(1)
+      end
+    end
+
+    context 'adjusted' do
+      let(:primary_quote) { build(:primary_quote, :with_adjusted_travel, id: 'primary') }
+      let(:travel_time) { 3 }
+
+      it 'travel_time_original does not change' do
+        expect(primary['travel_time_original']).to eq(1)
+      end
+
+      it 'travel_time does not change' do
+        expect(primary['travel_time']).to eq(3)
+      end
+    end
+
+    context 'adjust when no travel_cost present' do
+      it 'adjusts travel_time' do
+        expect(primary['travel_time']).to eq(1)
+      end
+
+      it 'creates travel_time_original' do
+        expect(primary['travel_time_original']).to be_nil
+      end
+
+      it 'adjusts travel_cost_per_hour' do
+        expect(primary['travel_cost_per_hour']).to eq('1.0')
+      end
+
+      it 'creates travel_cost_per_hour_original' do
+        expect(primary['travel_cost_per_hour_original']).to be_nil
+      end
+    end
+  end
+end

--- a/spec/system/prior_authority/adjust_travel_costs_spec.rb
+++ b/spec/system/prior_authority/adjust_travel_costs_spec.rb
@@ -1,6 +1,35 @@
 require 'rails_helper'
-
 RSpec.describe 'Adjust travel costs', :stub_oauth_token do
+  let(:caseworker) { create(:caseworker) }
+  let(:quotes) do
+    [
+      build(
+        :primary_quote,
+        cost_type: 'per_hour',
+        period: 180,
+        cost_per_hour: '3.50',
+        travel_time: 90,
+        travel_cost_per_hour: '100.00',
+        travel_cost_reason: 'Client detained in prison',
+      ),
+      build(:alternative_quote)
+    ]
+  end
+
+  let(:application) do
+    build(
+      :prior_authority_application,
+      state: 'submitted',
+      data: build(
+        :prior_authority_data,
+        laa_reference: 'LAA-1234',
+        service_type: 'pathologist_report',
+        quotes: quotes,
+        additional_costs: [],
+      )
+    )
+  end
+
   before do
     stub_app_store_interactions(application)
     sign_in caseworker
@@ -12,91 +41,127 @@ RSpec.describe 'Adjust travel costs', :stub_oauth_token do
     visit prior_authority_application_path(application)
     click_on 'Adjust quote'
     expect(page).to have_title('Adjustments')
-    click_on 'Adjust travel costs'
-    expect(page).to have_title('Adjust travel costs')
   end
 
-  let(:caseworker) { create(:caseworker) }
+  context 'travel cost entered' do
+    before do
+      click_on 'Adjust travel costs'
+      expect(page).to have_title('Adjust travel costs')
+    end
 
-  let(:application) do
-    build(
-      :prior_authority_application,
-      state: 'submitted',
-      data: build(
-        :prior_authority_data,
-        laa_reference: 'LAA-1234',
-        service_type: 'pathologist_report',
-        quotes: [
-          build(
-            :primary_quote,
-            cost_type: 'per_hour',
-            period: 180,
-            cost_per_hour: '3.50',
-            travel_time: 90,
-            travel_cost_per_hour: '100.00',
-            travel_cost_reason: 'Client detained in prison',
-          ),
-          build(:alternative_quote)
-        ],
-        additional_costs: [],
-      )
-    )
-  end
+    it 'allows me to adjust the travel time' do
+      fill_in 'Hours', with: 1
+      fill_in 'Minutes', with: 0
+      fill_in 'Explain your decision', with: 'travel cost adjustment explanation'
+      click_on 'Save changes'
 
-  it 'allows me to adjust the travel time' do
-    fill_in 'Hours', with: 1
-    fill_in 'Minutes', with: 0
-    fill_in 'Explain your decision', with: 'travel cost adjustment explanation'
-    click_on 'Save changes'
+      expect(page).to have_title('Adjustments')
+      expect(page).to have_css('.govuk-inset-text', text: 'travel cost adjustment explanation')
 
-    expect(page).to have_title('Adjustments')
-    expect(page).to have_css('.govuk-inset-text', text: 'travel cost adjustment explanation')
+      within('.govuk-table#travel_costs') do
+        expect(page)
+          .to have_content('Amount1 hour 30 minutes1 hour 0 minutes')
+          .and have_content('Rate£100.00 per hour£100.00 per hour')
+          .and have_content('Total£150.00£100.0')
+      end
+    end
 
-    within('.govuk-table#travel_costs') do
-      expect(page)
-        .to have_content('Amount1 hour 30 minutes1 hour 0 minutes')
-        .and have_content('Rate£100.00 per hour£100.00 per hour')
-        .and have_content('Total£150.00£100.0')
+    it 'allows me to adjust the cost per hour' do
+      fill_in 'Cost per hour', with: '90.00'
+      fill_in 'Explain your decision', with: 'travel cost adjustment explanation'
+      click_on 'Save changes'
+
+      expect(page).to have_title('Adjustments')
+      expect(page).to have_css('.govuk-inset-text', text: 'travel cost adjustment explanation')
+
+      within('.govuk-table#travel_costs') do
+        expect(page)
+          .to have_content('Amount1 hour 30 minutes1 hour 30 minutes')
+          .and have_content('Rate£100.00 per hour£90.00 per hour')
+          .and have_content('Total£150.00£135.0')
+      end
+    end
+
+    it 'warns me that I have not made any changes' do
+      fill_in 'Explain your decision', with: 'oops!'
+      click_on 'Save changes'
+
+      expect(page).to have_title('Adjust travel costs')
+      expect(page).to have_content('There are no changes to save. ' \
+                                   'Select cancel if you do not want to make any changes.')
+    end
+
+    it 'allows me to cancel and return to adjustments page' do
+      click_on 'Cancel'
+      expect(page).to have_title('Adjustments')
+    end
+
+    it 'allows me to recalculate the values on the page', :javascript do
+      fill_in 'Hours', with: 2
+      fill_in 'Minutes', with: 0
+      fill_in 'Cost per hour', with: '100.00'
+
+      expect(page).to have_css('#adjusted-cost', text: '0.00')
+      click_on 'Calculate my changes'
+      expect(page).to have_css('#adjusted-cost', text: '200.00')
     end
   end
 
-  it 'allows me to adjust the cost per hour' do
-    fill_in 'Cost per hour', with: '90.00'
-    fill_in 'Explain your decision', with: 'travel cost adjustment explanation'
-    click_on 'Save changes'
+  context 'travel cost not entered and no additional quote' do
+    let(:quotes) do
+      [
+        build(
+          :primary_quote,
+          cost_type: 'per_hour',
+          period: 180,
+          cost_per_hour: '3.50',
+          travel_time: nil,
+          travel_cost_per_hour: nil,
+        )
+      ]
+    end
 
-    expect(page).to have_title('Adjustments')
-    expect(page).to have_css('.govuk-inset-text', text: 'travel cost adjustment explanation')
-
-    within('.govuk-table#travel_costs') do
-      expect(page)
-        .to have_content('Amount1 hour 30 minutes1 hour 30 minutes')
-        .and have_content('Rate£100.00 per hour£90.00 per hour')
-        .and have_content('Total£150.00£135.0')
+    it 'does not allow travel costs to be adjusted if no additional quote' do
+      expect(page).to have_no_link('Adjust travel costs')
     end
   end
 
-  it 'warns me that I have not made any changes' do
-    fill_in 'Explain your decision', with: 'oops!'
-    click_on 'Save changes'
+  context 'travel cost not entered and additional quote' do
+    let(:quotes) do
+      [
+        build(
+          :primary_quote,
+          cost_type: 'per_hour',
+          period: 180,
+          cost_per_hour: '3.50',
+          travel_time: nil,
+          travel_cost_per_hour: nil,
+        ),
+        build(:alternative_quote)
+      ]
+    end
 
-    expect(page).to have_title('Adjust travel costs')
-    expect(page).to have_content('There are no changes to save. ' \
-                                 'Select cancel if you do not want to make any changes.')
-  end
+    before do
+      click_on 'Adjust travel costs'
+      expect(page).to have_title('Adjust travel costs')
+    end
 
-  it 'allows me to cancel and return to adjustments page' do
-    click_on 'Cancel'
-    expect(page).to have_title('Adjustments')
-  end
+    it 'allows me to adjust the cost per hour' do
+      fill_in 'Hours', with: 1
+      fill_in 'Minutes', with: 0
+      fill_in 'Cost per hour', with: '100.00'
+      fill_in 'Explain your decision', with: 'travel cost adjustment explanation'
+      click_on 'Save changes'
 
-  it 'allows me to recalculate the values on the page', :javascript do
-    fill_in 'Hours', with: 2
-    fill_in 'Minutes', with: 0
-    fill_in 'Cost per hour', with: '100.00'
+      expect(page).to have_title('Adjustments')
+      expect(page).to have_css('.govuk-inset-text', text: 'travel cost adjustment explanation')
 
-    expect(page).to have_css('#adjusted-cost', text: '0.00')
-    click_on 'Calculate my changes'
-    expect(page).to have_css('#adjusted-cost', text: '200.00')
+      within('.govuk-table#travel_costs') do
+        expect(page)
+          .to have_content('1 hour 0 minutes')
+          .and have_content('£100.00 per hour')
+          .and have_content('£100.0')
+      end
+    end
   end
 end

--- a/spec/system/prior_authority/view_adjust_quote_spec.rb
+++ b/spec/system/prior_authority/view_adjust_quote_spec.rb
@@ -186,13 +186,12 @@ RSpec.describe 'View Adjust quote tab', :stub_oauth_token do
       )
     end
 
-    it 'does not show the travel costs summary' do
-      expect(page).to have_no_content('Travel cost')
-        .and have_no_content('Reason for travel cost')
-        .and have_no_css('.govuk-table#travel_costs')
+    it 'show the travel costs summary' do
+      expect(page).to have_content('Travel cost')
+      expect(page).to have_content('Adjust travel costs')
     end
 
-    it 'does not show any addtional costs summaries' do
+    it 'show any addtional costs summaries' do
       expect(page).to have_no_content('Additional cost')
         .and have_no_content('Cost description"')
         .and have_no_css('.govuk-table#tadditional_cost_1')

--- a/spec/view_models/prior_authority/v1/quote_spec.rb
+++ b/spec/view_models/prior_authority/v1/quote_spec.rb
@@ -620,7 +620,7 @@ RSpec.describe PriorAuthority::V1::Quote do
       end
 
       context 'with adjusted travel cost per hour' do
-        let(:attributes) { { travel_cost_per_hour: '25.00', travel_cost_per_hour_original: '30.00' } }
+        let(:attributes) { { travel_cost_per_hour: '25.00', travel_cost_per_hour_original: '30.00', travel_time_original: 60 } }
 
         it 'returns formatted original travel cost per hour' do
           expect(requested_formatted_travel_cost_per_hour).to eql '£30.00 per hour'
@@ -628,7 +628,7 @@ RSpec.describe PriorAuthority::V1::Quote do
       end
 
       context 'with unadjusted travel cost per hour' do
-        let(:attributes) { { travel_cost_per_hour: '28:00' } }
+        let(:attributes) { { travel_cost_per_hour: '28:00', travel_time_original: 60 } }
 
         it 'returns formatted travel cost per hour' do
           expect(requested_formatted_travel_cost_per_hour).to eql '£28.00 per hour'


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2532)

- [x] system test

## Notes for reviewer

allows a Caseworker to add a travel cost adjustment to the primary quote when the primary quote does not originally contain a requested travel cost from the provider. 

## Screenshots of changes (if applicable)

### Before changes:
![Screenshot 2025-07-07 at 15 45 22](https://github.com/user-attachments/assets/a90ca334-6a82-4498-84b4-44cea0c6332d)
![Screenshot 2025-07-07 at 15 45 43](https://github.com/user-attachments/assets/ccedc7d4-6ff1-455b-96e6-434976693704)

### After changes:
![Screenshot 2025-07-07 at 15 41 52](https://github.com/user-attachments/assets/ecbe6e15-5472-4009-8b67-1e83280f02c2)
![Screenshot 2025-07-07 at 15 42 39](https://github.com/user-attachments/assets/cc13c179-8c9e-44c4-b18f-82cd668c495a)

## How to manually test the feature
