### PR TITLE
CRM457-3034: Fix Assigned Counsel Journey with Digital NSM Linked

### DIFF
--- a/app/models/payments/base_selected_transformer.rb
+++ b/app/models/payments/base_selected_transformer.rb
@@ -40,13 +40,13 @@ module Payments
         claim.merge!(
           {
             nsm_claim_id: claim['id'],
-            linked_nsm_ref: claim['laa_reference'],
+            linked_nsm_reference: claim['laa_reference'],
             laa_reference: nil
           }
         )
       else
         claim[:nsm_claim_id] = claim.dig('nsm_claim', 'id')
-        claim[:linked_nsm_ref] = claim.dig('nsm_claim', 'laa_reference')
+        claim[:linked_nsm_reference] = claim.dig('nsm_claim', 'laa_reference')
       end
       claim.except!(*NSM_KEYS)
     end

--- a/app/presenters/payments/check_your_answers/ac_claim_details_card.rb
+++ b/app/presenters/payments/check_your_answers/ac_claim_details_card.rb
@@ -91,7 +91,7 @@ module Payments
       private
 
       def linked_claim?
-        session_answers['linked_nsm_ref'].present? || session_answers['laa_reference'].present?
+        session_answers['linked_nsm_reference'].present? || session_answers['laa_reference'].present?
       end
     end
   end

--- a/app/presenters/payments/check_your_answers/linked_claim_card.rb
+++ b/app/presenters/payments/check_your_answers/linked_claim_card.rb
@@ -40,7 +40,7 @@ module Payments
       def linked_ref
         ref = nil
         if ac?
-          ref = session_answers['linked_nsm_ref']
+          ref = session_answers['linked_nsm_reference']
         elsif nsm_addition?
           ref = session_answers['linked_laa_reference'] || session_answers['laa_reference']
         elsif nsm_original?

--- a/app/services/decisions/multi_step_form_session.rb
+++ b/app/services/decisions/multi_step_form_session.rb
@@ -34,7 +34,7 @@ module Decisions
     end
 
     def no_existing_ref?
-      answers['laa_reference'].blank? && answers['linked_nsm_ref'].blank?
+      answers['laa_reference'].blank? && answers['linked_nsm_reference'].blank? && answers['linked_laa_reference'].blank?
     end
 
     def ac_claim_details_incomplete?

--- a/spec/models/payments/selected_claim_transformer_spec.rb
+++ b/spec/models/payments/selected_claim_transformer_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Payments::SelectedClaimTransformer do
         result = transformer.transform
 
         expect(result[:nsm_claim_id]).to eq('nsm-456')
-        expect(result[:linked_nsm_ref]).to eq('LAA-linked')
+        expect(result[:linked_nsm_reference]).to eq('LAA-linked')
         expect(result).not_to have_key(:nsm_claim)
       end
     end

--- a/spec/models/payments/selected_submission_transformer_spec.rb
+++ b/spec/models/payments/selected_submission_transformer_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Payments::SelectedSubmissionTransformer do
         result = transformer.transform
 
         expect(result[:nsm_claim_id]).to eq('crm7-abc')
-        expect(result[:linked_nsm_ref]).to eq('LAA-CRM7')
+        expect(result[:linked_nsm_reference]).to eq('LAA-CRM7')
         expect(result[:laa_reference]).to be_nil
       end
     end
@@ -83,7 +83,7 @@ RSpec.describe Payments::SelectedSubmissionTransformer do
         result = transformer.transform
 
         expect(result[:nsm_claim_id]).to eq('nsm-123')
-        expect(result[:linked_nsm_ref]).to eq('LAA-NSM')
+        expect(result[:linked_nsm_reference]).to eq('LAA-NSM')
       end
     end
   end

--- a/spec/presenters/payments/check_your_answers/ac_claim_details_card_spec.rb
+++ b/spec/presenters/payments/check_your_answers/ac_claim_details_card_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Payments::CheckYourAnswers::AcClaimDetailsCard do
       let(:session_answers) do
         {
           'request_type' => 'assigned_counsel',
-          'linked_nsm_ref' => 'LAA-NSM-123'
+          'linked_nsm_reference' => 'LAA-NSM-123'
         }
       end
 

--- a/spec/presenters/payments/check_your_answers/linked_claim_card_spec.rb
+++ b/spec/presenters/payments/check_your_answers/linked_claim_card_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Payments::CheckYourAnswers::LinkedClaimCard do
       {
         'request_type' => 'assigned_counsel_amendment',
         'laa_reference' => 'LAA-AC-123',
-        'linked_nsm_ref' => 'LAA-NSM-999'
+        'linked_nsm_reference' => 'LAA-NSM-999'
       }
     end
 


### PR DESCRIPTION

## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-3034)

## Notes for reviewer

- Include "linked_laa_reference" in list of things that need to be not present for claim search page to go to office code search when on an AC claim
- Change variable "linked_nsm_ref" to "linked_nsm_reference" for naming consistency