### PR TITLE
CRM457-2024: AC Scenarios - Fix VAT Totalling

### DIFF
--- a/app/forms/payments/steps/base_payments_form.rb
+++ b/app/forms/payments/steps/base_payments_form.rb
@@ -47,7 +47,7 @@ module Payments
       private
 
       def calculated_costs
-        attribute_names.grep(/_cost$/).sum { |attr| public_send(attr).to_d }
+        attribute_names.grep(/(_cost|_vat)$/).sum { |attr| public_send(attr).to_d }
       end
 
       # :nocov:

--- a/spec/system/payments/ac_payment_request_spec.rb
+++ b/spec/system/payments/ac_payment_request_spec.rb
@@ -84,6 +84,7 @@ payment_request: { claimed_total: 100, allowed_total: 10, request_type: 'assigne
       expect(page).not_to have_field('Unique file number', with: '120223/001')
     end
 
+    # rubocop:disable RSpec/MultipleExpectations
     it 'allows user to complete payment journey' do
       expect(page).to have_title('Claim Details')
       fill_ac_claim_details(linked_claim: true)
@@ -100,10 +101,14 @@ payment_request: { claimed_total: 100, allowed_total: 10, request_type: 'assigne
 
       expect(page).to have_title('Check your answers')
       expect(page).to have_content('Claimed and allowed costs')
+      total_row = find('tfoot.govuk-table__foot')
+      expect(total_row).to have_text('£250.40')
+      expect(total_row).to have_text('£170.00')
       click_on 'Submit payment request'
 
       expect(page).to have_content('Payment request complete')
     end
+    # rubocop:enable RSpec/MultipleExpectations
 
     it 'sends Claim details Change to claim search from CYA' do
       expect(page).to have_title('Claim Details')


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-3034)

## Notes for reviewer
Ensures fields ending with "_vat" also get included when calculating costs in forms

## Screenshots of changes (if applicable)

### Before changes:
<img width="991" height="400" alt="image" src="https://github.com/user-attachments/assets/55d283ed-c244-4dcd-8698-e9e759ba2fa7" />

### After changes:
<img width="991" height="400" alt="image" src="https://github.com/user-attachments/assets/ed966440-df21-46c0-b2d6-97b270d4e64b" />

## How to manually test the feature
Create any assigned counsel payment add non zero costs for both net counsel fees and vat, go to check your answers page (also payment confirmation page)