### PR TITLE
CRM457-3034: AC Scenario Fixes 3 

### DIFF
--- a/app/view_models/payments/costs_summary_amended.rb
+++ b/app/view_models/payments/costs_summary_amended.rb
@@ -11,7 +11,7 @@ module Payments
     def headers
       [
         '',
-        (t('original_total_allowed') if session_answers['claimed_total'].present?),
+        (t('original_total_allowed') if session_answers['original_allowed_total'].present?),
         t('total_allowed')
       ].compact
     end
@@ -29,7 +29,7 @@ module Payments
     def formatted_summed_fields
       {
         name: t('total', numeric: false),
-        original_total_allowed: (if session_answers['claimed_total'].present?
+        original_total_allowed: (if session_answers['original_allowed_total'].present?
                                    format(session_answers['original_allowed_total'].to_f)
                                  end),
         total_allowed: format(session_answers['allowed_total'].to_f)
@@ -41,7 +41,7 @@ module Payments
     def build_row(type)
       {
         name: t(type, numeric: false),
-        original_total_allowed: (if session_answers['claimed_total'].present?
+        original_total_allowed: (if session_answers["original_allowed_#{type}"].present?
                                    format(session_answers["original_allowed_#{type}"].to_f)
                                  end),
         total_allowed: format(session_answers["allowed_#{type}"].to_f)


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-3034)

## Notes for reviewer
<img width="700" height="68" alt="image" src="https://github.com/user-attachments/assets/6961b073-d3ce-40ec-9620-fffcf6250010" />

Ensures originally allowed total column always shows in CYA page in appeals/amendments when linked to an existing claim 
Note that this was previously not working for appeals/amendments linked to an existing AC payment that has an appeal/amendment only

## Screenshots of changes (if applicable)

### Before changes:
<img width="989" height="384" alt="image" src="https://github.com/user-attachments/assets/6ec20b87-caca-4839-9881-31cf0ebe0620" />


### After changes:
<img width="989" height="384" alt="image" src="https://github.com/user-attachments/assets/5ef84924-67ad-4832-8a39-8e6deeef2047" />

## How to manually test the feature
