### PR TITLE
Don't apply Unix Command Injection rule to Post args

### DIFF
--- a/helm_deploy/templates/ingress.yaml
+++ b/helm_deploy/templates/ingress.yaml
@@ -38,6 +38,7 @@ metadata:
       SecRuleRemoveById 952100
       SecRuleUpdateTargetById 932115 "!ARGS"
       SecRuleUpdateTargetById 932380 "!ARGS"
+      SecRuleUpdateTargetById 932100 "!ARGS"
       SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"
       SecAction "id:900110,phase:1,nolog,pass,t:none,setvar:tx.inbound_anomaly_score_threshold=25"
     external-dns.alpha.kubernetes.io/aws-weight: "100"


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-3057)

## Notes for reviewer
Removes scanning requests args for Unix Command Injection Rule due to too many false positives 
