### PR TITLE
CRM457-3063: Increase security on multiline text sanitization

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -60,6 +60,10 @@ module ApplicationHelper
     sanitize(string.gsub("\n", '<br>'), tags: %w[br])
   end
 
+  def safer_simple_format(string)
+    simple_format(string, {}, sanitize_options: { tags: %w[br p] })
+  end
+
   def govuk_error_summary(form_object)
     return if form_object.try(:errors).blank?
 

--- a/app/view_models/base_view_model.rb
+++ b/app/view_models/base_view_model.rb
@@ -55,7 +55,7 @@ class BaseViewModel
 
   private
 
-  delegate :sanitize, :format_in_zone, :format_period, :multiline_text,
+  delegate :sanitize, :format_in_zone, :format_period, :multiline_text, :safer_simple_format,
            to: :helpers
 
   def helpers

--- a/app/view_models/nsm/v1/further_information.rb
+++ b/app/view_models/nsm/v1/further_information.rb
@@ -38,7 +38,7 @@ module Nsm
       end
 
       def provider_response
-        response_content = [simple_format(information_supplied)]
+        response_content = [safer_simple_format(information_supplied)]
         response_content.concat(uploaded_documents.flat_map { [tag.br, document_link(_1)] })
         safe_join(response_content)
       end

--- a/app/view_models/prior_authority/v1/application_details/alternative_quote_card.rb
+++ b/app/view_models/prior_authority/v1/application_details/alternative_quote_card.rb
@@ -23,7 +23,7 @@ module PriorAuthority
         def additional_items
           return I18n.t('prior_authority.application_details.none') if additional_cost_list.blank?
 
-          simple_format(additional_cost_list)
+          safer_simple_format(additional_cost_list)
         end
 
         def additional_label

--- a/app/view_models/prior_authority/v1/application_details/base_card.rb
+++ b/app/view_models/prior_authority/v1/application_details/base_card.rb
@@ -6,6 +6,7 @@ module PriorAuthority
         include ActionView::Helpers::OutputSafetyHelper
         include ActionView::Helpers::UrlHelper
         include ActionView::Helpers::TextHelper
+        include ApplicationHelper
         include NameConstructable
 
         CARD_ROWS = [].freeze

--- a/app/view_models/prior_authority/v1/application_details/further_information_card.rb
+++ b/app/view_models/prior_authority/v1/application_details/further_information_card.rb
@@ -18,12 +18,12 @@ module PriorAuthority
         end
 
         def information_request
-          simple_format(@further_information['information_requested'])
+          safer_simple_format(@further_information['information_requested'])
         end
 
         def provider_response
           safe_join(
-            [simple_format(@further_information['information_supplied'])] +
+            [safer_simple_format(@further_information['information_supplied'])] +
              documents.flat_map { [tag.br, document_link(_1)] }
           )
         end

--- a/app/view_models/prior_authority/v1/application_details/hearing_details_card.rb
+++ b/app/view_models/prior_authority/v1/application_details/hearing_details_card.rb
@@ -35,7 +35,7 @@ module PriorAuthority
         def psychiatric_liaison_reason_not
           return if application_details.psychiatric_liaison_reason_not.blank?
 
-          simple_format(application_details.psychiatric_liaison_reason_not)
+          safer_simple_format(application_details.psychiatric_liaison_reason_not)
         end
       end
     end

--- a/app/view_models/prior_authority/v1/application_details/incorrect_information_card.rb
+++ b/app/view_models/prior_authority/v1/application_details/incorrect_information_card.rb
@@ -18,7 +18,7 @@ module PriorAuthority
         end
 
         def information_request
-          simple_format(@incorrect_information['information_requested'])
+          safer_simple_format(@incorrect_information['information_requested'])
         end
 
         def provider_response

--- a/app/view_models/prior_authority/v1/application_details/no_alternative_quotes_card.rb
+++ b/app/view_models/prior_authority/v1/application_details/no_alternative_quotes_card.rb
@@ -5,7 +5,7 @@ module PriorAuthority
         CARD_ROWS = %i[no_alternative_quote_reason].freeze
 
         def no_alternative_quote_reason
-          simple_format(application_details.no_alternative_quote_reason)
+          safer_simple_format(application_details.no_alternative_quote_reason)
         end
       end
     end

--- a/app/view_models/prior_authority/v1/application_details/primary_quote_card.rb
+++ b/app/view_models/prior_authority/v1/application_details/primary_quote_card.rb
@@ -43,7 +43,7 @@ module PriorAuthority
         end
 
         def travel_cost_reason
-          simple_format(quote.travel_cost_reason) if quote.travel_cost_reason.present?
+          safer_simple_format(quote.travel_cost_reason) if quote.travel_cost_reason.present?
         end
 
         def service_label

--- a/app/view_models/prior_authority/v1/application_details/reason_why_card.rb
+++ b/app/view_models/prior_authority/v1/application_details/reason_why_card.rb
@@ -7,7 +7,7 @@ module PriorAuthority
         delegate :supporting_documents, to: :application_details
 
         def reason_why
-          simple_format(application_details.reason_why)
+          safer_simple_format(application_details.reason_why)
         end
 
         def supporting_document_string

--- a/app/views/nsm/claim_details/show.html.erb
+++ b/app/views/nsm/claim_details/show.html.erb
@@ -11,7 +11,7 @@
       <div class="govuk-inset-text">
         <p><strong><%= t(".sent_back", date: claim_summary.sent_back_on.to_fs(:stamp)) %></strong></p>
         <%= t(".further_information_request") %>
-        <%= simple_format claim_summary.assessment_comment %>
+        <%= safer_simple_format claim_summary.assessment_comment %>
       </div>
     <% elsif claim.provider_updated? %>
       <div class="govuk-inset-text">
@@ -21,7 +21,7 @@
     <% elsif claim.assessed? && (claim_summary.assessment_comment.present? || claim.eligible_for_payment_request?) %>
       <div class="govuk-inset-text">
         <p><strong><%= t(".assessed_statuses.#{claim.state}") %></strong></p>
-        <%= simple_format claim_summary.assessment_comment %>
+        <%= safer_simple_format claim_summary.assessment_comment %>
         <% if claim.eligible_for_payment_request? %>
           <div class="govuk-button-group">
             <%= govuk_link_to(t('.create_payment_request'),

--- a/app/views/nsm/decisions/show.html.erb
+++ b/app/views/nsm/decisions/show.html.erb
@@ -30,7 +30,7 @@
           <%= t('.comments') %>
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= simple_format @decision.comments.presence || t('.no_comments') %>
+          <%= safer_simple_format @decision.comments.presence || t('.no_comments') %>
         </dd>
       </div>
     </dl>

--- a/app/views/nsm/send_backs/show.html.erb
+++ b/app/views/nsm/send_backs/show.html.erb
@@ -23,7 +23,7 @@
           <%= t('.further_information') %>
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= simple_format @claim.data['assessment_comment'] %>
+          <%= safer_simple_format @claim.data['assessment_comment'] %>
         </dd>
       </div>
     </dl>

--- a/app/views/prior_authority/adjustments/_additional_costs.html.erb
+++ b/app/views/prior_authority/adjustments/_additional_costs.html.erb
@@ -4,12 +4,12 @@
 
   <% if additional_cost.adjustment_comment %>
     <div class="govuk-inset-text">
-      <%= simple_format additional_cost.adjustment_comment %>
+      <%= safer_simple_format additional_cost.adjustment_comment %>
     </div>
   <% end %>
 
   <p><%= t(".cost_description", name: additional_cost.name) %></p>
-  <%= simple_format additional_cost.description %>
+  <%= safer_simple_format additional_cost.description %>
 
   <%= govuk_table(id: "additional_cost_#{index + 1}") do |table|
         table.with_head do |head|

--- a/app/views/prior_authority/adjustments/_service_costs.html.erb
+++ b/app/views/prior_authority/adjustments/_service_costs.html.erb
@@ -4,7 +4,7 @@
 
 <% if service_cost.adjustment_comment %>
   <div class="govuk-inset-text">
-    <%= simple_format service_cost.adjustment_comment %>
+    <%= safer_simple_format service_cost.adjustment_comment %>
   </div>
 <% end %>
 

--- a/app/views/prior_authority/adjustments/_travel_costs.erb
+++ b/app/views/prior_authority/adjustments/_travel_costs.erb
@@ -4,13 +4,13 @@
 
 <% if quote.travel_adjustment_comment %>
   <div class="govuk-inset-text">
-    <%= simple_format quote.travel_adjustment_comment %>
+    <%= safer_simple_format quote.travel_adjustment_comment %>
   </div>
 <% end %>
 
 <% if quote.travel_cost_reason %>
   <p><%= t(".cost_description") %></p>
-  <%= simple_format quote.travel_cost_reason %>
+  <%= safer_simple_format quote.travel_cost_reason %>
 <% end %>
 
 <%= govuk_table(id: 'travel_costs') do |table|

--- a/app/views/prior_authority/applications/show.html.erb
+++ b/app/views/prior_authority/applications/show.html.erb
@@ -12,7 +12,7 @@
     <% if @summary.assessed? && @details.assessment_comment.present? %>
       <div class="govuk-inset-text">
         <p><strong><%= t(".assessed_statuses.#{@details.submission.state}") %></strong></p>
-        <p> <%= simple_format @details.assessment_comment %></p>
+        <p> <%= safer_simple_format @details.assessment_comment %></p>
         <% if @details.submission.part_grant? %>
           <p> <%= link_to t('.review_adjustments'), prior_authority_application_adjustments_path(@summary.id) %></p>
         <% end %>
@@ -22,11 +22,11 @@
         <p><strong><%= t(".sent_back", date: @summary.date_updated_str) %></strong></p>
         <% if @details.further_information_requested? %>
           <p><%= t('.further_information') %></p>
-          <%= simple_format @details.further_information_explanation %>
+          <%= safer_simple_format @details.further_information_explanation %>
         <% end %>
         <% if @details.corrections_requested? %>
           <p><%= t('.incorrect_information') %></p>
-          <%= simple_format @details.incorrect_information_explanation %>
+          <%= safer_simple_format @details.incorrect_information_explanation %>
         <% end %>
       </div>
     <% elsif @summary.provider_updated? %>

--- a/app/views/prior_authority/decisions/show.html.erb
+++ b/app/views/prior_authority/decisions/show.html.erb
@@ -34,7 +34,7 @@
           <%= t('.comments') %>
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= simple_format @decision.comments.presence || t('.no_comments') %>
+          <%= safer_simple_format @decision.comments.presence || t('.no_comments') %>
         </dd>
       </div>
     </dl>

--- a/app/views/prior_authority/events/index.html.erb
+++ b/app/views/prior_authority/events/index.html.erb
@@ -51,7 +51,7 @@
                     </strong>
                     <% if event.comment? %>
                       <br>
-                      <%= simple_format event.comment %>
+                      <%= safer_simple_format event.comment %>
                     <% end %>
                   </td>
                 </tr>

--- a/app/views/prior_authority/send_backs/show.html.erb
+++ b/app/views/prior_authority/send_backs/show.html.erb
@@ -28,7 +28,7 @@
               <%= t('.further_information') %>
             </dt>
             <dd class="govuk-summary-list__value">
-              <%= simple_format @model.further_information_explanation %>
+              <%= safer_simple_format @model.further_information_explanation %>
             </dd>
           </div>
         <% end %>
@@ -39,7 +39,7 @@
               <%= t('.incorrect_information') %>
             </dt>
             <dd class="govuk-summary-list__value">
-              <%= simple_format @model.incorrect_information_explanation %>
+              <%= safer_simple_format @model.incorrect_information_explanation %>
             </dd>
           </div>
         <% end %>


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-3063)

## Notes for reviewer

- Add new `safer_simple_format` method to ApplicationHelper that ensures only `<p>` and `<br>` tags are allowed
- Use `safer_simple_format` instead of `simple_format`