### PR TITLE
CRM457-3077: Provider Data API is called as an instance class

### DIFF
--- a/app/services/provider_data/provider_data_client.rb
+++ b/app/services/provider_data/provider_data_client.rb
@@ -1,7 +1,7 @@
 module ProviderData
   class ProviderDataClient
     def initialize
-      @client = FeatureFlags.provider_api.enabled? ? ProviderDataApiClient.new : LocalDataClient.new
+      @client = FeatureFlags.provider_api.enabled? ? ProviderDataApiClient : LocalDataClient.new
     end
 
     delegate :contracted_office_details, to: :@client

--- a/spec/services/provider_data/provider_data_client_spec.rb
+++ b/spec/services/provider_data/provider_data_client_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ProviderData::ProviderDataClient do
       end
 
       it 'uses ProviderDataApiClient' do
-        expect(described_class.new.instance_variable_get(:@client)).to be_a(ProviderData::ProviderDataApiClient)
+        expect(described_class.instance_variable_get(:@client)).to be_a(ProviderData::ProviderDataApiClient)
       end
     end
 

--- a/spec/services/provider_data/provider_data_client_spec.rb
+++ b/spec/services/provider_data/provider_data_client_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe ProviderData::ProviderDataClient do
       end
 
       it 'uses ProviderDataApiClient' do
-        expect(described_class.instance_variable_get(:@client)).to be_a(ProviderData::ProviderDataApiClient)
+        expect(described_class.new.instance_variable_get(:@client)).to eq(ProviderData::ProviderDataApiClient)
       end
     end
 


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-XXX)

## Notes for reviewer
- Ensures ProviderDataApiClient is called as a singleton