### PR TITLE
CRM457-3078: Assess: Provider Data API schedule endpoint cannot retreive data in UAT

### DIFF
--- a/app/services/provider_data/provider_data_api_client.rb
+++ b/app/services/provider_data/provider_data_api_client.rb
@@ -6,6 +6,8 @@ module ProviderData
     headers 'X-Authorization' => ENV.fetch('PROVIDER_API_KEY')
     format :json
 
+    PROVIDER_API_EFFECTIVE_DATE_PARAM = ENV.fetch('PROVIDER_API_EFFECTIVE_DATE_PARAM', '01-01-2025').freeze
+
     class << self
       def office_details(office_code)
         query(
@@ -19,10 +21,13 @@ module ProviderData
       end
 
       def contracted_office_details(office_code)
+        # effective_date only used in UAT environment
+        effective_date = HostEnv.uat? ? PROVIDER_API_EFFECTIVE_DATE_PARAM : nil
         # :nocov: Querying an external API
         params = {
-          'areaOfLaw' => 'CRIME LOWER'
-        }
+          'areaOfLaw' => 'CRIME LOWER',
+          'effectiveDate' => effective_date
+        }.compact
         # :nocov:
 
         query(

--- a/helm_deploy/templates/deployment-worker.yaml
+++ b/helm_deploy/templates/deployment-worker.yaml
@@ -192,6 +192,8 @@ spec:
                   key: MAINTENANCE_MODE
             - name: SENTRY_TRACE_SAMPLE_RATE
               value: {{ .Values.variables.sentryTraceSampleRate }}
+            - name: PROVIDER_API_EFFECTIVE_DATE_PARAM
+              value: '{{ .Values.variables.providerApiEffectiveDate }}'
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm_deploy/templates/deployment.yaml
+++ b/helm_deploy/templates/deployment.yaml
@@ -230,6 +230,8 @@ spec:
                   key: MAINTENANCE_MODE
             - name: SENTRY_TRACE_SAMPLE_RATE
               value: {{ .Values.variables.sentryTraceSampleRate }}
+            - name: PROVIDER_API_EFFECTIVE_DATE_PARAM
+              value: '{{ .Values.variables.providerApiEffectiveDate }}'
 
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/helm_deploy/values-uat.yaml
+++ b/helm_deploy/values-uat.yaml
@@ -63,6 +63,7 @@ variables:
   enableSyncTriggerEndpoint: 'false'
   allowIndexing: 'false'
   providerApiHost: https://laa-provider-details-api-preprod.apps.live.cloud-platform.service.justice.gov.uk
+  providerApiEffectiveDate: 01-01-2025
 
 service_account:
   name: laa-assess-crime-forms-uat-irsa

--- a/spec/services/provider_data/provider_data_api_client_spec.rb
+++ b/spec/services/provider_data/provider_data_api_client_spec.rb
@@ -71,7 +71,63 @@ RSpec.describe ProviderData::ProviderDataApiClient do
       stub_request(:head, api_url).to_return(status: code, body: body)
     end
 
-    context 'when there are office details returned' do
+    context 'when running locally' do
+      before do
+        allow(HostEnv).to receive(:uat?).and_return(false)
+      end
+
+      context 'when there are office details returned' do
+        let(:code) { 200 }
+        let(:body) do
+          {
+            'office' => {
+              'firmOfficeId' => 1,
+              'ccmsFirmOfficeId' => 1,
+              'firmOfficeCode' => '1A123B',
+              'officeName' => 'Firm & Sons',
+              'officeCodeAlt' => '1A123B',
+              'type' => 'Solicitor'
+            }
+          }.to_json
+        end
+
+        it 'returns the correct office details' do
+          expect(described_class.contracted_office_details(office_code)).to eq(
+            {
+              'firmOfficeId' => 1,
+              'ccmsFirmOfficeId' => 1,
+              'firmOfficeCode' => '1A123B',
+              'officeName' => 'Firm & Sons',
+              'officeCodeAlt' => '1A123B',
+              'type' => 'Solicitor'
+            }
+          )
+        end
+      end
+
+      context 'when there are no office details returned' do
+        let(:code) { 204 }
+        let(:body) { {}.to_json }
+
+        it 'returns nil' do
+          expect(described_class.contracted_office_details(office_code)).to be_nil
+        end
+      end
+
+      context 'when an unexpected status code is returned' do
+        let(:code) { 500 }
+        let(:body) { {}.to_json }
+
+        it 'raises an error' do
+          expect do
+            described_class.contracted_office_details(office_code)
+          end.to raise_error(StandardError, /Unexpected status code 500/)
+        end
+      end
+    end
+
+    context 'when running in UAT environment' do
+      let(:api_url) { "https://provider-api.example.com/provider-offices/#{office_code}/schedules?areaOfLaw=CRIME+LOWER&effectiveDate=01-01-2025" }
       let(:code) { 200 }
       let(:body) do
         {
@@ -86,37 +142,14 @@ RSpec.describe ProviderData::ProviderDataApiClient do
         }.to_json
       end
 
+      before do
+        allow(HostEnv).to receive(:uat?).and_return(true)
+        stub_request(:head, api_url).to_return(status: code, body: body)
+      end
+
       it 'returns the correct office details' do
-        expect(described_class.contracted_office_details(office_code)).to eq(
-          {
-            'firmOfficeId' => 1,
-            'ccmsFirmOfficeId' => 1,
-            'firmOfficeCode' => '1A123B',
-            'officeName' => 'Firm & Sons',
-            'officeCodeAlt' => '1A123B',
-            'type' => 'Solicitor'
-          }
-        )
-      end
-    end
-
-    context 'when there are no office details returned' do
-      let(:code) { 204 }
-      let(:body) { {}.to_json }
-
-      it 'returns nil' do
-        expect(described_class.contracted_office_details(office_code)).to be_nil
-      end
-    end
-
-    context 'when an unexpected status code is returned' do
-      let(:code) { 500 }
-      let(:body) { {}.to_json }
-
-      it 'raises an error' do
-        expect do
-          described_class.contracted_office_details(office_code)
-        end.to raise_error(StandardError, /Unexpected status code 500/)
+        described_class.contracted_office_details(office_code)
+        expect(WebMock).to have_requested(:head, api_url)
       end
     end
   end


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-3078)

## Notes for reviewer

- Add `effectiveDate` param to schedule endpoint usage
- Add tests