### PR TITLE
CRM457-3068 Part 3: Use granted/part-granted date for original_submission_date for appeals etc

### DIFF
--- a/app/view_models/nsm/v1/payment_claim_details.rb
+++ b/app/view_models/nsm/v1/payment_claim_details.rb
@@ -184,6 +184,7 @@ module Nsm
 
       def decision_date
         grant_event = submission.events.detect { |e| e.event_type == 'Event::Decision' }
+
         raise "No decision event found for submission: #{submission.id}" if grant_event.blank?
 
         grant_event.created_at

--- a/app/view_models/nsm/v1/payment_claim_details.rb
+++ b/app/view_models/nsm/v1/payment_claim_details.rb
@@ -183,7 +183,10 @@ module Nsm
       end
 
       def decision_date
-        submission.events.detect { |e| e.event_type == 'Event::Decision' }&.created_at
+        grant_event = submission.events.detect { |e| e.event_type == 'Event::Decision' }
+        raise "No decision event found for submission: #{submission.id}" if grant_event.blank?
+
+        grant_event.created_at
       end
     end
   end

--- a/app/view_models/nsm/v1/payment_claim_details.rb
+++ b/app/view_models/nsm/v1/payment_claim_details.rb
@@ -9,11 +9,11 @@ module Nsm
       delegate :id, to: :submission
 
       def original_submission_month
-        Date.current.month
+        original_submission_date.month
       end
 
       def original_submission_year
-        Date.current.year
+        original_submission_date.year
       end
 
       def linked_laa_reference
@@ -166,6 +166,24 @@ module Nsm
 
       def court_item
         LaaCrimeFormsCommon::Court.all.find { |c| submission.data[:court].downcase == c.name.downcase }
+      end
+
+      def original_submission_date
+        if request_type.in?(
+          %w[
+            non_standard_mag_appeal
+            non_standard_mag_amendment
+            non_standard_mag_supplemental
+          ]
+        )
+          decision_date
+        else
+          Date.current
+        end
+      end
+
+      def decision_date
+        submission.events.detect { |e| e.event_type == 'Event::Decision' }&.created_at
       end
     end
   end

--- a/spec/view_models/nsm/v1/payments/payment_claim_details_spec.rb
+++ b/spec/view_models/nsm/v1/payments/payment_claim_details_spec.rb
@@ -4,10 +4,11 @@ RSpec.describe Nsm::V1::PaymentClaimDetails do
   subject do
     described_class.new(
       submission: instance_double(Submission,
-                                  data: { court: })
+                                  data: { court: }, events: events)
     )
   end
 
+  let(:events) { [] }
   let(:court) { 'Acton - C2723' }
 
   describe '#court_name' do
@@ -34,6 +35,54 @@ RSpec.describe Nsm::V1::PaymentClaimDetails do
 
       it 'returns the custom court id label' do
         expect(subject.court_id).to eq(I18n.t('laa_crime_forms_common.shared.custom'))
+      end
+    end
+  end
+
+  describe '#original_submission_month' do
+    let(:events) { [instance_double(Event, event_type: 'Event::Decision', created_at: Date.new(2023, 5, 15))] }
+
+    context 'when request_type is non_standard_mag_appeal' do
+      before do
+        allow(subject).to receive(:request_type).and_return('non_standard_mag_appeal')
+      end
+
+      it 'returns the month of the original submission date' do
+        expect(subject.original_submission_month).to eq(5)
+      end
+    end
+
+    context 'when request_type is not non_standard_magistrate' do
+      before do
+        allow(subject).to receive(:request_type).and_return('non_standard_magistrate')
+      end
+
+      it 'returns the current month' do
+        expect(subject.original_submission_month).to eq(Date.current.month)
+      end
+    end
+  end
+
+  describe '#original_submission_year' do
+    let(:events) { [instance_double(Event, event_type: 'Event::Decision', created_at: Date.new(2023, 5, 15))] }
+
+    context 'when request_type is non_standard_mag_appeal' do
+      before do
+        allow(subject).to receive(:request_type).and_return('non_standard_mag_appeal')
+      end
+
+      it 'returns the year of the original submission date' do
+        expect(subject.original_submission_year).to eq(2023)
+      end
+    end
+
+    context 'when request_type is not non_standard_magistrate' do
+      before do
+        allow(subject).to receive(:request_type).and_return('non_standard_magistrate')
+      end
+
+      it 'returns the current year' do
+        expect(subject.original_submission_year).to eq(Date.current.year)
       end
     end
   end

--- a/spec/view_models/nsm/v1/payments/payment_claim_details_spec.rb
+++ b/spec/view_models/nsm/v1/payments/payment_claim_details_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Nsm::V1::PaymentClaimDetails do
   subject do
     described_class.new(
       submission: instance_double(Submission,
-                                  data: { court: }, events: events)
+                                  id: SecureRandom.uuid, data: { court: }, events: events)
     )
   end
 
@@ -41,8 +41,14 @@ RSpec.describe Nsm::V1::PaymentClaimDetails do
 
   describe '#original_submission_month' do
     context 'when there is no decision event' do
-      it 'returns the current month' do
-        expect(subject.original_submission_month).to eq(Date.current.month)
+      let(:events) { [instance_double(Event, event_type: 'Event::NewVersion', created_at: Date.new(2023, 5, 15))] }
+
+      before do
+        allow(subject).to receive(:request_type).and_return('non_standard_mag_appeal')
+      end
+
+      it 'raises an error' do
+        expect { subject.original_submission_month }.to raise_error RuntimeError
       end
     end
 

--- a/spec/view_models/nsm/v1/payments/payment_claim_details_spec.rb
+++ b/spec/view_models/nsm/v1/payments/payment_claim_details_spec.rb
@@ -40,25 +40,33 @@ RSpec.describe Nsm::V1::PaymentClaimDetails do
   end
 
   describe '#original_submission_month' do
-    let(:events) { [instance_double(Event, event_type: 'Event::Decision', created_at: Date.new(2023, 5, 15))] }
-
-    context 'when request_type is non_standard_mag_appeal' do
-      before do
-        allow(subject).to receive(:request_type).and_return('non_standard_mag_appeal')
-      end
-
-      it 'returns the month of the original submission date' do
-        expect(subject.original_submission_month).to eq(5)
+    context 'when there is no decision event' do
+      it 'returns the current month' do
+        expect(subject.original_submission_month).to eq(Date.current.month)
       end
     end
 
-    context 'when request_type is not non_standard_magistrate' do
-      before do
-        allow(subject).to receive(:request_type).and_return('non_standard_magistrate')
+    context 'when there is a decision event' do
+      let(:events) { [instance_double(Event, event_type: 'Event::Decision', created_at: Date.new(2023, 5, 15))] }
+
+      context 'when request_type is non_standard_mag_appeal' do
+        before do
+          allow(subject).to receive(:request_type).and_return('non_standard_mag_appeal')
+        end
+
+        it 'returns the month of the original submission date' do
+          expect(subject.original_submission_month).to eq(5)
+        end
       end
 
-      it 'returns the current month' do
-        expect(subject.original_submission_month).to eq(Date.current.month)
+      context 'when request_type is not non_standard_magistrate' do
+        before do
+          allow(subject).to receive(:request_type).and_return('non_standard_magistrate')
+        end
+
+        it 'returns the current month' do
+          expect(subject.original_submission_month).to eq(Date.current.month)
+        end
       end
     end
   end


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-3068)

## Notes for reviewer
Changes needed from 3rd round of QA testing: 

- Appeals, Supplemental and Amendment payments built from a digital submission should use that submission's grant/part grant date for the original submission month 
- If a submission doesn't have a "decision" event, something has gone severely wrong somewhere so an error should be raised

Note that this feature assumes that the grant date = the date the payment was requested for contingency payments, this assumption has been accepted by BA Aimee