### PR TITLE
DO NOT MERGE - CRM457-3128: Investigate Whether It's Possible to Allow Blob Downloads Via Metabase iFrame

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -21,7 +21,7 @@ Rails.application.configure do
     # Sentry creates workers from "blobs" in order to report on errors, so we allow that
     policy.worker_src :blob
 
-    policy.frame_src ENV.fetch('METABASE_SITE_URL', nil)
+    policy.frame_src ENV.fetch('METABASE_SITE_URL', nil), "'blob:#{ENV.fetch('METABASE_SITE_URL', nil)}'"
   end
 
   # Generate session nonces for permitted importmap and inline scripts

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -21,7 +21,7 @@ Rails.application.configure do
     # Sentry creates workers from "blobs" in order to report on errors, so we allow that
     policy.worker_src :blob
 
-    policy.frame_src "'blob:#{ENV.fetch('METABASE_SITE_URL', nil)}'"
+    policy.frame_src ENV.fetch('METABASE_SITE_URL', nil), :blob
   end
 
   # Generate session nonces for permitted importmap and inline scripts

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -21,7 +21,7 @@ Rails.application.configure do
     # Sentry creates workers from "blobs" in order to report on errors, so we allow that
     policy.worker_src :blob
 
-    policy.frame_src ENV.fetch('METABASE_SITE_URL', nil), "'blob:#{ENV.fetch('METABASE_SITE_URL', nil)}'"
+    policy.frame_src "'blob:#{ENV.fetch('METABASE_SITE_URL', nil)}'"
   end
 
   # Generate session nonces for permitted importmap and inline scripts


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2138)

- Add `:blob` to frame_src of content security policy to allow Metabase downloads
