### PR TITLE
CRM457-2512: Propagate request IDs to downstream calls

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,7 @@ class ApplicationController < ActionController::Base
 
   default_form_builder GOVUKDesignSystemFormBuilder::FormBuilder
 
+  before_action :store_outbound_request_id
   before_action :check_maintenance_mode
   before_action :check_controller_params
   before_action :authenticate_user!
@@ -21,6 +22,10 @@ class ApplicationController < ActionController::Base
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   private
+
+  def store_outbound_request_id
+    OutboundRequestId.set(request.request_id)
+  end
 
   def user_not_authorized
     flash[:alert] = t('errors.unauthorised')

--- a/app/services/app_store_client.rb
+++ b/app/services/app_store_client.rb
@@ -124,6 +124,10 @@ class AppStoreClient
   end
 
   def headers
+    client_headers.merge(OutboundRequestId.headers)
+  end
+
+  def client_headers
     if AppStoreTokenProvider.instance.authentication_configured?
       token = AppStoreTokenProvider.instance.bearer_token
 

--- a/app/services/outbound_request_id.rb
+++ b/app/services/outbound_request_id.rb
@@ -1,0 +1,20 @@
+require 'request_store'
+
+class OutboundRequestId
+  STORE_KEY = :outbound_request_id
+  SERVICE_PREFIX = 'nscc-assess'.freeze
+
+  class << self
+    def set(request_id)
+      RequestStore.store[STORE_KEY] = request_id.to_s if request_id.present?
+    end
+
+    def current
+      RequestStore.store[STORE_KEY].presence || "#{SERVICE_PREFIX}-#{SecureRandom.uuid}"
+    end
+
+    def headers
+      { 'request-id' => current }
+    end
+  end
+end

--- a/app/services/provider_data/provider_data_api_client.rb
+++ b/app/services/provider_data/provider_data_api_client.rb
@@ -43,7 +43,7 @@ module ProviderData
       private
 
       def query(method, endpoint, handlers)
-        response = send(method, endpoint)
+        response = send(method, endpoint, headers: OutboundRequestId.headers)
         unless handlers.key?(response.code)
           raise StandardError, "Unexpected status code #{response.code} when querying provider API endpoint #{endpoint}"
         end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+require 'request_store'
+
+RSpec.describe ApplicationController, type: :controller do
+  controller do
+    skip_before_action :authenticate_user!
+    skip_after_action :verify_authorized
+
+    def index
+      render plain: OutboundRequestId.current
+    end
+  end
+
+  before do
+    routes.draw { get 'index' => 'anonymous#index' }
+    allow_any_instance_of(ActionDispatch::Request).to receive(:request_id).and_return('rails-request-id')
+  end
+
+  after { RequestStore.clear! }
+
+  it 'stores the Rails request id for downstream service calls' do
+    get :index
+
+    expect(response.body).to eq('rails-request-id')
+  end
+end

--- a/spec/services/app_store_client_spec.rb
+++ b/spec/services/app_store_client_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
+require 'request_store'
 
 RSpec.describe AppStoreClient, :stub_oauth_token do
+  let(:request_id) { 'rails-request-id' }
   let(:response) { double(:response, code:, body:) }
   let(:code) { 200 }
   let(:body) { { some: :data }.to_json }
@@ -8,10 +10,13 @@ RSpec.describe AppStoreClient, :stub_oauth_token do
   let(:claim) { instance_double(Claim, id: SecureRandom.uuid) }
 
   before do
+    RequestStore.store[:outbound_request_id] = request_id
     allow(ENV).to receive(:fetch).and_call_original
     allow(described_class).to receive(:get)
       .and_return(response)
   end
+
+  after { RequestStore.clear! }
 
   describe '#update_submission' do
     let(:application_id) { SecureRandom.uuid }
@@ -34,7 +39,8 @@ RSpec.describe AppStoreClient, :stub_oauth_token do
       it 'puts the message to the specified URL' do
         expect(described_class).to receive(:put).with("http://some.url/v1/application/#{application_id}",
                                                       body: message.to_json,
-                                                      headers: { authorization: 'Bearer test-bearer-token' })
+                                                      headers: { :authorization => 'Bearer test-bearer-token',
+                                                                 'request-id' => request_id })
 
         subject.update_submission(message)
       end
@@ -47,7 +53,8 @@ RSpec.describe AppStoreClient, :stub_oauth_token do
         it 'puts the message without headers' do
           expect(described_class).to receive(:put).with("http://some.url/v1/application/#{application_id}",
                                                         body: message.to_json,
-                                                        headers: { 'X-Client-Type': 'caseworker' })
+                                                        headers: { :'X-Client-Type' => 'caseworker',
+                                                                   'request-id' => request_id })
 
           subject.update_submission(message)
         end
@@ -58,7 +65,8 @@ RSpec.describe AppStoreClient, :stub_oauth_token do
       it 'puts the message to default localhost url' do
         expect(described_class).to receive(:put).with("https://appstore.example.com/v1/application/#{application_id}",
                                                       body: message.to_json,
-                                                      headers: { authorization: 'Bearer test-bearer-token' })
+                                                      headers: { :authorization => 'Bearer test-bearer-token',
+                                                                 'request-id' => request_id })
 
         subject.update_submission(message)
       end
@@ -111,7 +119,8 @@ RSpec.describe AppStoreClient, :stub_oauth_token do
     it 'puts the message to default localhost url' do
       expect(described_class).to receive(:post).with("https://appstore.example.com/v1/submissions/#{application_id}/events",
                                                      body: message.to_json,
-                                                     headers: { authorization: 'Bearer test-bearer-token' })
+                                                     headers: { :authorization => 'Bearer test-bearer-token',
+                                                                'request-id' => request_id })
 
       subject.create_events(application_id, message)
     end
@@ -145,13 +154,15 @@ RSpec.describe AppStoreClient, :stub_oauth_token do
 
     it 'delegates search context to submissions' do
       expect(described_class).to receive(:post).with('http://some.url/v1/submissions/searches',
-                                                     headers: { authorization: 'Bearer test-bearer-token' })
+                                                     headers: { :authorization => 'Bearer test-bearer-token',
+                                                                'request-id' => request_id })
       subject.search(nil, :submissions)
     end
 
     it 'delegates search context to payments' do
       expect(described_class).to receive(:post).with('http://some.url/v1/payment_requests/searches',
-                                                     headers: { authorization: 'Bearer test-bearer-token' })
+                                                     headers: { :authorization => 'Bearer test-bearer-token',
+                                                                'request-id' => request_id })
       subject.search(nil, :payment_requests)
     end
   end
@@ -192,7 +203,7 @@ RSpec.describe AppStoreClient, :stub_oauth_token do
         expect(described_class).to receive(:post).with(
           'https://appstore.example.com/v1/payment_requests',
           body: payload.to_json,
-          headers: { authorization: 'Bearer test-bearer-token' }
+          headers: { :authorization => 'Bearer test-bearer-token', 'request-id' => request_id }
         ).and_return(response)
 
         described_class.new.create_payment_request(payload)
@@ -231,7 +242,7 @@ RSpec.describe AppStoreClient, :stub_oauth_token do
         expect(described_class).to receive(:post).with(
           'http://some.url/v1/payment_requests',
           body: payload.to_json,
-          headers: { authorization: 'Bearer test-bearer-token' }
+          headers: { :authorization => 'Bearer test-bearer-token', 'request-id' => request_id }
         ).and_return(response)
 
         described_class.new.create_payment_request(payload)

--- a/spec/services/outbound_request_id_spec.rb
+++ b/spec/services/outbound_request_id_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+require 'request_store'
+
+RSpec.describe OutboundRequestId do
+  after { RequestStore.clear! }
+
+  describe '.current' do
+    it 'returns the request id stored for the current request' do
+      described_class.set('rails-request-id')
+
+      expect(described_class.current).to eq('rails-request-id')
+    end
+
+    it 'generates a unique NSCC Assess id when no request id is stored' do
+      allow(SecureRandom).to receive(:uuid).and_return('first-uuid', 'second-uuid')
+
+      expect(described_class.current).to eq('nscc-assess-first-uuid')
+      expect(described_class.current).to eq('nscc-assess-second-uuid')
+    end
+  end
+
+  describe '.headers' do
+    it 'returns a request-id header' do
+      described_class.set('rails-request-id')
+
+      expect(described_class.headers).to eq('request-id' => 'rails-request-id')
+    end
+  end
+end

--- a/spec/services/provider_data/provider_data_api_client_spec.rb
+++ b/spec/services/provider_data/provider_data_api_client_spec.rb
@@ -1,6 +1,13 @@
 require 'rails_helper'
+require 'request_store'
 
 RSpec.describe ProviderData::ProviderDataApiClient do
+  let(:request_id) { 'rails-request-id' }
+
+  before { OutboundRequestId.set(request_id) }
+
+  after { RequestStore.clear! }
+
   describe '#office_details' do
     let(:office_code) { '1A123C' }
     let(:api_response) { nil }
@@ -55,6 +62,16 @@ RSpec.describe ProviderData::ProviderDataApiClient do
           }
         )
       end
+    end
+
+    it 'sends a request-id header' do
+      api_request = stub_request(:get, api_url)
+                    .with(headers: { 'request-id' => request_id })
+                    .to_return(status: 204)
+
+      described_class.office_details(office_code)
+
+      expect(api_request).to have_been_requested
     end
   end
 
@@ -169,6 +186,17 @@ RSpec.describe ProviderData::ProviderDataApiClient do
         described_class.contracted_office_details(office_code)
         expect(WebMock).to have_requested(:get, api_url)
       end
+    end
+
+    it 'sends a request-id header' do
+      allow(HostEnv).to receive(:uat?).and_return(false)
+      api_request = stub_request(:get, api_url)
+                    .with(headers: { 'request-id' => request_id })
+                    .to_return(status: 204)
+
+      described_class.contracted_office_details(office_code)
+
+      expect(api_request).to have_been_requested
     end
   end
 end


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2512)

Propagates outbound request IDs in Assess. Captures the Rails request ID for each controller request, adds it to App Store and Provider Data API calls, and falls back to an nscc-assess UUID outside request context.

## Notes for reviewer

Existing App Store auth and client-type headers are preserved. No UI changes.
