### PR TITLE
CRM457-3129: Dev: Unlink Digital Submission Claim Type From Payable Claim Request Type

### DIFF
--- a/app/controllers/payments/steps/check_your_answers_controller.rb
+++ b/app/controllers/payments/steps/check_your_answers_controller.rb
@@ -34,7 +34,9 @@ module Payments
       end
 
       def refresh_answers_from_claim
-        BaseViewModel.build(:payment_claim_details, claim).to_h
+        @claim ||= BaseViewModel.build(:payment_claim_details, claim)
+        @claim.request_type = 'non_standard_magistrate'
+        @claim.to_h.with_indifferent_access
       end
 
       def apply_persisted_submission_token!(answers)

--- a/app/controllers/payments/steps/check_your_answers_controller.rb
+++ b/app/controllers/payments/steps/check_your_answers_controller.rb
@@ -34,9 +34,9 @@ module Payments
       end
 
       def refresh_answers_from_claim
-        @claim ||= BaseViewModel.build(:payment_claim_details, claim)
-        @claim.request_type = 'non_standard_magistrate'
-        @claim.to_h.with_indifferent_access
+        data = BaseViewModel.build(:payment_claim_details, claim)
+        data.request_type = 'non_standard_magistrate'
+        data.to_h.with_indifferent_access
       end
 
       def apply_persisted_submission_token!(answers)

--- a/app/models/payments/selected_submission_transformer.rb
+++ b/app/models/payments/selected_submission_transformer.rb
@@ -10,7 +10,9 @@ module Payments
 
     def claim
       loaded_claim = Claim.load_from_app_store(payable_claim_id)
-      @claim ||= BaseViewModel.build(:payment_claim_details, loaded_claim).to_h.with_indifferent_access
+      @claim ||= BaseViewModel.build(:payment_claim_details, loaded_claim)
+      @claim.request_type = multi_step_form_session['request_type']
+      @claim.to_h.with_indifferent_access
     end
 
     def format_claim(claim)

--- a/app/view_models/nsm/v1/payment_claim_details.rb
+++ b/app/view_models/nsm/v1/payment_claim_details.rb
@@ -4,7 +4,7 @@ module Nsm
       attribute :matter_type
       attribute :youth_court
       attribute :ufn
-      attrinbute :request_type
+      attribute :request_type
 
       attribute :submission
       delegate :id, to: :submission

--- a/app/view_models/nsm/v1/payment_claim_details.rb
+++ b/app/view_models/nsm/v1/payment_claim_details.rb
@@ -4,6 +4,7 @@ module Nsm
       attribute :matter_type
       attribute :youth_court
       attribute :ufn
+      attrinbute :request_type
 
       attribute :submission
       delegate :id, to: :submission
@@ -62,10 +63,6 @@ module Nsm
 
       def number_of_defendants
         submission.data[:defendants].size
-      end
-
-      def request_type
-        submission.data[:claim_type]
       end
 
       def claimed_profit_cost

--- a/config/locales/en/payments/payments.yml
+++ b/config/locales/en/payments/payments.yml
@@ -5,7 +5,6 @@ en:
       non_standard_magistrate: Non-standard magistrates'
       assigned_counsel: Assigned counsel
     request_types:
-      breach_of_injunction: Breach of injunction
       non_standard_magistrate: Non-standard magistrates'
       non_standard_mag_supplemental: Non-standard magistrates' - supplemental
       non_standard_mag_appeal: Non-standard magistrates' - appeal
@@ -236,7 +235,6 @@ en:
         no_payments: There are no related payment requests for this claim
       payment_details:
         payment_heading:
-          breach_of_injunction: Breach of injunction
           non_standard_magistrate: Claimed and allowed costs
           non_standard_mag_supplemental: Allowed costs after supplemental payment
           non_standard_mag_appeal: Allowed costs after appeal

--- a/config/locales/en/payments/requests.yml
+++ b/config/locales/en/payments/requests.yml
@@ -2,7 +2,6 @@ en:
   payments:
     requests:
       type:
-        breach_of_injunction: Breach of injunction
         assigned_counsel: Assigned counsel
         assigned_counsel_amendment: Assigned counsel - amendment
         assigned_counsel_appeal: Assigned counsel - appeal

--- a/spec/models/payments/selected_submission_transformer_spec.rb
+++ b/spec/models/payments/selected_submission_transformer_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe Payments::SelectedSubmissionTransformer do
   before do
     allow(Claim).to receive(:load_from_app_store).with(payable_claim_id).and_return(claim_record)
     allow(BaseViewModel).to receive(:build).with(:payment_claim_details, claim_record).and_return(view_model)
+    allow(view_model).to receive(:request_type=).and_return(true)
   end
 
   describe '#transform' do

--- a/spec/support/system/payments_helpers.rb
+++ b/spec/support/system/payments_helpers.rb
@@ -60,6 +60,7 @@ module PaymentsHelpers
     }
   end
 
+  # rubocop:disable Metrics/AbcSize
   def stub_crm7_submission_claim(submission_id:, laa_reference: 'LAA-CRM7', request_type: 'non_standard_magistrate',
                                  nsm_claim: nil)
     claim_double = instance_double(Claim)
@@ -101,12 +102,15 @@ module PaymentsHelpers
     }
 
     answers['nsm_claim'] = nsm_claim if nsm_claim
+    view_model_double = instance_double(Nsm::V1::PaymentClaimDetails, to_h: answers)
 
     allow(Claim).to receive(:load_from_app_store).with(submission_id).and_return(claim_double)
     allow(BaseViewModel).to receive(:build)
       .with(:payment_claim_details, claim_double)
-      .and_return(instance_double(Nsm::V1::PaymentClaimDetails, to_h: answers))
+      .and_return(view_model_double)
+    allow(view_model_double).to receive(:request_type=).and_return(true)
   end
+  # rubocop:enable Metrics/AbcSize
 
   def ac_claim
     {

--- a/spec/system/nsm/assessment_spec.rb
+++ b/spec/system/nsm/assessment_spec.rb
@@ -220,7 +220,7 @@ Rails.describe 'Assessment', :stub_oauth_token, type: :system do
       it 'clicking "create payment" request takes user to payment check your answers page' do
         click_link_or_button 'Create payment request'
         expect(page).to have_content 'Check your answers'
-        expect(page).to have_content 'Claim typeBreach of injunction'
+        expect(page).to have_content 'Claim typeNon-Standard magistrates'
       end
     end
   end

--- a/spec/system/nsm/assessment_spec.rb
+++ b/spec/system/nsm/assessment_spec.rb
@@ -220,7 +220,7 @@ Rails.describe 'Assessment', :stub_oauth_token, type: :system do
       it 'clicking "create payment" request takes user to payment check your answers page' do
         click_link_or_button 'Create payment request'
         expect(page).to have_content 'Check your answers'
-        expect(page).to have_content 'Claim typeNon-Standard magistrates'
+        expect(page).to have_content 'Claim typeNon-Standard Magistrates'
       end
     end
   end

--- a/spec/system/payments/check_your_answers_guards_spec.rb
+++ b/spec/system/payments/check_your_answers_guards_spec.rb
@@ -59,18 +59,22 @@ RSpec.describe 'Payment submission safeguards', type: :system do
     expect(page).to have_title('Check your answers')
   end
 
+  # rubocop:disable Metrics/AbcSize
   def stub_submission_claim(id)
     claim_double = instance_double(Claim)
+    view_model_double = instance_double(Nsm::V1::PaymentClaimDetails, to_h: submission_answers(id))
     allow(Claim).to receive(:load_from_app_store).with(id).and_return(claim_double)
 
-    answers = submission_answers(id).merge({
-                                             'original_submission_year' => Date.current.year,
+    submission_answers(id).merge({
+                                   'original_submission_year' => Date.current.year,
       'original_submission_month' => Date.current.month
-                                           })
+                                 })
     allow(BaseViewModel).to receive(:build)
       .with(:payment_claim_details, claim_double)
-      .and_return(instance_double(Nsm::V1::PaymentClaimDetails, to_h: answers))
+      .and_return(view_model_double)
+    allow(view_model_double).to receive(:request_type=).and_return(true)
   end
+  # rubocop:enable Metrics/AbcSize
 
   # rubocop:disable Metrics/MethodLength
   def submission_answers(id)


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-3129)

## Notes for reviewer

- Remove request_type method in payment_claim_details model and replace with attribute
- Set attribute to appropriate value in each instance of usage (`non_standard_magistrates` in CYA page when `submission = true`, request type in session data in `SelectedSubmssionTransformer`)
- Fix tests