### PR TITLE
CRM457-2512: Prefix Assess outbound request IDs

### DIFF
--- a/app/services/outbound_request_id.rb
+++ b/app/services/outbound_request_id.rb
@@ -10,11 +10,20 @@ class OutboundRequestId
     end
 
     def current
-      RequestStore.store[STORE_KEY].presence || "#{SERVICE_PREFIX}-#{SecureRandom.uuid}"
+      with_service_prefix(RequestStore.store[STORE_KEY].presence || SecureRandom.uuid)
     end
 
     def headers
       { 'request-id' => current }
+    end
+
+    private
+
+    def with_service_prefix(request_id)
+      request_id = request_id.to_s
+      return request_id if request_id.start_with?("#{SERVICE_PREFIX}-")
+
+      "#{SERVICE_PREFIX}-#{request_id}"
     end
   end
 end

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -13,7 +13,8 @@ Rails.application.configure do
   # `ApplicationController` but instead a `BareApplicationController`
   config.lograge.custom_payload do |controller|
     {
-      caseworker_id: controller.current_user.to_param
+      caseworker_id: controller.current_user.to_param,
+      request_id: OutboundRequestId.current
     }
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -21,6 +21,6 @@ RSpec.describe ApplicationController, type: :controller do
   it 'stores the Rails request id for downstream service calls' do
     get :index
 
-    expect(response.body).to eq('rails-request-id')
+    expect(response.body).to eq('nscc-assess-rails-request-id')
   end
 end

--- a/spec/initializers/lograge_spec.rb
+++ b/spec/initializers/lograge_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+require 'request_store'
+
+RSpec.describe Lograge do
+  after { RequestStore.clear! }
+
+  it 'includes the request id for app log correlation' do
+    user = instance_double(User, to_param: 'caseworker-id')
+    controller = instance_double(ApplicationController, current_user: user)
+
+    OutboundRequestId.set('rails-request-id')
+
+    expect(Rails.application.config.lograge.custom_payload_method.call(controller)).to eq(
+      caseworker_id: 'caseworker-id',
+      request_id: 'nscc-assess-rails-request-id'
+    )
+  end
+end

--- a/spec/services/app_store_client_spec.rb
+++ b/spec/services/app_store_client_spec.rb
@@ -3,6 +3,7 @@ require 'request_store'
 
 RSpec.describe AppStoreClient, :stub_oauth_token do
   let(:request_id) { 'rails-request-id' }
+  let(:outbound_request_id) { 'nscc-assess-rails-request-id' }
   let(:response) { double(:response, code:, body:) }
   let(:code) { 200 }
   let(:body) { { some: :data }.to_json }
@@ -40,7 +41,7 @@ RSpec.describe AppStoreClient, :stub_oauth_token do
         expect(described_class).to receive(:put).with("http://some.url/v1/application/#{application_id}",
                                                       body: message.to_json,
                                                       headers: { :authorization => 'Bearer test-bearer-token',
-                                                                 'request-id' => request_id })
+                                                                 'request-id' => outbound_request_id })
 
         subject.update_submission(message)
       end
@@ -54,7 +55,7 @@ RSpec.describe AppStoreClient, :stub_oauth_token do
           expect(described_class).to receive(:put).with("http://some.url/v1/application/#{application_id}",
                                                         body: message.to_json,
                                                         headers: { :'X-Client-Type' => 'caseworker',
-                                                                   'request-id' => request_id })
+                                                                   'request-id' => outbound_request_id })
 
           subject.update_submission(message)
         end
@@ -66,7 +67,7 @@ RSpec.describe AppStoreClient, :stub_oauth_token do
         expect(described_class).to receive(:put).with("https://appstore.example.com/v1/application/#{application_id}",
                                                       body: message.to_json,
                                                       headers: { :authorization => 'Bearer test-bearer-token',
-                                                                 'request-id' => request_id })
+                                                                 'request-id' => outbound_request_id })
 
         subject.update_submission(message)
       end
@@ -120,7 +121,7 @@ RSpec.describe AppStoreClient, :stub_oauth_token do
       expect(described_class).to receive(:post).with("https://appstore.example.com/v1/submissions/#{application_id}/events",
                                                      body: message.to_json,
                                                      headers: { :authorization => 'Bearer test-bearer-token',
-                                                                'request-id' => request_id })
+                                                                'request-id' => outbound_request_id })
 
       subject.create_events(application_id, message)
     end
@@ -155,14 +156,14 @@ RSpec.describe AppStoreClient, :stub_oauth_token do
     it 'delegates search context to submissions' do
       expect(described_class).to receive(:post).with('http://some.url/v1/submissions/searches',
                                                      headers: { :authorization => 'Bearer test-bearer-token',
-                                                                'request-id' => request_id })
+                                                                'request-id' => outbound_request_id })
       subject.search(nil, :submissions)
     end
 
     it 'delegates search context to payments' do
       expect(described_class).to receive(:post).with('http://some.url/v1/payment_requests/searches',
                                                      headers: { :authorization => 'Bearer test-bearer-token',
-                                                                'request-id' => request_id })
+                                                                'request-id' => outbound_request_id })
       subject.search(nil, :payment_requests)
     end
   end
@@ -203,7 +204,7 @@ RSpec.describe AppStoreClient, :stub_oauth_token do
         expect(described_class).to receive(:post).with(
           'https://appstore.example.com/v1/payment_requests',
           body: payload.to_json,
-          headers: { :authorization => 'Bearer test-bearer-token', 'request-id' => request_id }
+          headers: { :authorization => 'Bearer test-bearer-token', 'request-id' => outbound_request_id }
         ).and_return(response)
 
         described_class.new.create_payment_request(payload)
@@ -242,7 +243,7 @@ RSpec.describe AppStoreClient, :stub_oauth_token do
         expect(described_class).to receive(:post).with(
           'http://some.url/v1/payment_requests',
           body: payload.to_json,
-          headers: { :authorization => 'Bearer test-bearer-token', 'request-id' => request_id }
+          headers: { :authorization => 'Bearer test-bearer-token', 'request-id' => outbound_request_id }
         ).and_return(response)
 
         described_class.new.create_payment_request(payload)

--- a/spec/services/outbound_request_id_spec.rb
+++ b/spec/services/outbound_request_id_spec.rb
@@ -5,10 +5,16 @@ RSpec.describe OutboundRequestId do
   after { RequestStore.clear! }
 
   describe '.current' do
-    it 'returns the request id stored for the current request' do
+    it 'returns the stored request id prefixed with the service slug' do
       described_class.set('rails-request-id')
 
-      expect(described_class.current).to eq('rails-request-id')
+      expect(described_class.current).to eq('nscc-assess-rails-request-id')
+    end
+
+    it 'does not add the service slug twice' do
+      described_class.set('nscc-assess-rails-request-id')
+
+      expect(described_class.current).to eq('nscc-assess-rails-request-id')
     end
 
     it 'generates a unique NSCC Assess id when no request id is stored' do
@@ -23,7 +29,7 @@ RSpec.describe OutboundRequestId do
     it 'returns a request-id header' do
       described_class.set('rails-request-id')
 
-      expect(described_class.headers).to eq('request-id' => 'rails-request-id')
+      expect(described_class.headers).to eq('request-id' => 'nscc-assess-rails-request-id')
     end
   end
 end

--- a/spec/services/provider_data/provider_data_api_client_spec.rb
+++ b/spec/services/provider_data/provider_data_api_client_spec.rb
@@ -3,6 +3,7 @@ require 'request_store'
 
 RSpec.describe ProviderData::ProviderDataApiClient do
   let(:request_id) { 'rails-request-id' }
+  let(:outbound_request_id) { 'nscc-assess-rails-request-id' }
 
   before { OutboundRequestId.set(request_id) }
 
@@ -66,7 +67,7 @@ RSpec.describe ProviderData::ProviderDataApiClient do
 
     it 'sends a request-id header' do
       api_request = stub_request(:get, api_url)
-                    .with(headers: { 'request-id' => request_id })
+                    .with(headers: { 'request-id' => outbound_request_id })
                     .to_return(status: 204)
 
       described_class.office_details(office_code)
@@ -206,7 +207,7 @@ RSpec.describe ProviderData::ProviderDataApiClient do
     it 'sends a request-id header' do
       allow(HostEnv).to receive(:uat?).and_return(false)
       api_request = stub_request(:get, api_url)
-                    .with(headers: { 'request-id' => request_id })
+                    .with(headers: { 'request-id' => outbound_request_id })
                     .to_return(status: 204)
 
       described_class.contracted_office_details(office_code)


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-2512)

Prefixes Assess-generated outbound `request-id` headers with `nscc-assess-` before calls to App Store and Provider Data API, and adds the correlation id to structured Lograge payloads as `request_id`.

## Notes for reviewer

- Existing Rails request ids still seed outbound correlation ids.
- Already-prefixed ids are not double-prefixed.
- The app log field is intentionally named `request_id` to align Submit, Assess and App Store with a single searchable correlation field.
- This is a logging/tracing change only; no UI changes.

## Testing

- Focused Lograge spec passed: `1 example, 0 failures`.
- RuboCop passed: `565 files inspected, no offenses detected`.

## How to manually test the feature

Make an Assess journey that calls App Store or Provider Data API, then check OpenSearch for `request_id` in Assess app logs and matching downstream `request-id` values prefixed with `nscc-assess-`.
