### PR TITLE
CRM457-2512: Normalise outbound request ID format

### DIFF
--- a/app/services/outbound_request_id.rb
+++ b/app/services/outbound_request_id.rb
@@ -3,14 +3,16 @@ require 'request_store'
 class OutboundRequestId
   STORE_KEY = :outbound_request_id
   SERVICE_PREFIX = 'nscc-assess'.freeze
+  UUID_PATTERN = /\A(?:[0-9a-f]{32}|[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12})\z/i
 
   class << self
     def set(request_id)
-      RequestStore.store[STORE_KEY] = request_id.to_s if request_id.present?
+      RequestStore.store[STORE_KEY] = normalised_uuid(request_id) if request_id.present?
     end
 
     def current
-      with_service_prefix(RequestStore.store[STORE_KEY].presence || SecureRandom.uuid)
+      uuid = RequestStore.store[STORE_KEY].presence || normalised_uuid
+      "#{SERVICE_PREFIX}-#{uuid}"
     end
 
     def headers
@@ -19,11 +21,11 @@ class OutboundRequestId
 
     private
 
-    def with_service_prefix(request_id)
-      request_id = request_id.to_s
-      return request_id if request_id.start_with?("#{SERVICE_PREFIX}-")
+    def normalised_uuid(request_id = nil)
+      uuid = request_id.to_s.delete_prefix("#{SERVICE_PREFIX}-")
+      uuid = SecureRandom.uuid unless uuid.match?(UUID_PATTERN)
 
-      "#{SERVICE_PREFIX}-#{request_id}"
+      uuid.delete('-').downcase
     end
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe ApplicationController, type: :controller do
 
   before do
     routes.draw { get 'index' => 'anonymous#index' }
-    allow_any_instance_of(ActionDispatch::Request).to receive(:request_id).and_return('rails-request-id')
+    allow_any_instance_of(ActionDispatch::Request).to receive(:request_id)
+      .and_return('A8B0EB88-EA9A-DCAB-8902-CD521F2D5F51')
   end
 
   after { RequestStore.clear! }
@@ -21,6 +22,6 @@ RSpec.describe ApplicationController, type: :controller do
   it 'stores the Rails request id for downstream service calls' do
     get :index
 
-    expect(response.body).to eq('nscc-assess-rails-request-id')
+    expect(response.body).to eq('nscc-assess-a8b0eb88ea9adcab8902cd521f2d5f51')
   end
 end

--- a/spec/initializers/lograge_spec.rb
+++ b/spec/initializers/lograge_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe Lograge do
     user = instance_double(User, to_param: 'caseworker-id')
     controller = instance_double(ApplicationController, current_user: user)
 
-    OutboundRequestId.set('rails-request-id')
+    OutboundRequestId.set('A8B0EB88-EA9A-DCAB-8902-CD521F2D5F51')
 
     expect(Rails.application.config.lograge.custom_payload_method.call(controller)).to eq(
       caseworker_id: 'caseworker-id',
-      request_id: 'nscc-assess-rails-request-id'
+      request_id: 'nscc-assess-a8b0eb88ea9adcab8902cd521f2d5f51'
     )
   end
 end

--- a/spec/services/app_store_client_spec.rb
+++ b/spec/services/app_store_client_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 require 'request_store'
 
 RSpec.describe AppStoreClient, :stub_oauth_token do
-  let(:request_id) { 'rails-request-id' }
-  let(:outbound_request_id) { 'nscc-assess-rails-request-id' }
+  let(:request_id) { 'A8B0EB88-EA9A-DCAB-8902-CD521F2D5F51' }
+  let(:outbound_request_id) { 'nscc-assess-a8b0eb88ea9adcab8902cd521f2d5f51' }
   let(:response) { double(:response, code:, body:) }
   let(:code) { 200 }
   let(:body) { { some: :data }.to_json }
@@ -11,7 +11,7 @@ RSpec.describe AppStoreClient, :stub_oauth_token do
   let(:claim) { instance_double(Claim, id: SecureRandom.uuid) }
 
   before do
-    RequestStore.store[:outbound_request_id] = request_id
+    OutboundRequestId.set(request_id)
     allow(ENV).to receive(:fetch).and_call_original
     allow(described_class).to receive(:get)
       .and_return(response)

--- a/spec/services/outbound_request_id_spec.rb
+++ b/spec/services/outbound_request_id_spec.rb
@@ -2,34 +2,59 @@ require 'rails_helper'
 require 'request_store'
 
 RSpec.describe OutboundRequestId do
+  let(:hyphenated_uuid) { 'A8B0EB88-EA9A-DCAB-8902-CD521F2D5F51' }
+  let(:compact_uuid) { 'a8b0eb88ea9adcab8902cd521f2d5f51' }
+
   after { RequestStore.clear! }
 
   describe '.current' do
-    it 'returns the stored request id prefixed with the service slug' do
-      described_class.set('rails-request-id')
+    context 'when a request id is stored' do
+      it 'normalises a hyphenated UUID' do
+        described_class.set(hyphenated_uuid)
 
-      expect(described_class.current).to eq('nscc-assess-rails-request-id')
+        expect(described_class.current).to eq("nscc-assess-#{compact_uuid}")
+      end
+
+      it 'normalises an uppercase compact UUID' do
+        described_class.set(compact_uuid.upcase)
+
+        expect(described_class.current).to eq("nscc-assess-#{compact_uuid}")
+      end
+
+      it 'does not add the service slug twice' do
+        described_class.set("nscc-assess-#{compact_uuid.upcase}")
+
+        expect(described_class.current).to eq("nscc-assess-#{compact_uuid}")
+      end
+
+      it 'replaces a non-UUID request id' do
+        allow(SecureRandom).to receive(:uuid).and_return(hyphenated_uuid)
+        described_class.set('rails-request-id')
+
+        expect(described_class.current).to eq("nscc-assess-#{compact_uuid}")
+        expect(described_class.current).to eq("nscc-assess-#{compact_uuid}")
+        expect(SecureRandom).to have_received(:uuid).once
+      end
     end
 
-    it 'does not add the service slug twice' do
-      described_class.set('nscc-assess-rails-request-id')
+    context 'when no request id is stored' do
+      it 'generates a unique normalised UUID for each outbound request' do
+        allow(SecureRandom).to receive(:uuid).and_return(
+          '11111111-2222-3333-4444-555555555555',
+          'AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE',
+        )
 
-      expect(described_class.current).to eq('nscc-assess-rails-request-id')
-    end
-
-    it 'generates a unique NSCC Assess id when no request id is stored' do
-      allow(SecureRandom).to receive(:uuid).and_return('first-uuid', 'second-uuid')
-
-      expect(described_class.current).to eq('nscc-assess-first-uuid')
-      expect(described_class.current).to eq('nscc-assess-second-uuid')
+        expect(described_class.current).to eq('nscc-assess-11111111222233334444555555555555')
+        expect(described_class.current).to eq('nscc-assess-aaaaaaaabbbbccccddddeeeeeeeeeeee')
+      end
     end
   end
 
   describe '.headers' do
     it 'returns a request-id header' do
-      described_class.set('rails-request-id')
+      described_class.set(hyphenated_uuid)
 
-      expect(described_class.headers).to eq('request-id' => 'nscc-assess-rails-request-id')
+      expect(described_class.headers).to eq('request-id' => "nscc-assess-#{compact_uuid}")
     end
   end
 end

--- a/spec/services/provider_data/provider_data_api_client_spec.rb
+++ b/spec/services/provider_data/provider_data_api_client_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 require 'request_store'
 
 RSpec.describe ProviderData::ProviderDataApiClient do
-  let(:request_id) { 'rails-request-id' }
-  let(:outbound_request_id) { 'nscc-assess-rails-request-id' }
+  let(:request_id) { 'A8B0EB88-EA9A-DCAB-8902-CD521F2D5F51' }
+  let(:outbound_request_id) { 'nscc-assess-a8b0eb88ea9adcab8902cd521f2d5f51' }
 
   before { OutboundRequestId.set(request_id) }
 


### PR DESCRIPTION
## Description of change

[CRM457-2512](https://dsdmoj.atlassian.net/browse/CRM457-2512)

Normalise every outbound request ID to `nscc-assess-<32 lowercase hexadecimal characters>`.

## Notes for reviewer

- Preserves valid incoming UUIDs while removing hyphens and lowercasing them.
- Generates a fresh UUID when the incoming request ID is missing or malformed.
- Avoids adding the Assess service prefix twice.
- Applies the same normalised ID to PDA and App Store requests and application logs.

## Testing

- Request-ID controller, logging, PDA client, App Store client, and service specs: 34 examples, 0 failures.
- Full Flatware RSpec: 1,522 examples, 0 failures, 100% line and branch coverage.
- Full RuboCop: 565 files inspected, no offences.

[CRM457-2512]: https://dsdmoj.atlassian.net/browse/CRM457-2512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ