### PR TITLE
Update ViewComponent to resolve CVE-2026-54498

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'bootsnap', require: false
 gem 'cssbundling-rails', '>= 1.4.1'
 gem 'devise', '>= 4.9.4'
 gem 'faker'
-gem 'govuk-components', '6.2.0'
+gem 'govuk-components', '6.3.1'
 gem 'govuk_design_system_formbuilder', '~> 6.3.0'
 gem 'govuk_notify_rails', '~> 3.0.0'
 gem 'httparty'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,10 +223,10 @@ GEM
       rspec (>= 3.8)
     globalid (1.3.0)
       activesupport (>= 6.1)
-    govuk-components (6.2.0)
+    govuk-components (6.3.1)
       html-attributes-utils (~> 1.0.0, >= 1.0.0)
       pagy (>= 6, < 10)
-      view_component (>= 4.9, < 4.10)
+      view_component (>= 4.9, < 4.13)
     govuk_design_system_formbuilder (6.3.0)
       actionview (>= 7.2)
       activemodel (>= 7.2)
@@ -614,7 +614,7 @@ GEM
       activemodel (>= 3.0.0)
       public_suffix
     version_gem (1.1.12)
-    view_component (4.9.0)
+    view_component (4.12.0)
       actionview (>= 7.1.0)
       activesupport (>= 7.1.0)
       concurrent-ruby (~> 1)
@@ -666,7 +666,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   flatware-rspec
-  govuk-components (= 6.2.0)
+  govuk-components (= 6.3.1)
   govuk_design_system_formbuilder (~> 6.3.0)
   govuk_notify_rails (~> 3.0.0)
   httparty


### PR DESCRIPTION
## Description of change

Updates `govuk-components` from 6.2.0 to 6.3.1 so `view_component` can move from 4.9.0 to the patched 4.12.0 release.

ViewComponent 4.12.0 fixes [CVE-2026-54498 / GHSA-97jw-64cj-jc58](https://github.com/ViewComponent/view_component/security/advisories/GHSA-97jw-64cj-jc58), an XSS risk caused by unsafe output returned from `around_render` bypassing normal escaping.

## Notes for reviewer

- This is a dependency-only change; no application source files are changed.
- 6.3.1 is the smallest `govuk-components` release that permits ViewComponent 4.12.0. It is preferred over 6.4.0 because this app still resolves `govuk-frontend` 6.1.0, while 6.4.0 targets 6.3.0.
- The app does not define `around_render` and renders its own footer, so the upstream footer component markup change does not affect the layout.
- Existing Prior Authority and payment summary-card journeys cover the affected GOV.UK component rendering.

## Verification

- RuboCop passed with 565 files and no offences.
- JavaScript, CSS and Rails asset builds passed.
- The normal suite passed with 1,520 examples and no failures.
- The accessibility-enabled suite passed with 1,546 examples and no failures.
- Focused summary-card system coverage passed with 100 examples and no failures.

## How to manually test the feature

Open a Prior Authority application or payment request and confirm its summary cards and footer render normally. No visual or functional change is intended.
