### PR TITLE
CRM457-3237: Fix NSM claim details page title

### DIFF
--- a/app/views/nsm/claim_details/show.html.erb
+++ b/app/views/nsm/claim_details/show.html.erb
@@ -1,6 +1,4 @@
-<% content_for(:page_title) do %>
-  <%= claim_summary.laa_reference %>
-<% end %>
+<% title "#{claim_summary.laa_reference} - #{t('.page_title')}" %>
 <%= render partial: 'nsm/claims/claim_summary', locals: { claim:, claim_summary: } %>
 <%= render partial: 'nsm/claims/claim_nav', locals: { claim: claim, current_page: 'claim_details' } %>
 <div class="govuk-grid-row">

--- a/config/locales/en/nsm/claim_details.yml
+++ b/config/locales/en/nsm/claim_details.yml
@@ -3,7 +3,7 @@ en:
   nsm:
     claim_details:
       show:
-        page_title: Assess a non-standard magistrates court payment
+        page_title: Claim details
         overview: Overview
         sent_back: Sent back to provider on %{date}
         further_information_request: 'Further information request:'

--- a/spec/system/nsm/overview_spec.rb
+++ b/spec/system/nsm/overview_spec.rb
@@ -44,6 +44,13 @@ RSpec.describe 'Overview', :stub_oauth_token, type: :system do
     let(:firm) { claim.data['firm_office'] }
     let(:solicitor) { claim.data['solicitor'] }
 
+    it 'shows the claim reference and page context in the page title' do
+      expect(page).to have_title(
+        "#{claim.data[:laa_reference]} - Claim details - Assess a non-standard magistrates court payment - GOV.UK",
+        exact: true
+      )
+    end
+
     it 'shows me the total claimed but not adjusted' do
       expect(page)
         .to have_content('Claimed: £359.76')


### PR DESCRIPTION
## Description of change

[CRM457-3237](https://dsdmoj.atlassian.net/browse/CRM457-3237)

Fixes the NSM claim details browser title so it follows:

`<LAA reference> - Claim details - Assess a non-standard magistrates court payment - GOV.UK`

## Notes for reviewer

- Uses the shared title helper so the canonical NSM service name and GOV.UK suffix are included.
- Keeps the page context in the existing locale file.
- Adds an exact system-spec assertion for the complete browser title.
- The change affects browser metadata rather than page-body UI, so no screenshot is included.

## How to manually test the feature

1. Open an NSM claim at `/nsm/claims/<claim-id>/claim_details`.
2. Check the browser tab title is `<LAA reference> - Claim details - Assess a non-standard magistrates court payment - GOV.UK`.

[CRM457-3237]: https://dsdmoj.atlassian.net/browse/CRM457-3237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ