### PR TITLE
CRM457-3211: Implement updated urls and page titles + tags for payment requests AC3

### DIFF
--- a/app/javascript/court_name_autocomplete.js
+++ b/app/javascript/court_name_autocomplete.js
@@ -17,7 +17,7 @@ function customSuggestion(result){
 
 async function allCourts(){
   try{
-    let response = await fetch(`/payments/courts`)
+    let response = await fetch(`/request-a-payment/courts`)
     if(response.ok){
       const courts = await response.json()
       return courts

--- a/app/view_models/payments/related_payments.rb
+++ b/app/view_models/payments/related_payments.rb
@@ -58,7 +58,7 @@ module Payments
     end
 
     def link
-      "/payments/requests/#{payable_claim_id}"
+      "/request-a-payment/requests/#{payable_claim_id}"
     end
   end
 end

--- a/app/views/payments/requests/show.html.erb
+++ b/app/views/payments/requests/show.html.erb
@@ -19,21 +19,21 @@
   <li class="moj-sub-navigation__item">
     <%=
       link_to t(".payment_request"),
-      "/payments/requests/#{@claim_details.id}",
+      "/request-a-payment/requests/#{@claim_details.id}",
       class: "moj-sub-navigation__link", "aria-current": (@current_page == "payment_request" ? "page" : nil)
     %>
   </li>
   <li class="moj-sub-navigation__item">
     <%=
       link_to t(".claim_details"),
-      "/payments/requests/#{@claim_details.id}?current_page=claim_details",
+      "/request-a-payment/requests/#{@claim_details.id}?current_page=claim_details",
       class: "moj-sub-navigation__link", "aria-current": (@current_page == "claim_details" ? "page" : nil)
     %>
   </li>
   <li class="moj-sub-navigation__item">
     <%=
       link_to t(".related_payments"),
-      "/payments/requests/#{@claim_details.id}?current_page=related_payments",
+      "/request-a-payment/requests/#{@claim_details.id}?current_page=related_payments",
       class: "moj-sub-navigation__link", "aria-current": (@current_page == "related_payments" ? "page" : nil)
     %>
   </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,7 +147,7 @@ Rails.application.routes.draw do
   end
 
   constraints ->(_req) { FeatureFlags.payments.enabled? } do
-    namespace :payments do
+    namespace :payments, path: 'request-a-payment' do
       resources :requests, only: %i[new create show index] do
         member do
           get :confirmation

--- a/spec/system/payments/view_payment_claim_spec.rb
+++ b/spec/system/payments/view_payment_claim_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe 'View payment request', :stub_oauth_token do
     before do
       allow_any_instance_of(AppStoreClient).to receive(:get_payable_claim)
         .and_return(payload)
-      visit "payments/requests/#{id}"
+      visit "request-a-payment/requests/#{id}"
     end
 
     it 'shows the correct top level details' do
@@ -374,7 +374,7 @@ RSpec.describe 'View payment request', :stub_oauth_token do
     before do
       allow_any_instance_of(AppStoreClient).to receive(:get_payable_claim)
         .and_return(payload)
-      visit "payments/requests/#{id}"
+      visit "request-a-payment/requests/#{id}"
     end
 
     it 'shows the correct top level details' do
@@ -517,7 +517,7 @@ RSpec.describe 'View payment request', :stub_oauth_token do
     end
 
     it 'raises an error trying to go to the payment request' do
-      expect { visit "payments/requests/#{id}" }.to raise_error 'Invalid claim type: garbage'
+      expect { visit "request-a-payment/requests/#{id}" }.to raise_error 'Invalid claim type: garbage'
     end
   end
 end


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-3211)

## Notes for reviewer

- Request a payment routes use the agreed service path: /request-a-payment/
- Existing /payments/ routes are replaced or redirected