### PR TITLE
CRM457-3211: Implement updated urls and page titles + tags for payment requests AC4

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -177,7 +177,7 @@ Rails.application.routes.draw do
           edit_step :office_code_confirm
           edit_step :counsel_code_search
           edit_step :counsel_code_confirm
-          resource :claim_search, only: %i[new edit update],
+          resource :claim_search, path: 'find-a-claim', only: %i[new edit update],
             controller: 'claim_search', path_names: { edit: '' }
           edit_step :claim_types
         end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -173,10 +173,10 @@ Rails.application.routes.draw do
 
           edit_step :check_your_answers
           edit_step :date_claim_assessed
-          edit_step :office_code_search
-          edit_step :office_code_confirm
-          edit_step :counsel_code_search
-          edit_step :counsel_code_confirm
+          edit_step :office_code_search, path: 'solicitor-account-number'
+          edit_step :office_code_confirm, path: 'check-solicitor-details'
+          edit_step :counsel_code_search, path: 'assigned-counsel-account-number'
+          edit_step :counsel_code_confirm, path: 'check-assigned-counsel-details'
           resource :claim_search, path: 'find-a-claim', only: %i[new edit update],
             controller: 'claim_search', path_names: { edit: '' }
           edit_step :claim_types


### PR DESCRIPTION
## Description of change

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-3211)

## Notes for reviewer

- Internal naming such as claim_search, office_code_search, office_code_confirm and similar implementation-led route names are removed.
- claim_search --> find-a-claim
- office_code_search --> solicitor-account-number
- office_code_confirm --> check-solicitor-details
- counsel_code_search --> assigned-counsel-account-number
- counsel_code_confirm --> check-assigned-counsel-details