### PR TITLE
CRM457-3236 unique URL for RAP payment confirmation page

### DIFF
--- a/app/controllers/payments/requests_controller.rb
+++ b/app/controllers/payments/requests_controller.rb
@@ -28,15 +28,21 @@ module Payments
       redirect_to edit_payments_steps_claim_types_path(id: cycle_multi_step_form_session_object.id)
     end
 
-    def confirmation; end
+    def confirmation
+      @payment_confirmation = Payments::ConfirmationSummary.new(session.delete(:payments_confirmation_response))
+    end
 
     def create
-      response = AppStoreClient.new.create_payment_request(request_payload)
+      payload = request_payload
+      response = AppStoreClient.new.create_payment_request(payload)
       persist_last_submission_token
       destroy_current_form_sessions
-      @payment_confirmation = Payments::ConfirmationSummary.new(response)
+      session[:payments_confirmation_response] = confirmation_response_payload(response)
 
-      render :confirmation
+      redirect_to payments_confirmation_path(
+        flow_id: payload['id'],
+        payment_request_id: payment_request_id_from(response)
+      )
     rescue RuntimeError => e
       persist_last_submission_token
       destroy_current_form_sessions
@@ -57,6 +63,22 @@ module Payments
 
     def request_payload
       current_multi_step_form_session.answers.merge('submitter_id' => current_user.id)
+    end
+
+    def confirmation_response_payload(response)
+      {
+        'payment_request' => {
+          'request_type' => response.dig('payment_request', 'request_type'),
+          'allowed_total' => response.dig('payment_request', 'allowed_total')
+        },
+        'claim' => {
+          'laa_reference' => response.dig('claim', 'laa_reference')
+        }
+      }
+    end
+
+    def payment_request_id_from(response)
+      response['payment_request_id'] || response.dig('payment_request', 'id')
     end
 
     def persist_last_submission_token
@@ -83,7 +105,9 @@ module Payments
         :sort_direction,
         :page,
         :current_page,
-        :payment_id
+        :payment_id,
+        :flow_id,
+        :payment_request_id
       )
     end
 

--- a/app/param_validators/payments/requests_params.rb
+++ b/app/param_validators/payments/requests_params.rb
@@ -6,6 +6,8 @@ module Payments
     attribute :page, :integer
     attribute :current_page, :string
     attribute :payment_id, :string
+    attribute :flow_id, :string
+    attribute :payment_request_id, :string
 
     validates :sort_by, inclusion: { in: %w[
       laa_reference firm_name solicitor_firm_name
@@ -16,5 +18,7 @@ module Payments
     validates :id, is_a_uuid: true, allow_nil: true
     validates :current_page, inclusion: { in: %w[payment_request claim_details related_payments] }, allow_nil: true
     validates :payment_id, is_a_uuid: true, allow_nil: true
+    validates :flow_id, is_a_uuid: true, allow_nil: true
+    validates :payment_request_id, is_a_uuid: true, allow_nil: true
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -148,11 +148,8 @@ Rails.application.routes.draw do
 
   constraints ->(_req) { FeatureFlags.payments.enabled? } do
     namespace :payments, path: 'request-a-payment' do
-      resources :requests, only: %i[new create show index] do
-        member do
-          get :confirmation
-        end
-      end
+      get 'confirmation/:flow_id/payment_request/:payment_request_id', to: 'requests#confirmation', as: :confirmation
+      resources :requests, only: %i[new create show index]
       resource :search, only: %i[new show]
       resource :claim_reference, only: %i[edit]
       resources :courts, only: [:index], format: :js

--- a/spec/controllers/payments/requests_controller_spec.rb
+++ b/spec/controllers/payments/requests_controller_spec.rb
@@ -21,7 +21,9 @@ RSpec.describe Payments::RequestsController, :stub_oauth_token do
   end
 
   describe 'POST #create' do
-    let(:session_answers) { { 'some' => 'answer', 'nested' => { 'a' => 1 } } }
+    let(:flow_id) { '11111111-1111-4111-8111-111111111111' }
+    let(:payment_request_id) { '22222222-2222-4222-8222-222222222222' }
+    let(:session_answers) { { 'id' => flow_id, 'some' => 'answer', 'nested' => { 'a' => 1 } } }
     let(:session_double) { instance_double(Decisions::MultiStepFormSession, id: 'session-123', answers: session_answers) }
     let(:client_double) { instance_double(AppStoreClient) }
 
@@ -43,26 +45,64 @@ RSpec.describe Payments::RequestsController, :stub_oauth_token do
     end
 
     context 'when the AppStore succeeds' do
-      let(:ok_response) { { 'payment_request_id' => 'pr-123' } }
+      let(:ok_response) do
+        {
+          'payment_request_id' => payment_request_id,
+          'payment_request' => {
+            'id' => payment_request_id,
+            'request_type' => 'non_standard_magistrate',
+            'allowed_total' => 123.45,
+            'ignored' => 'x'
+          },
+          'claim' => { 'laa_reference' => 'LAA-REF-123', 'ignored' => 'y' },
+          'ignored' => 'z'
+        }
+      end
       let(:summary_double) { instance_double(Payments::ConfirmationSummary) }
 
-      it 'builds a confirmation summary and renders :confirmation' do
+      it 'redirects to confirmation with flow id and payment request id' do
         expected_payload = session_answers.merge('submitter_id' => controller.current_user.id)
         expect(client_double)
           .to receive(:create_payment_request)
           .with(expected_payload)
           .and_return(ok_response)
 
-        allow(Payments::ConfirmationSummary)
-          .to receive(:new)
-          .with(ok_response)
-          .and_return(summary_double)
-
         post :create
 
-        expect(assigns(:payment_confirmation)).to eq(summary_double)
-        expect(response).to render_template(:confirmation)
+        expect(response).to redirect_to(payments_confirmation_path(flow_id:, payment_request_id:))
+        expect(session[:payments_confirmation_response]).to eq(
+          {
+            'payment_request' => { 'request_type' => 'non_standard_magistrate', 'allowed_total' => 123.45 },
+            'claim' => { 'laa_reference' => 'LAA-REF-123' }
+          }
+        )
       end
+    end
+  end
+
+  describe 'GET #confirmation' do
+    let(:flow_id) { '11111111-1111-4111-8111-111111111111' }
+    let(:payment_request_id) { '22222222-2222-4222-8222-222222222222' }
+    let(:ok_response) do
+      {
+        'payment_request' => { 'request_type' => 'non_standard_magistrate', 'allowed_total' => 123.45 },
+        'claim' => { 'laa_reference' => 'LAA-REF-123' }
+      }
+    end
+    let(:summary_double) { instance_double(Payments::ConfirmationSummary) }
+
+    it 'builds a confirmation summary from session response' do
+      allow(Payments::ConfirmationSummary)
+        .to receive(:new)
+        .with(ok_response)
+        .and_return(summary_double)
+
+      get :confirmation,
+          params: { flow_id:, payment_request_id: },
+          session: { payments_confirmation_response: ok_response }
+
+      expect(assigns(:payment_confirmation)).to eq(summary_double)
+      expect(session[:payments_confirmation_response]).to be_nil
     end
   end
 

--- a/spec/support/shared_examples/ac_payment_request_flow.rb
+++ b/spec/support/shared_examples/ac_payment_request_flow.rb
@@ -58,6 +58,7 @@ RSpec.shared_examples 'AC payment request flow' do |type_suffix|
   end
 
   let(:create_endpoint) { 'https://appstore.example.com/v1/payment_requests' }
+  let(:created_payment_request_id) { SecureRandom.uuid }
   let(:create_payload) do
     {
       laa_reference: '123-abc'
@@ -68,7 +69,13 @@ RSpec.shared_examples 'AC payment request flow' do |type_suffix|
     stub_request(:post, create_endpoint).to_return(
       status: 201,
       body: { claim: { laa_reference: '1234-abc' },
-payment_request: { claimed_total: 100, allowed_total: 10, request_type: claim_type_code } }.to_json
+payment_request_id: created_payment_request_id,
+payment_request: {
+  id: created_payment_request_id,
+  claimed_total: 100,
+  allowed_total: 10,
+  request_type: claim_type_code
+} }.to_json
     )
   end
 

--- a/spec/system/payments/ac_payment_request_spec.rb
+++ b/spec/system/payments/ac_payment_request_spec.rb
@@ -51,11 +51,18 @@ RSpec.describe 'Assigned counsel payment request', :stub_oauth_token do
   end
 
   let(:create_endpoint) { 'https://appstore.example.com/v1/payment_requests' }
+  let(:created_payment_request_id) { SecureRandom.uuid }
   let(:create_payment_stub) do
     stub_request(:post, create_endpoint).to_return(
       status: 201,
       body: { claim: { laa_reference: '1234-abc' },
-payment_request: { claimed_total: 100, allowed_total: 10, request_type: 'assigned_counsel' } }.to_json
+payment_request_id: created_payment_request_id,
+payment_request: {
+  id: created_payment_request_id,
+  claimed_total: 100,
+  allowed_total: 10,
+  request_type: 'assigned_counsel'
+} }.to_json
     )
   end
 

--- a/spec/system/payments/check_your_answers_guards_spec.rb
+++ b/spec/system/payments/check_your_answers_guards_spec.rb
@@ -4,11 +4,14 @@ RSpec.describe 'Payment submission safeguards', type: :system do
   let(:caseworker) { create(:caseworker, first_name: 'Sam', last_name: 'Beta') }
   let(:claim_id) { SecureRandom.uuid }
   let(:token) { SecureRandom.uuid }
+  let(:payment_request_id) { SecureRandom.uuid }
   let(:app_store_client) { instance_double(AppStoreClient) }
   let(:confirmation_response) do
     {
+      'payment_request_id' => payment_request_id,
       'claim' => { 'laa_reference' => 'LAA-123' },
       'payment_request' => {
+        'id' => payment_request_id,
         'request_type' => 'non_standard_magistrate',
         'allowed_total' => '100.0'
       }

--- a/spec/system/payments/nsm_payment_request_spec.rb
+++ b/spec/system/payments/nsm_payment_request_spec.rb
@@ -18,12 +18,19 @@ RSpec.describe 'NSM payment request', :javascript, :stub_oauth_token do
       laa_reference: '123-abc'
     }
   end
+  let(:created_payment_request_id) { SecureRandom.uuid }
 
   let(:create_payment_stub) do
     stub_request(:post, create_endpoint).to_return(
       status: 201,
       body: { claim: { laa_reference: '1234-abc' },
-payment_request: { claimed_total: 100, allowed_total: 10, request_type: 'non_standard_magistrate' } }.to_json
+payment_request_id: created_payment_request_id,
+payment_request: {
+  id: created_payment_request_id,
+  claimed_total: 100,
+  allowed_total: 10,
+  request_type: 'non_standard_magistrate'
+} }.to_json
     )
   end
 


### PR DESCRIPTION
## Description of change

changes RAP confirmation url from

`/request-a-payment/requests` 
to
`request-a-payment/confirmation/:flow_id/payment_request/:payment_request_id`

[Link to relevant ticket](https://dsdmoj.atlassian.net/browse/CRM457-3236)

## Notes for reviewer

## Screenshots of changes (if applicable)

### Before changes:

### After changes:

## How to manually test the feature
